### PR TITLE
fix: allow nullable resource_id in Postgres items

### DIFF
--- a/src/memu/database/postgres/models.py
+++ b/src/memu/database/postgres/models.py
@@ -51,7 +51,7 @@ class ResourceModel(BaseModelMixin, Resource):
 
 
 class MemoryItemModel(BaseModelMixin, MemoryItem):
-    resource_id: str = Field(sa_column=Column(ForeignKey("resources.id", ondelete="CASCADE"), nullable=True))
+    resource_id: str | None = Field(sa_column=Column(ForeignKey("resources.id", ondelete="CASCADE"), nullable=True))
     memory_type: MemoryType = Field(sa_column=Column(String, nullable=False))
     summary: str = Field(sa_column=Column(Text, nullable=False))
     embedding: list[float] | None = Field(default=None, sa_column=Column(Vector(), nullable=True))


### PR DESCRIPTION
Align Postgres MemoryItemModel with schema/nullability so patch flows can create items without a resource_id.