### PR TITLE
fix(database): allow nullable resource_id in InMemory and SQLite backends

### DIFF
--- a/src/memu/database/inmemory/repositories/memory_item_repo.py
+++ b/src/memu/database/inmemory/repositories/memory_item_repo.py
@@ -79,7 +79,7 @@ class InMemoryMemoryItemRepository(MemoryItemRepo):
     def create_item(
         self,
         *,
-        resource_id: str,
+        resource_id: str | None = None,
         memory_type: MemoryType,
         summary: str,
         embedding: list[float],
@@ -122,7 +122,7 @@ class InMemoryMemoryItemRepository(MemoryItemRepo):
     def create_item_reinforce(
         self,
         *,
-        resource_id: str,
+        resource_id: str | None = None,
         memory_type: MemoryType,
         summary: str,
         embedding: list[float],

--- a/src/memu/database/repositories/memory_item.py
+++ b/src/memu/database/repositories/memory_item.py
@@ -21,7 +21,7 @@ class MemoryItemRepo(Protocol):
     def create_item(
         self,
         *,
-        resource_id: str,
+        resource_id: str | None = None,
         memory_type: MemoryType,
         summary: str,
         embedding: list[float],

--- a/src/memu/database/sqlite/repositories/memory_item_repo.py
+++ b/src/memu/database/sqlite/repositories/memory_item_repo.py
@@ -211,7 +211,7 @@ class SQLiteMemoryItemRepo(SQLiteRepoBase, MemoryItemRepo):
     def create_item(
         self,
         *,
-        resource_id: str,
+        resource_id: str | None = None,
         memory_type: MemoryType,
         summary: str,
         embedding: list[float],
@@ -285,7 +285,7 @@ class SQLiteMemoryItemRepo(SQLiteRepoBase, MemoryItemRepo):
     def create_item_reinforce(
         self,
         *,
-        resource_id: str,
+        resource_id: str | None = None,
         memory_type: MemoryType,
         summary: str,
         embedding: list[float],


### PR DESCRIPTION
## 📝 Pull Request Summary

This PR makes the `resource_id` parameter optional (`str | None = None`) in the `InMemory` and `SQLite` database backends, aligning their signatures with the PostgreSQL backend and resolving a runtime `TypeError`.

---

## ✅ What does this PR do?
- Updates the `MemoryItemRepo` protocol in `src/memu/database/repositories/memory_item.py` to allow `resource_id: str | None = None`.
- Updates `create_item` and `create_item_reinforce` methods in the `InMemory` backend (`inmemory/repositories/memory_item_repo.py`).
- Updates `create_item` and `create_item_reinforce` methods in the `SQLite` backend (`sqlite/repositories/memory_item_repo.py`).

---

## 🤔 Why is this change needed?
- **Context/Impact**: When users call the standard `MemoryService.create_memory_item()` API, it does not provide a `resource_id`. Previously, this caused a `TypeError` (missing 1 required keyword-only argument: 'resource_id') when using `InMemory` or `SQLite` backends.
- **Consistency**: The PostgreSQL backend was already fixed to make this optional in PR #232. This PR extends that fix to the remaining backends.
- Fixes #318 

---

## 🔍 Type of Change
Please check what applies:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (please explain)

---

## ✅ PR Quality Checklist

- [x] PR title follows the conventional format (feat:, fix:, docs:)
- [x] Changes are limited in scope and easy to review
- [ ] Documentation updated where applicable
- [x] No breaking changes (or clearly documented)
- [x] Related issues or discussions linked

---

## 📌 Optional

- [ ] Screenshots or examples added (if applicable)
- [x] Edge cases considered
- [ ] Follow-up tasks mentioned