### PR TITLE
fix(embedding): Fix Doubao embedding input field mismatch

### DIFF
--- a/src/memu/embedding/backends/doubao.py
+++ b/src/memu/embedding/backends/doubao.py
@@ -37,7 +37,7 @@ class DoubaoEmbeddingBackend(EmbeddingBackend):
 
     def build_embedding_payload(self, *, inputs: list[str], embed_model: str) -> dict[str, Any]:
         """Build payload for standard text embeddings."""
-        return {"model": embed_model, "input": inputs, "encoding_format": "float"}
+        return {"model": embed_model, "inputs": inputs, "encoding_format": "float"}
 
     def parse_embedding_response(self, data: dict[str, Any]) -> list[list[float]]:
         """Parse embedding response."""
@@ -64,7 +64,7 @@ class DoubaoEmbeddingBackend(EmbeddingBackend):
         return {
             "model": embed_model,
             "encoding_format": encoding_format,
-            "input": [inp.to_dict() for inp in inputs],
+            "inputs": [inp.to_dict() for inp in inputs],
         }
 
     def parse_multimodal_embedding_response(self, data: dict[str, Any]) -> list[list[float]]:


### PR DESCRIPTION
## Description

Fixes the input field mismatch issue for Doubao embedding models. The problem was that the Doubao API expects the input field to be named `inputs` instead of `input`.

## Changes Made

- Modified `src/memu/embedding/backends/doubao.py`:
  - Changed `input` to `inputs` in `build_embedding_payload` method
  - Changed `input` to `inputs` in `build_multimodal_embedding_payload` method

## Testing

The fix ensures that Doubao embedding models now work correctly with the API by using the proper field name for inputs.

## References

- Issue #347: [BUG] 接入doubao embedding模型  input输入字段不匹配