### PR TITLE
fix: resolve SQLite embedding TypeError by using sa_column=False

### DIFF
--- a/src/memu/database/sqlite/models.py
+++ b/src/memu/database/sqlite/models.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-import logging
 import uuid
 from datetime import datetime
 from typing import Any
@@ -14,8 +12,6 @@ from sqlalchemy import JSON, MetaData, String, Text
 from sqlmodel import Column, DateTime, Field, Index, SQLModel, func
 
 from memu.database.models import CategoryItem, MemoryCategory, MemoryItem, MemoryType, Resource
-
-logger = logging.getLogger(__name__)
 
 
 class TZDateTime(DateTime):
@@ -52,27 +48,10 @@ class SQLiteResourceModel(SQLiteBaseModelMixin, Resource):
     modality: str = Field(sa_column=Column(String, nullable=False))
     local_path: str = Field(sa_column=Column(String, nullable=False))
     caption: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
-    # Store embedding as JSON string since SQLite doesn't have native vector type
+    # Override inherited embedding field: SQLite stores vectors as JSON, not a native column type
+    embedding: list[float] | None = Field(default=None, sa_column=False)
+    # Actual column storing the embedding as a JSON string
     embedding_json: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
-
-    @property
-    def embedding(self) -> list[float] | None:
-        """Parse embedding from JSON string."""
-        if self.embedding_json is None:
-            return None
-        try:
-            return list(json.loads(self.embedding_json))
-        except (json.JSONDecodeError, TypeError) as e:
-            logger.warning("Failed to parse resource embedding JSON: %s", e)
-            return None
-
-    @embedding.setter
-    def embedding(self, value: list[float] | None) -> None:
-        """Serialize embedding to JSON string."""
-        if value is None:
-            self.embedding_json = None
-        else:
-            self.embedding_json = json.dumps(value)
 
 
 class SQLiteMemoryItemModel(SQLiteBaseModelMixin, MemoryItem):
@@ -81,29 +60,12 @@ class SQLiteMemoryItemModel(SQLiteBaseModelMixin, MemoryItem):
     resource_id: str | None = Field(sa_column=Column(String, nullable=True))
     memory_type: MemoryType = Field(sa_column=Column(String, nullable=False))
     summary: str = Field(sa_column=Column(Text, nullable=False))
-    # Store embedding as JSON string since SQLite doesn't have native vector type
+    # Override inherited embedding field: SQLite stores vectors as JSON, not a native column type
+    embedding: list[float] | None = Field(default=None, sa_column=False)
+    # Actual column storing the embedding as a JSON string
     embedding_json: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
     happened_at: datetime | None = Field(default=None, sa_column=Column(DateTime, nullable=True))
     extra: dict[str, Any] = Field(default={}, sa_column=Column(JSON, nullable=True))
-
-    @property
-    def embedding(self) -> list[float] | None:
-        """Parse embedding from JSON string."""
-        if self.embedding_json is None:
-            return None
-        try:
-            return list(json.loads(self.embedding_json))
-        except (json.JSONDecodeError, TypeError) as e:
-            logger.warning("Failed to parse memory item embedding JSON: %s", e)
-            return None
-
-    @embedding.setter
-    def embedding(self, value: list[float] | None) -> None:
-        """Serialize embedding to JSON string."""
-        if value is None:
-            self.embedding_json = None
-        else:
-            self.embedding_json = json.dumps(value)
 
 
 class SQLiteMemoryCategoryModel(SQLiteBaseModelMixin, MemoryCategory):
@@ -111,28 +73,11 @@ class SQLiteMemoryCategoryModel(SQLiteBaseModelMixin, MemoryCategory):
 
     name: str = Field(sa_column=Column(String, nullable=False, index=True))
     description: str = Field(sa_column=Column(Text, nullable=False))
-    # Store embedding as JSON string since SQLite doesn't have native vector type
+    # Override inherited embedding field: SQLite stores vectors as JSON, not a native column type
+    embedding: list[float] | None = Field(default=None, sa_column=False)
+    # Actual column storing the embedding as a JSON string
     embedding_json: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
     summary: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
-
-    @property
-    def embedding(self) -> list[float] | None:
-        """Parse embedding from JSON string."""
-        if self.embedding_json is None:
-            return None
-        try:
-            return list(json.loads(self.embedding_json))
-        except (json.JSONDecodeError, TypeError) as e:
-            logger.warning("Failed to parse category embedding JSON: %s", e)
-            return None
-
-    @embedding.setter
-    def embedding(self, value: list[float] | None) -> None:
-        """Serialize embedding to JSON string."""
-        if value is None:
-            self.embedding_json = None
-        else:
-            self.embedding_json = json.dumps(value)
 
 
 class SQLiteCategoryItemModel(SQLiteBaseModelMixin, CategoryItem):


### PR DESCRIPTION
Fixes #382

## Problem

When running the SQLite test script (`tests/test_sqlite.py`), table creation fails with:

```
raise ValueError(f"{type_} has no matching SQLAlchemy type")
ValueError: <class 'list'> has no matching SQLAlchemy type
```

`SQLiteResourceModel`, `SQLiteMemoryItemModel`, and `SQLiteMemoryCategoryModel` all inherit `embedding: list[float] | None` from their respective parent base classes (`Resource`, `MemoryItem`, `MemoryCategory`). SQLModel's metaclass traverses the full MRO to discover annotated fields and attempts to create a SQLAlchemy column for every one of them. Since SQLAlchemy has no native mapping for `list[float]`, it raises a `ValueError`.

The previous `@property` approach tried to shadow the inherited field, but Python properties do not prevent Pydantic v2 / SQLModel's metaclass from processing the annotation found in the parent class hierarchy.

## Solution

Re-declare `embedding` in each SQLite model class with `Field(default=None, sa_column=False)`. This tells SQLModel the field exists for Pydantic validation purposes only — no SQL column should be created for it.

The actual persistence of embeddings is unchanged: `embedding_json` (a `Text` column) stores the vector serialized as a JSON string, and the repository layer's `_normalize_embedding` / `_prepare_embedding` helpers handle conversion between `list[float]` and JSON on every read/write.

The now-unreachable `@property` / `@embedding.setter` bodies and their associated `import json` / `import logging` are also removed.

## Testing

- SQLite table creation no longer raises `ValueError: <class 'list'> has no matching SQLAlchemy type`
- Read/write round-trips for embeddings are unaffected because all repository code already accessed `embedding_json` directly, not the property