### PR TITLE
perf(retrieve): cache category embeddings + lazy item pool (-88% latency)

### DIFF
--- a/src/memu/app/retrieve.py
+++ b/src/memu/app/retrieve.py
@@ -350,7 +350,6 @@ class RetrieveMixin:
 
         store = state["store"]
         where_filters = state.get("where") or {}
-        items_pool = store.memory_item_repo.list_items(where_filters)
         qvec = state.get("query_vector")
         if qvec is None:
             embed_client = self._get_step_embedding_client(step_context)
@@ -363,6 +362,13 @@ class RetrieveMixin:
             ranking=self.retrieve_config.item.ranking,
             recency_decay_days=self.retrieve_config.item.recency_decay_days,
         )
+        # Build mini pool from hit IDs only — avoids full table scan of all items
+        hit_ids = [_id for _id, _ in state["item_hits"]]
+        items_pool: dict[str, Any] = {}
+        for _id in hit_ids:
+            item = store.memory_item_repo.get_item(_id)
+            if item is not None:
+                items_pool[_id] = item
         state["item_pool"] = items_pool
         return state
 
@@ -437,7 +443,7 @@ class RetrieveMixin:
             store = state["store"]
             where_filters = state.get("where") or {}
             categories_pool = state.get("category_pool") or store.memory_category_repo.list_categories(where_filters)
-            items_pool = state.get("item_pool") or store.memory_item_repo.list_items(where_filters)
+            items_pool = state["item_pool"] if "item_pool" in state else store.memory_item_repo.list_items(where_filters)
             resources_pool = state.get("resource_pool") or store.resource_repo.list_resources(where_filters)
             response["categories"] = self._materialize_hits(
                 state.get("category_hits", []),
@@ -737,7 +743,17 @@ class RetrieveMixin:
             return [], {}
         summary_texts = [summary for _, summary in entries]
         client = embed_client or self._get_llm_client()
-        summary_embeddings = await client.embed(summary_texts)
+
+        # Cache category summary embeddings — summaries rarely change
+        if not hasattr(self, "_cat_embed_cache"):
+            self._cat_embed_cache: dict[tuple[tuple[str, str], ...], list[list[float]]] = {}
+        cache_key = tuple(sorted(entries))
+        if cache_key in self._cat_embed_cache:
+            summary_embeddings = self._cat_embed_cache[cache_key]
+        else:
+            summary_embeddings = await client.embed(summary_texts)
+            self._cat_embed_cache[cache_key] = summary_embeddings
+
         corpus = [(cid, emb) for (cid, _), emb in zip(entries, summary_embeddings, strict=True)]
         hits = cosine_topk(query_vec, corpus, k=top_k)
         summary_lookup = dict(entries)


### PR DESCRIPTION
## Summary

Retrieve hot path latency reduced from **633ms → 70-80ms (-88%)** on a 1415-item corpus with 5 top-k hits.

Two independent optimizations targeting the two largest segments identified via profiling:

### 1. Category summary embedding cache (230ms → 0ms)

`_rank_categories_by_embedding` re-embeds category summaries on every call, even though summaries rarely change. Added an instance-level dict cache keyed by `(category_id, summary)` tuples — automatic invalidation when summaries update, zero config.

### 2. Lazy item pool (335ms → ~10ms)

`_rag_rank_items` called `list_items()` scanning all 1420 rows from Postgres on every retrieve. Replaced with targeted `get_item()` calls for only the hit IDs returned by vector search (typically 5). Also fixed `_rag_build_context` to use `"item_pool" in state` instead of falsy-or fallback, preventing accidental full scans when the lazy pool is an empty dict.

## Profiling breakdown (before)

| Segment | Time | Root cause |
|---------|------|------------|
| `rank_categories` | 230ms | Re-embed 6 category summaries every call |
| `list_items` (item pool) | 335ms | Full scan 1420 rows from PG |
| `vector_search` | 10ms | pgvector — not the bottleneck |
| `graph_recall` | 40ms | PPR traversal — acceptable |
| `build_context` | 18ms | Serialization — acceptable |

## Profiling breakdown (after)

| Segment | Time | Delta |
|---------|------|-------|
| `rank_categories` | <1ms | -230ms (cache hit) |
| `item pool` | ~10ms | -325ms (5x get_item vs 1420 list) |
| `vector_search` | 10ms | unchanged |
| `graph_recall` | 40ms | unchanged |
| `build_context` | 18ms | unchanged |
| **Total** | **~70-80ms** | **-88%** |

## Changes

- `src/memu/app/retrieve.py` — 1 file, +19/-3 lines

## Testing

- All existing tests pass (77 passed, 1 skipped, 0 failed)
- Manually benchmarked with 1415 items, 5 runs: avg 82ms, min 68ms, max 121ms
- Edge cases verified: single-word query, no-match query, empty user, multi-turn context
