### PR TITLE
fix: correct coverage source to track memu package instead of tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ skip_empty = true
 
 [tool.coverage.run]
 branch = true
-source = ["tests"]
+source = ["memu"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Fixes #219

Corrected the coverage configuration to track the `memu` source package instead of the `tests` directory.

## Problem

The `[tool.coverage.run] source` was set to `["tests"]`, which caused coverage to analyze test code coverage rather than the actual source code.

## Solution

Changed `source = ["tests"]` to `source = ["memu"]` in `pyproject.toml` (line 153).

## Verification

Ran `pytest --cov --cov-report=term-missing` and confirmed coverage now correctly reports for all `src/memu/` modules.