### PR TITLE
fix: handle multiple root-level XML elements from non-conformant LLMs

### DIFF
--- a/src/memu/app/memorize.py
+++ b/src/memu/app/memorize.py
@@ -1315,10 +1315,18 @@ class MemorizeMixin:
             xml_content = raw[start_idx : end_idx + len(end_tag)]
             xml_content = xml_content.replace("&", "&amp;")
 
-            root = ET.fromstring(xml_content)
+            try:
+                root = ET.fromstring(xml_content)
+            except ET.ParseError:
+                # Some LLMs emit one <item> per memory rather than a single root
+                # element wrapping all memories, resulting in "junk after document
+                # element" when the slice contains multiple top-level tags.  Wrap
+                # the content in a synthetic root element and retry.
+                root = ET.fromstring(f"<_root_>{xml_content}</_root_>")
+
             result: list[dict[str, Any]] = []
 
-            for memory_elem in root.findall("memory"):
+            for memory_elem in root.iter("memory"):
                 parsed = self._parse_memory_element(memory_elem)
                 if parsed:
                     result.append(parsed)


### PR DESCRIPTION
Fixes #407

## Problem

Some LLMs (e.g. llama3.2 via Ollama) do not follow the expected XML output format precisely. Instead of wrapping all extracted memories in a single `<item>` root element, they produce one `<item>` element per memory with natural-language numbering in between:

```
1. <item>
    <memory>...</memory>
</item>

2. <item>
    <memory>...</memory>
</item>
```

`_find_xml_boundaries` extracts the slice from the first `<item>` to the last `</item>`, which contains multiple top-level tags separated by text (`2. `, `3. `, …). `ET.fromstring` then raises `ParseError: junk after document element` because the first root element closes before the end of the string.

## Solution

Two minimal changes to `_parse_memory_type_response_xml`:

1. **Wrap-and-retry**: catch `ParseError` from the first `ET.fromstring` call, wrap the content in a synthetic `<_root_>` element, and retry. This makes the multi-`<item>` layout valid XML without affecting well-formed single-root responses.

2. **`findall` → `iter`**: switch from `root.findall("memory")` to `root.iter("memory")` so that `<memory>` nodes are found regardless of depth—direct children of the root (normal case) or grandchildren via `<item>` wrappers (wrapped multi-root case).

## Testing

Manually validated against the XML snippets from the issue report. The retry path successfully parses multiple top-level `<item>` elements and returns all contained `<memory>` items.