### PR TITLE
chore: add PR title check workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,44 @@
+name: pr-title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+      - name: Disallow trailing ellipsis
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ "$PR_TITLE" == *... ]]; then
+            echo "::error title=Invalid PR title::PR title must not end with an ellipsis (...)"
+            exit 1
+          fi


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce PR title conventions. The workflow validates that pull request titles follow semantic commit message types and do not end with an ellipsis.

**CI/CD improvements:**

* Added a `.github/workflows/pr-title.yml` workflow that checks PR titles for semantic types and disallows titles ending with an ellipsis, helping maintain consistency and clarity in pull request naming.