### PR TITLE
docs: update memU Bot section with GitHub reference and "Now open source"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,17 @@ memU **continuously captures and understands user intent**. Even without a comma
 
 ---
 
-## 🤖 [OpenClaw (Moltbot, Clawdbot) Alternative](https://memu.bot)
+## 🤖 [OpenClaw (Moltbot, Clawdbot) Alternative](https://github.com/NevaMind-AI/memUBot)
 
 <img width="100%" src="https://github.com/NevaMind-AI/memU/blob/main/assets/memUbot.png" />
 
-- **Download-and-use and simple** to get started.
-- Builds long-term memory to **understand user intent** and act proactively.
-- **Cuts LLM token cost** with smaller context.
+**[memU Bot](https://github.com/NevaMind-AI/memUBot)** — Now open source. The enterprise-ready OpenClaw. Your proactive AI assistant that remembers everything.
 
-Try now: [memU bot](https://memu.bot)
+- **Download-and-use and simple** to get started (one-click install, &lt; 3 min).
+- Builds long-term memory to **understand user intent** and act proactively (24/7).
+- **Cuts LLM token cost** with smaller context (~1/10 of comparable usage).
+
+Try now: [memu.bot](https://memu.bot) · Source: [memUBot on GitHub](https://github.com/NevaMind-AI/memUBot)
 
 ---
 


### PR DESCRIPTION
## 📝 Pull Request Summary

Update the memU Bot (OpenClaw alternative) section in the main README to reference the [memUBot](https://github.com/NevaMind-AI/memUBot) GitHub repo, add a clear product tagline and "Now open source," and refine the bullet points (one-click install, 24/7, token cost).

---

## ✅ What does this PR do?

- **README**: Revise the "OpenClaw (Moltbot, Clawdbot) Alternative" block to use [memUBot](https://github.com/NevaMind-AI/memUBot) as the primary reference.
- **Links**: Point the section title and a new "Source" link to the memUBot GitHub repo; keep the "Try now" link to memu.bot.
- **Copy**: Add a one-line tagline for memU Bot, add "Now open source," and tighten the bullets (one-click install &lt; 3 min, 24/7, ~1/10 token usage).
- **Motivation**: Align the README with the open-source memUBot repo and make it clear the bot is now open source and easy to try from GitHub and memu.bot.

---

## 🤔 Why is this change needed?

- Readers need a single, clear link to the memUBot source (GitHub) and a way to try it (memu.bot).
- Stating "Now open source" and the new tagline/bullets improves discoverability and sets expectations (enterprise-ready, proactive, cost-efficient) without changing any code or behavior.

---

## 🔍 Type of Change

Please check what applies:

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (please explain)

---

## ✅ PR Quality Checklist

- [x] PR title follows the conventional format (e.g. `docs: update memU Bot section and add GitHub reference`)
- [x] Changes are limited in scope and easy to review (README only)
- [x] Documentation updated where applicable (this is the doc change)
- [x] No breaking changes (or clearly documented)
- [ ] Related issues or discussions linked (add if you have one)

---

## 📌 Optional

- [ ] Screenshots or examples added (not needed for README text)
- [x] Edge cases considered (links and wording only)
- [ ] Follow-up tasks mentioned