### PR TITLE
fix: remove duplicate document text from preprocess prompt

### DIFF
--- a/src/memu/prompts/preprocess/document.py
+++ b/src/memu/prompts/preprocess/document.py
@@ -5,7 +5,7 @@ Analyze the provided document text and produce two outputs:
 2. A one-sentence caption summarizing what the document is about.
 
 # Workflow
-1. Read the **Document** (`{document_text}`) carefully to understand its full content.
+1. Read the **Document** carefully to understand its full content.
 2. Identify the main points, key arguments, and essential details.
 3. Remove repetition, filler, and unnecessary verbosity while preserving meaning and completeness.
 4. Rewrite the content in a concise, structured form.


### PR DESCRIPTION
## Summary
- remove the duplicate `{document_text}` placeholder from the document preprocess workflow step
- keep document content only in the `# Input` section, matching the other preprocess prompts

## Testing
- `git diff --check`

Close #419