### PR TITLE
fix(cli): add missing memu-server CLI entry point

### DIFF
--- a/src/memu/server/__init__.py
+++ b/src/memu/server/__init__.py
@@ -1,0 +1,1 @@
+"""Server module for MemU."""

--- a/src/memu/server/cli.py
+++ b/src/memu/server/cli.py
@@ -1,0 +1,85 @@
+"""CLI entry point for memu-server."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+
+def main(args: Sequence[str] | None = None) -> int:
+    """Main entry point for memu-server CLI."""
+    parser = argparse.ArgumentParser(
+        prog="memu-server",
+        description="MemU Server - AI Memory and Conversation Management Framework",
+    )
+    
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s 1.4.0",
+    )
+    
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+    
+    # Start command
+    start_parser = subparsers.add_parser(
+        "start",
+        help="Start the MemU server",
+    )
+    start_parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind to (default: 127.0.0.1)",
+    )
+    start_parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to bind to (default: 8000)",
+    )
+    start_parser.add_argument(
+        "--config",
+        type=str,
+        help="Path to configuration file",
+    )
+    
+    # Info command
+    info_parser = subparsers.add_parser(
+        "info",
+        help="Show system information",
+    )
+    
+    parsed = parser.parse_args(args)
+    
+    if parsed.command == "start":
+        print("🧠 Starting MemU server...")
+        print(f"   Host: {parsed.host}")
+        print(f"   Port: {parsed.port}")
+        if parsed.config:
+            print(f"   Config: {parsed.config}")
+        print()
+        print("⚠️  Note: Full server implementation is in development.")
+        print("   Currently, use MemoryService programmatically:")
+        print()
+        print("   from memu import MemoryService")
+        print("   service = MemoryService()")
+        print()
+        return 0
+    
+    elif parsed.command == "info":
+        print("🧠 MemU - AI Memory Framework")
+        print("   Version: 1.4.0")
+        print("   Python: >=3.13")
+        print()
+        print("   For documentation, visit:")
+        print("   https://github.com/NevaMind-AI/MemU")
+        return 0
+    
+    else:
+        parser.print_help()
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -1,0 +1,62 @@
+"""Tests for server CLI module."""
+
+import pytest
+from memu.server.cli import main
+
+
+class TestServerCLI:
+    """Test suite for memu-server CLI."""
+
+    def test_cli_help(self, capsys):
+        """Test that CLI shows help without error."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--help"])
+        
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "MemU Server" in captured.out
+
+    def test_cli_version(self, capsys):
+        """Test that CLI shows version."""
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--version"])
+        
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "1.4.0" in captured.out
+
+    def test_cli_info(self, capsys):
+        """Test info command."""
+        result = main(["info"])
+        
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "MemU" in captured.out
+        assert "1.4.0" in captured.out
+
+    def test_cli_start(self, capsys):
+        """Test start command."""
+        result = main(["start", "--host", "0.0.0.0", "--port", "8080"])
+        
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Starting MemU server" in captured.out
+        assert "0.0.0.0" in captured.out
+        assert "8080" in captured.out
+
+    def test_cli_start_default(self, capsys):
+        """Test start command with default values."""
+        result = main(["start"])
+        
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "127.0.0.1" in captured.out
+        assert "8000" in captured.out
+
+    def test_cli_no_args_shows_help(self, capsys):
+        """Test that running without args shows help."""
+        result = main([])
+        
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "usage:" in captured.out


### PR DESCRIPTION
## 📝 Pull Request Summary

Please provide a short summary explaining the purpose of this PR.

---

## ✅ What does this PR do?
- Creates the missing src/memu/server/ package with CLI implementation
- Implements memu-server entry point with start, info, --help, and --version commands
- Adds tests/test_server_cli.py for test coverage
- The start command currently shows a helpful message directing users to programmatic API usage

---

## 🤔 Why is this change needed?
The pyproject.toml defines a console script entry point memu-server = "memu.server.cli:main", but the memu.server module doesn't exist. This causes ModuleNotFoundError when users install the package and try to run memu-server. Fixes #354.


---

## 🔍 Type of Change
Please check what applies:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (please explain)

---

## ✅ PR Quality Checklist

- [x] PR title follows the conventional format (feat:, fix:, docs:)
- [x] Changes are limited in scope and easy to review
- [ ] Documentation updated where applicable
- [x] No breaking changes (or clearly documented)
- [x] Related issues or discussions linked

---

## 📌 Optional

- [ ] Screenshots or examples added (if applicable)
- [x] Edge cases considered
- [ ] Follow-up tasks mentioned
