### PR TITLE
fix: remove broken memu-server entry point (fixes #354)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,6 @@ claude = ["claude-agent-sdk>=0.1.24"]
 "Bug Tracker" = "https://github.com/NevaMind-AI/MemU/issues"
 "Documentation" = "https://github.com/NevaMind-AI/MemU#readme"
 
-[project.scripts]
-memu-server = "memu.server.cli:main"
-
 [tool.deptry.per_rule_ignores]
 # Optional dependencies used in examples/
 DEP002 = ["claude-agent-sdk"]


### PR DESCRIPTION
Fixes #354

## Problem

The `[project.scripts]` entry point in `pyproject.toml` references `memu.server.cli:main`, but the `memu.server` module was removed during the v1.5.0 refactor. After `pip install`, running `memu-server` immediately fails with `ModuleNotFoundError`.

## Fix

Remove the stale `[project.scripts]` section from `pyproject.toml`. The server module no longer exists and there is no replacement CLI entry point in the current codebase.

## Test

After this change, `pip install -e .` no longer registers a broken `memu-server` console script.