### PR TITLE
fix(memu-js): use globalThis.process instead of process

### DIFF
--- a/memu/sdk/javascript/src/client.ts
+++ b/memu/sdk/javascript/src/client.ts
@@ -59,8 +59,8 @@ export class MemuClient {
    * @param config Client configuration options
    */
   constructor(config: MemuClientConfig = {}) {
-    this.baseUrl = config.baseUrl || process.env.MEMU_API_BASE_URL || 'http://localhost:8000';
-    this.apiKey = config.apiKey || process.env.MEMU_API_KEY || '';
+    this.baseUrl = config.baseUrl || globalThis.process?.env?.MEMU_API_BASE_URL || 'http://localhost:8000';
+    this.apiKey = config.apiKey || globalThis.process?.env?.MEMU_API_KEY || '';
     this.timeout = config.timeout || 30000; // 30 seconds
     this.maxRetries = config.maxRetries || 3;
 


### PR DESCRIPTION
Without this PR, memu-js cannot be run in a browser.

<img width="1381" height="507" alt="image" src="https://github.com/user-attachments/assets/4361b3ee-f6d4-4731-acef-39d2d5e87b6f" />
