### PR TITLE
fix: resolve runtime errors in examples and core modules

### DIFF
--- a/examples/example_1_conversation_memory.py
+++ b/examples/example_1_conversation_memory.py
@@ -77,11 +77,14 @@ async def main():
         msg = "Please set OPENAI_API_KEY environment variable"
         raise ValueError(msg)
 
-    # Initialize service with OpenAI
+    # Initialize service with OpenAI using llm_profiles
+    # The "default" profile is required and used as the primary LLM configuration
     service = MemoryService(
-        llm_config={
-            "api_key": api_key,
-            "chat_model": "gpt-4o-mini",
+        llm_profiles={
+            "default": {
+                "api_key": api_key,
+                "chat_model": "gpt-4o-mini",
+            },
         },
     )
 
@@ -95,6 +98,7 @@ async def main():
     # Process each conversation
     print("\nProcessing conversations...")
     total_items = 0
+    categories = []
     for conv_file in conversation_files:
         if not os.path.exists(conv_file):
             continue
@@ -102,11 +106,10 @@ async def main():
         try:
             result = await service.memorize(resource_url=conv_file, modality="conversation")
             total_items += len(result.get("items", []))
+            # Categories are returned in the result and updated after each memorize call
+            categories = result.get("categories", [])
         except Exception as e:
             print(f"Error: {e}")
-
-    # Extract and serialize categories
-    categories = [cat.model_dump() for cat in service.store.categories.values()]
 
     # Write to output files
     output_dir = "examples/output/conversation_example"

--- a/examples/example_2_skill_extraction.py
+++ b/examples/example_2_skill_extraction.py
@@ -22,7 +22,7 @@ src_path = os.path.abspath("src")
 sys.path.insert(0, src_path)
 
 
-async def generate_skill_md(all_skills, service, output_file, attempt_number, total_attempts, is_final=False):
+async def generate_skill_md(all_skills, service, output_file, attempt_number, total_attempts, categories=None, is_final=False):
     """
     Use LLM to generate a concise task execution guide (skill.md).
 
@@ -36,13 +36,13 @@ async def generate_skill_md(all_skills, service, output_file, attempt_number, to
 
     # Get category summaries if available
     categories_text = ""
-    if service.store.categories:
-        categories_with_content = {
-            cat_id: cat for cat_id, cat in service.store.categories.items() if cat.summary and cat.summary.strip()
-        }
+    if categories:
+        categories_with_content = [
+            cat for cat in categories if cat.get("summary") and cat.get("summary").strip()
+        ]
         if categories_with_content:
             categories_text = "\n\n".join([
-                f"**{cat.name}**:\n{cat.summary}" for cat_id, cat in categories_with_content.items()
+                f"**{cat.get('name', 'unknown')}**:\n{cat.get('summary', '')}" for cat in categories_with_content
             ])
 
     # Construct prompt for LLM
@@ -202,11 +202,14 @@ async def main():
         "memory_categories": skill_categories,
     }
 
-    # Initialize service
+    # Initialize service with OpenAI using llm_profiles
+    # The "default" profile is required and used as the primary LLM configuration
     service = MemoryService(
-        llm_config={
-            "api_key": api_key,
-            "chat_model": "gpt-4o-mini",
+        llm_profiles={
+            "default": {
+                "api_key": api_key,
+                "chat_model": "gpt-4o-mini",
+            },
         },
         memorize_config=memorize_config,
     )
@@ -221,6 +224,7 @@ async def main():
     # Process each resource sequentially
     print("\nProcessing files...")
     all_skills = []
+    categories = []
 
     for idx, (resource_file, modality) in enumerate(resources, 1):
         if not os.path.exists(resource_file):
@@ -234,6 +238,9 @@ async def main():
                 if item.get("memory_type") == "skill":
                     all_skills.append({"skill": item.get("summary", ""), "source": os.path.basename(resource_file)})
 
+            # Categories are returned in the result and updated after each memorize call
+            categories = result.get("categories", [])
+
             # Generate intermediate skill.md
             await generate_skill_md(
                 all_skills=all_skills,
@@ -241,6 +248,7 @@ async def main():
                 output_file=f"examples/output/skill_example/log_{idx}.md",
                 attempt_number=idx,
                 total_attempts=len(resources),
+                categories=categories,
             )
 
         except Exception as e:
@@ -253,11 +261,12 @@ async def main():
         output_file="examples/output/skill_example/skill.md",
         attempt_number=len(resources),
         total_attempts=len(resources),
+        categories=categories,
         is_final=True,
     )
 
     print(f"\n✓ Processed {len(resources)} files, extracted {len(all_skills)} skills")
-    print(f"✓ Generated {len(service.store.categories)} categories")
+    print(f"✓ Generated {len(categories)} categories")
     print("✓ Output: examples/output/skill_example/")
 
 

--- a/examples/example_3_multimodal_memory.py
+++ b/examples/example_3_multimodal_memory.py
@@ -86,10 +86,14 @@ async def main():
         {"name": "visual_diagrams", "description": "Visual concepts, diagrams, charts, and illustrations from images"},
     ]
 
+    # Initialize service with OpenAI using llm_profiles
+    # The "default" profile is required and used as the primary LLM configuration
     service = MemoryService(
-        llm_config={
-            "api_key": api_key,
-            "chat_model": "gpt-4o-mini",
+        llm_profiles={
+            "default": {
+                "api_key": api_key,
+                "chat_model": "gpt-4o-mini",
+            },
         },
         memorize_config={"memory_categories": multimodal_categories},
     )
@@ -104,6 +108,7 @@ async def main():
     # Process each resource
     print("\nProcessing resources...")
     total_items = 0
+    categories = []
     for resource_file, modality in resources:
         if not os.path.exists(resource_file):
             continue
@@ -111,11 +116,10 @@ async def main():
         try:
             result = await service.memorize(resource_url=resource_file, modality=modality)
             total_items += len(result.get("items", []))
+            # Categories are returned in the result and updated after each memorize call
+            categories = result.get("categories", [])
         except Exception as e:
             print(f"Error: {e}")
-
-    # Extract and serialize categories
-    categories = [cat.model_dump() for cat in service.store.categories.values()]
 
     # Write to output files
     output_dir = "examples/output/multimodal_example"

--- a/src/memu/app/service.py
+++ b/src/memu/app/service.py
@@ -53,7 +53,9 @@ class MemoryService(MemorizeMixin, RetrieveMixin):
         self.llm_profiles = self._validate_config(llm_profiles, LLMProfilesConfig)
         self.user_config = self._validate_config(user_config, UserConfig)
         self.user_model = self.user_config.model
-        self.llm_config = self._validate_config(self.llm_profiles.default, LLMConfig)
+        self.llm_config = self._validate_config(
+            self.llm_profiles.profiles.get(self.llm_profiles.default), LLMConfig
+        )
         self.blob_config = self._validate_config(blob_config, BlobConfig)
         self.storage_providers = self._validate_config(storage_providers, StorageProvidersConfig)
         self.memorize_config = self._validate_config(memorize_config, MemorizeConfig)
@@ -214,11 +216,11 @@ class MemoryService(MemorizeMixin, RetrieveMixin):
         }
         retrieve_initial_keys = {"original_query", "context_queries", "ctx", "store", "top_k", "skip_rewrite", "method"}
         memo_workflow = self._build_memorize_workflow()
-        self._pipelines.register("memorize", memo_workflow.steps, initial_state_keys=memorize_initial_keys)
+        self._pipelines.register("memorize", memo_workflow, initial_state_keys=memorize_initial_keys)
         rag_workflow = self._build_rag_retrieve_workflow()
-        self._pipelines.register("retrieve_rag", rag_workflow.steps, initial_state_keys=retrieve_initial_keys)
+        self._pipelines.register("retrieve_rag", rag_workflow, initial_state_keys=retrieve_initial_keys)
         llm_workflow = self._build_llm_retrieve_workflow()
-        self._pipelines.register("retrieve_llm", llm_workflow.steps, initial_state_keys=retrieve_initial_keys)
+        self._pipelines.register("retrieve_llm", llm_workflow, initial_state_keys=retrieve_initial_keys)
 
     async def _run_workflow(self, workflow_name: str, initial_state: WorkflowState) -> WorkflowState:
         """Execute a workflow through the configured runner backend."""

--- a/src/memu/database/inmemory/models.py
+++ b/src/memu/database/inmemory/models.py
@@ -14,6 +14,7 @@ class Resource(BaseModel):
     local_path: str
     caption: str | None = None
     embedding: list[float] | None = None
+    updated_at: float | None = None
 
 
 class MemoryItem(BaseModel):
@@ -22,6 +23,7 @@ class MemoryItem(BaseModel):
     memory_type: MemoryType
     summary: str
     embedding: list[float]
+    updated_at: float | None = None
 
 
 class MemoryCategory(BaseModel):
@@ -30,6 +32,7 @@ class MemoryCategory(BaseModel):
     description: str
     embedding: list[float] | None = None
     summary: str | None = None
+    updated_at: float | None = None
 
 
 class CategoryItem(BaseModel):
@@ -54,7 +57,8 @@ def build_memory_model(user_model: type[BaseModel], model: type[BaseModel]) -> t
 
     combined_name = f"{user_model.__name__}{model.__name__}"
     base_name = f"{combined_name}Base"
-    combined_base = type(base_name, (user_model, model, BaseModel), {"__module__": __name__})
+    # Both user_model and model already inherit from BaseModel, so no need to include it again
+    combined_base = type(base_name, (user_model, model), {"__module__": __name__})
     return create_model(combined_name, __base__=combined_base, __module__=__name__)
 
 

--- a/src/memu/workflow/pipeline.py
+++ b/src/memu/workflow/pipeline.py
@@ -46,7 +46,7 @@ class PipelineManager:
 
     def build(self, name: str) -> list[WorkflowStep]:
         revision = self._current_revision(name)
-        return copy.deepcopy(revision.steps)
+        return [step.copy() for step in revision.steps]
 
     def config_step(self, name: str, step_id: str, configs: dict[str, Any]) -> int:
         def mutator(steps: list[WorkflowStep]) -> None:
@@ -107,7 +107,7 @@ class PipelineManager:
 
     def _mutate(self, name: str, mutator: Any) -> int:
         revision = self._current_revision(name)
-        steps = copy.deepcopy(revision.steps)
+        steps = [step.copy() for step in revision.steps]
         metadata = copy.deepcopy(revision.metadata)
         mutator(steps)
         self._validate_steps(steps, initial_state_keys=metadata.get("initial_state_keys"))

--- a/src/memu/workflow/step.py
+++ b/src/memu/workflow/step.py
@@ -21,6 +21,19 @@ class WorkflowStep:
     capabilities: set[str] = field(default_factory=set)
     config: dict[str, Any] = field(default_factory=dict)
 
+    def copy(self) -> "WorkflowStep":
+        """Create a shallow copy with copied mutable fields but shared handler."""
+        return WorkflowStep(
+            step_id=self.step_id,
+            role=self.role,
+            handler=self.handler,  # Keep reference, don't copy
+            description=self.description,
+            requires=set(self.requires),
+            produces=set(self.produces),
+            capabilities=set(self.capabilities),
+            config=dict(self.config),
+        )
+
     async def run(self, state: WorkflowState, context: WorkflowContext) -> WorkflowState:
         result = self.handler(state, context)
         if inspect.isawaitable(result):


### PR DESCRIPTION
- Fix MemoryService to properly access llm_profiles.profiles[default] instead of llm_profiles.default (string)
- Update examples 1/2/3 to use llm_profiles instead of deprecated llm_config
- Fix examples to get categories from memorize() result instead of non-existent service.store
- Remove duplicate BaseModel in build_memory_model inheritance chain
- Fix _register_pipelines to pass workflow list directly (not .steps attribute)
- Add WorkflowStep.copy() method to avoid deepcopy pickle errors with RLock
- Add missing updated_at field to Resource, MemoryItem, MemoryCategory models