### PR TITLE
fix(cli): add compatibility memu-server entrypoint stub

### DIFF
--- a/src/memu/server/__init__.py
+++ b/src/memu/server/__init__.py
@@ -1,0 +1,2 @@
+"""CLI entrypoints for memu packaging compatibility."""
+

--- a/src/memu/server/cli.py
+++ b/src/memu/server/cli.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from importlib.metadata import PackageNotFoundError, version
+
+
+def _package_version() -> str:
+    try:
+        return version("memu-py")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="memu-server",
+        description="Compatibility CLI for the memu Python package.",
+    )
+    parser.add_argument("--version", action="store_true", help="Show memu package version and exit.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.version:
+        print(f"memu {_package_version()}")
+        return 0
+
+    print("`memu-server` in this package is a compatibility stub.")
+    print("The full backend server lives in the separate repository:")
+    print("https://github.com/NevaMind-AI/memU-server")
+    print("Use the `memu` Python API in this package for local memory workflows.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from memu.server.cli import main
+
+
+def test_server_cli_stub_message(capsys) -> None:
+    exit_code = main([])
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "compatibility stub" in out
+    assert "memU-server" in out
+
+
+def test_server_cli_version(capsys) -> None:
+    exit_code = main(["--version"])
+    out = capsys.readouterr().out.strip()
+    assert exit_code == 0
+    assert out.startswith("memu ")
+


### PR DESCRIPTION

PR Summary
Fix broken memu-server entrypoint by adding a minimal compatible CLI module.

What this PR does

Adds missing memu.server package and CLI entrypoint so memu-server no longer crashes with ModuleNotFoundError.
Keeps behavior explicit: current CLI is a compatibility stub and points users to the separate memU-server repository.
Adds tests for CLI default output and --version.
Why this change is needed
pyproject.toml defines:
memu-server = "memu.server.cli:main"
but current main did not include src/memu/server/cli.py, causing runtime failure.

Type of Change

 Bug fix
 New feature
 Documentation update
 Refactor / cleanup
 Other
PR Quality Checklist

 PR title follows conventional format
 Changes are limited in scope and easy to review
 No breaking changes
 Related issue/discussion can be linked
Testing

Ran: pytest tests/test_server_cli.py -q
Result: 2 passed