### PR TITLE
Fix export MemUService alias in __init__.py

### DIFF
--- a/src/memu/__init__.py
+++ b/src/memu/__init__.py
@@ -1,6 +1,8 @@
 from memu._core import hello_from_bin
 from memu.app.service import MemoryService
 
+__all__ = ["MemUService", "MemoryService", "hello_from_bin"]
+
 # Public alias used in documentation examples
 MemUService = MemoryService
 


### PR DESCRIPTION
Fixes #329. Adds explicit __all__ export list to make MemUService alias properly importable as shown in documentation examples.