### PR TITLE
docs(grok): fix MemoryService initialization example

### DIFF
--- a/docs/providers/grok.md
+++ b/docs/providers/grok.md
@@ -36,14 +36,18 @@ You can enable the Grok provider by setting the `provider` field to `"grok"` in 
 ### Using Python Configuration
 
 ```python
+import os
 from memu.app.settings import LLMConfig
 from memu.app.service import MemoryService
 
 # Configure the LLM provider to use Grok
-llm_config = LLMConfig(provider="grok")
+llm_config = LLMConfig(
+    provider="grok",
+    api_key=os.environ.get("GROK_API_KEY", ""),
+)
 
-# Initialize the service
-service = MemoryService(llm_config=llm_config)
+# Initialize the service — pass config via llm_profiles, not llm_config
+service = MemoryService(llm_profiles={"default": llm_config})
 print(f"Service initialized with model: {llm_config.chat_model}")
 # Output: Service initialized with model: grok-2-latest
 ```


### PR DESCRIPTION
## Problem

The code example in `docs/providers/grok.md` passes `LLMConfig` via a non-existent `llm_config` keyword argument:

```python
service = MemoryService(llm_config=llm_config)  # ❌ wrong parameter name
```

Running this code raises:
```
TypeError: MemoryService.__init__() got an unexpected keyword argument 'llm_config'
```

`MemoryService.__init__` does not accept `llm_config`; the correct parameter is `llm_profiles`.

## Solution

- Use `llm_profiles={"default": llm_config}` instead of `llm_config=llm_config`
- Add `os.environ.get("GROK_API_KEY", "")` for the API key so the example is copy-pasteable and actually works

## Testing

Verified by reading `MemoryService.__init__` signature in `src/memu/app/service.py`.