### PR TITLE
fix(server): correct entry point module path for memu-server CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,6 @@ claude = ["claude-agent-sdk>=0.1.24"]
 "Bug Tracker" = "https://github.com/NevaMind-AI/MemU/issues"
 "Documentation" = "https://github.com/NevaMind-AI/MemU#readme"
 
-[project.scripts]
-memu-server = "memu.server.cli:main"
-
 [tool.deptry.per_rule_ignores]
 # Optional dependencies used in examples/
 DEP002 = ["claude-agent-sdk"]


### PR DESCRIPTION
## Summary

Remove the broken `[project.scripts]` entry point that declared `memu-server = "memu.server.cli:main"`.

## Problem

The module `memu.server.cli` has never existed in this package. Installing `memu-py` and running `memu-server --help` (or `python -c 'import memu.server.cli'`) fails with `ModuleNotFoundError`.

## Root Cause

The `memu-server` CLI belongs to the separate [memU-server](https://github.com/NevaMind-AI/memU-server) repository, which has its own FastAPI-based server with additional dependencies (PostgreSQL, Temporal, etc.). The entry point was added to this core library's `pyproject.toml` but the corresponding module was never created.

## Fix

Remove the stale `[project.scripts]` section from `pyproject.toml` so the package installs cleanly without advertising a non-existent CLI command.

Closes #354