### PR TITLE
feat: add configurable batch_size for embedding API calls

### DIFF
--- a/src/memu/app/service.py
+++ b/src/memu/app/service.py
@@ -157,6 +157,7 @@ class MemoryService:
                 base_url=self.embedding_config.base_url,
                 api_key=self.embedding_config.api_key,
                 embed_model=self.embedding_config.embed_model,
+                batch_size=self.embedding_config.batch_size,
             )
         elif backend == "httpx":
             return HTTPEmbeddingClient(

--- a/src/memu/app/settings.py
+++ b/src/memu/app/settings.py
@@ -68,6 +68,10 @@ class EmbeddingConfig(BaseModel):
         default="sdk",
         description="Which embedding client backend to use: 'httpx' (httpx) or 'sdk' (official OpenAI).",
     )
+    batch_size: int = Field(
+        default=25,
+        description="Maximum batch size for embedding API calls. Some providers have limits (e.g., Bailian/DashScope: 10).",
+    )
     endpoint_overrides: dict[str, str] = Field(
         default_factory=dict,
         description="Optional overrides for HTTP endpoints (keys: 'embeddings'/'embed').",

--- a/src/memu/embedding/openai_sdk.py
+++ b/src/memu/embedding/openai_sdk.py
@@ -9,10 +9,11 @@ logger = logging.getLogger(__name__)
 class OpenAIEmbeddingSDKClient:
     """OpenAI embedding client that relies on the official Python SDK."""
 
-    def __init__(self, *, base_url: str, api_key: str, embed_model: str):
+    def __init__(self, *, base_url: str, api_key: str, embed_model: str, batch_size: int = 25):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key or ""
         self.embed_model = embed_model
+        self.batch_size = batch_size
         self.client = AsyncOpenAI(api_key=self.api_key, base_url=self.base_url)
 
     async def embed(self, inputs: list[str]) -> list[list[float]]:
@@ -25,5 +26,18 @@ class OpenAIEmbeddingSDKClient:
         Returns:
             List of embedding vectors
         """
-        response = await self.client.embeddings.create(model=self.embed_model, input=inputs)
-        return [cast(list[float], d.embedding) for d in response.data]
+        # Process in batches to handle API limits (e.g., some providers limit batch size)
+        if len(inputs) <= self.batch_size:
+            # Single batch - direct call
+            response = await self.client.embeddings.create(model=self.embed_model, input=inputs)
+            return [cast(list[float], d.embedding) for d in response.data]
+        
+        # Multiple batches - split and merge
+        all_embeddings = []
+        for i in range(0, len(inputs), self.batch_size):
+            batch = inputs[i:i + self.batch_size]
+            response = await self.client.embeddings.create(model=self.embed_model, input=batch)
+            batch_embeddings = [cast(list[float], d.embedding) for d in response.data]
+            all_embeddings.extend(batch_embeddings)
+        
+        return all_embeddings


### PR DESCRIPTION
## Problem

Different embedding API providers have different batch size limits:
- OpenAI: ~25 items per batch (no strict limit documented)
- Bailian/DashScope: max 10 items per batch (strict limit)
- Other providers may have different limits

Currently, MemU processes all embeddings in a single batch, which causes errors when the batch size exceeds the provider's limit.

## Solution

This PR adds a configurable `batch_size` parameter to handle provider-specific limits:

1. **Added `batch_size` to `EmbeddingConfig`**
   - Default: 25 (suitable for OpenAI)
   - Users can configure it based on their provider (e.g., 10 for Bailian)

2. **Implemented batch processing in `OpenAIEmbeddingSDKClient`**
   - Automatically splits large input lists into smaller batches
   - Optimized: skips batching when input size <= batch_size

3. **Updated service initialization**
   - Passes `batch_size` from config to embedding client

## Changes

- `src/memu/app/settings.py`: Add `batch_size` field to `EmbeddingConfig`
- `src/memu/embedding/openai_sdk.py`: 
  - Add `batch_size` parameter to `__init__`
  - Implement batch processing in `embed()` method
- `src/memu/app/service.py`: Pass `batch_size` to embedding client

## Example Usage

```python
from memu.app import MemoryService

# For Bailian/DashScope (max 10 per batch)
embedding_config = {
    "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
    "api_key": "YOUR_KEY",
    "embed_model": "text-embedding-v3",
    "batch_size": 10  # Configure batch size
}

service = MemoryService(embedding_config=embedding_config)