### PR TITLE
fix: remove unused type: ignore comment and add lazyllm mypy override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,10 @@ warn_unused_ignores = false
 disable_error_code = ["attr-defined", "call-arg"]
 
 [[tool.mypy.overrides]]
+module = ["lazyllm.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = ["pgvector.*"]
 ignore_missing_imports = true
 

--- a/src/memu/llm/lazyllm_client.py
+++ b/src/memu/llm/lazyllm_client.py
@@ -2,7 +2,7 @@ import asyncio
 import functools
 from typing import Any, cast
 
-import lazyllm  # type: ignore[import-untyped]
+import lazyllm
 from lazyllm import LOG
 
 


### PR DESCRIPTION
- Remove unnecessary '# type: ignore[import-untyped]' comment from lazyllm import
- Add mypy override for lazyllm module to ignore missing imports globally
- Fixes mypy 'unused-ignore' error in CI