### PR TITLE
fix: make lazyllm an optional dependency (fixes #373)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "alembic>=1.14.0",
     "pendulum>=3.1.0",
     "langchain-core>=1.2.7",
-    "lazyllm>=0.7.3",
 ]
 
 [build-system]
@@ -70,6 +69,7 @@ test = [
 postgres = ["pgvector>=0.3.4", "sqlalchemy[postgresql-psycopgbinary]>=2.0.36"]
 langgraph = ["langgraph>=0.0.10", "langchain-core>=0.1.0"]
 claude = ["claude-agent-sdk>=0.1.24"]
+lazyllm = ["lazyllm>=0.7.3"]
 
 [project.urls]
 "Homepage" = "https://github.com/NevaMind-AI/MemU"


### PR DESCRIPTION
Fixes #373
Fixes #374

## Problem

`pip install memu-py` fails with:
```
ERROR: Could not find a version that satisfies the requirement lazyllm>=0.7.3
```

`lazyllm>=0.7.3` was listed as a required core dependency, but lazyllm 0.7.3+ is not available on PyPI (only 0.6.3 and below are published), causing all installations to fail.

## Solution

Move `lazyllm` from `dependencies` to `[project.optional-dependencies]` under a new `lazyllm` extra. The LazyLLM backend is only used when `client_backend` is explicitly set to `"lazyllm_backend"` — it is not part of the default workflow.

Users who need the LazyLLM backend can install it with:
```bash
pip install memu-py[lazyllm]
```

## Testing

After this change, `pip install memu-py` (or `pip install -e .`) completes successfully without requiring lazyllm to be present on PyPI.