### PR TITLE
fix: remove stale memu-server script entry point (fixes #393)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,6 @@ claude = ["claude-agent-sdk>=0.1.24"]
 "Bug Tracker" = "https://github.com/NevaMind-AI/MemU/issues"
 "Documentation" = "https://github.com/NevaMind-AI/MemU#readme"
 
-[project.scripts]
-memu-server = "memu.server.cli:main"
-
 [tool.deptry.per_rule_ignores]
 # Optional dependencies used in examples/
 DEP002 = ["claude-agent-sdk"]


### PR DESCRIPTION
Fixes #393

## Problem

`pyproject.toml` still declares a `[project.scripts]` entry:

```toml
[project.scripts]
memu-server = "memu.server.cli:main"
```

But `memu.server.cli` was removed in the v1.5.0 refactor. Installing `memu-py` and running `memu-server` produces:

```
ModuleNotFoundError: No module named 'memu.server'
```

This is one of the contributing factors to the confusion in #393, where users installing `memu-py` from PyPI encounter a broken `memu-server` command and stale references to the old `RecallAgent`/`memu.server` architecture.

## Solution

Remove the `[project.scripts]` section from `pyproject.toml`. The v1.5.x architecture exposes memory operations through the `MemoryService` Python API directly — there is no longer a standalone server CLI to ship.

## Testing

- Verified `memu-server` entry is gone from `pyproject.toml`
- No new `memu.server` module was created; the removal is intentional and consistent with the v1.5.x design

## Related

Also related to #354 (same broken entry point, different issue context).