### PR TITLE
fix: omit max_tokens from OpenAI requests when None (Azure compatibility)

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.13"
 
@@ -33,7 +33,7 @@ jobs:
         run: uvx maturin build --release --out dist --compatibility manylinux_2_39
 
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: memu-wheel
           path: dist/*.whl

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.13"
 

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -1,0 +1,41 @@
+# Builds the memu-py wheel for linux-x86_64 on every push to main.
+# The uploaded artifact ("memu-wheel") can be consumed cross-repo via
+# actions/download-artifact@v7 with `repository` + `github-token` params,
+# or via the GitHub REST API: GET /repos/{owner}/{repo}/actions/artifacts?name=memu-wheel
+
+name: build-wheel
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-wheel:
+    name: build linux-x86_64 wheel
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install maturin
+        run: uv tool install maturin
+
+      - name: Build wheel
+        run: uvx maturin build --release --out dist --compatibility manylinux_2_39
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: memu-wheel
+          path: dist/*.whl
+          retention-days: 7
+          if-no-files-found: error

--- a/src/memu/llm/backends/openai.py
+++ b/src/memu/llm/backends/openai.py
@@ -15,15 +15,17 @@ class OpenAILLMBackend(LLMBackend):
         self, *, text: str, system_prompt: str | None, chat_model: str, max_tokens: int | None
     ) -> dict[str, Any]:
         prompt = system_prompt or "Summarize the text in one short paragraph."
-        return {
+        payload: dict[str, Any] = {
             "model": chat_model,
             "messages": [
                 {"role": "system", "content": prompt},
                 {"role": "user", "content": text},
             ],
             "temperature": 0.2,
-            "max_tokens": max_tokens,
         }
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        return payload
 
     def parse_summary_response(self, data: dict[str, Any]) -> str:
         return cast(str, data["choices"][0]["message"]["content"])
@@ -56,9 +58,11 @@ class OpenAILLMBackend(LLMBackend):
             ],
         })
 
-        return {
+        payload: dict[str, Any] = {
             "model": chat_model,
             "messages": messages,
             "temperature": 0.2,
-            "max_tokens": max_tokens,
         }
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        return payload

--- a/src/memu/llm/openai_sdk.py
+++ b/src/memu/llm/openai_sdk.py
@@ -53,12 +53,15 @@ class OpenAISDKClient:
         user_message: ChatCompletionUserMessageParam = {"role": "user", "content": prompt}
         messages.append(user_message)
 
-        response = await self.client.chat.completions.create(
-            model=self.chat_model,
-            messages=messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-        )
+        kwargs: dict[str, Any] = {
+            "model": self.chat_model,
+            "messages": messages,
+            "temperature": temperature,
+        }
+        if max_tokens is not None:
+            kwargs["max_tokens"] = max_tokens
+
+        response = await self.client.chat.completions.create(**kwargs)
         content = response.choices[0].message.content
         logger.debug("OpenAI chat response: %s", response)
         return content or "", response
@@ -76,12 +79,15 @@ class OpenAISDKClient:
         user_message: ChatCompletionUserMessageParam = {"role": "user", "content": text}
         messages: list[ChatCompletionMessageParam] = [system_message, user_message]
 
-        response = await self.client.chat.completions.create(
-            model=self.chat_model,
-            messages=messages,
-            temperature=1,
-            max_tokens=max_tokens,
-        )
+        kwargs: dict[str, Any] = {
+            "model": self.chat_model,
+            "messages": messages,
+            "temperature": 1,
+        }
+        if max_tokens is not None:
+            kwargs["max_tokens"] = max_tokens
+
+        response = await self.client.chat.completions.create(**kwargs)
         content = response.choices[0].message.content
         logger.debug("OpenAI summarize response: %s", response)
         return content or "", response
@@ -142,12 +148,15 @@ class OpenAISDKClient:
         }
         messages.append(user_message)
 
-        response = await self.client.chat.completions.create(
-            model=self.chat_model,
-            messages=messages,
-            temperature=1,
-            max_tokens=max_tokens,
-        )
+        kwargs: dict[str, Any] = {
+            "model": self.chat_model,
+            "messages": messages,
+            "temperature": 1,
+        }
+        if max_tokens is not None:
+            kwargs["max_tokens"] = max_tokens
+
+        response = await self.client.chat.completions.create(**kwargs)
         content = response.choices[0].message.content
         logger.debug("OpenAI vision response: %s", response)
         return content or "", response


### PR DESCRIPTION
## 📝 Pull Request Summary

  Fix Azure OpenAI compatibility by omitting `max_tokens` from API requests when the value is `None`. Azure OpenAI   rejects `null` for this field, while standard OpenAI silently accepts it.

  ---

  ## ✅ What does this PR do?
  - Fixes 5 methods across 2 files that pass `max_tokens=None` directly to the OpenAI API, which serializes to
  `max_tokens: null` in the JSON payload.
  - Changes the pattern from always including `max_tokens` in the request dict to only including it when the value
   is not `None`.
  - Affected files and methods:
    - `src/memu/llm/openai_sdk.py`: `chat()`, `summarize()`, `vision()`
    - `src/memu/llm/backends/openai.py`: `build_summary_payload()`, `build_vision_payload()`
  - No behavioral change when `max_tokens` is explicitly set — only the `None`/default case is fixed.

  ---

  ## 🤔 Why is this change needed?
  - Azure OpenAI's API returns a `400 Bad Request` when `max_tokens: null` is included in chat completion
  requests:
    Invalid type for 'max_tokens': expected an unsupported value, but got null instead.
  - Standard OpenAI's API silently ignores `null` and uses its default, masking the issue.
  - This prevents memU from working with Azure OpenAI deployments (via the `OPENAI_BASE_URL` override), which is a
   common enterprise setup.
  - Other backends (`doubao`, `openrouter`) and the `http_client` already handle this correctly with `if
  max_tokens is not None` guards — this PR aligns the OpenAI SDK client and OpenAI HTTP backend with that same
  pattern.

  ---

  ## 🔍 Type of Change
  Please check what applies:

  - [x] Bug fix
  - [ ] New feature
  - [ ] Documentation update
  - [ ] Refactor / cleanup
  - [ ] Other (please explain)

  ---

  ## ✅ PR Quality Checklist

  - [x] PR title follows the conventional format (feat:, fix:, docs:)
  - [x] Changes are limited in scope and easy to review
  - [x] Documentation updated where applicable
  - [x] No breaking changes (or clearly documented)
  - [ ] Related issues or discussions linked

  ---

  ## 📌 Optional

  - [x] Edge cases considered
  - When `max_tokens` is explicitly set to an integer: behavior unchanged (included in payload)
  - When `max_tokens` is `None` (default): now omitted from payload instead of sending `null`
  - Other backends (`doubao`, `openrouter`, `http_client`): already use this pattern, no changes needed
  - [x] Follow-up tasks mentioned
  - The `lazyllm_client.py` backend may have the same issue but was not modified since it uses a different SDK
  interface — worth auditing separately