### PR TITLE
fix(memorize): silent memory item drops in XML parser and    LLM-mode retrieval

### DIFF
--- a/src/memu/app/memorize.py
+++ b/src/memu/app/memorize.py
@@ -1259,7 +1259,20 @@ class MemorizeMixin:
 
     def _find_xml_boundaries(self, raw: str) -> tuple[int, int, str] | None:
         """Find the start index, end index, and closing tag for XML root element."""
-        root_tags = ["item", "profile", "behaviors", "events", "knowledge", "skills"]
+        root_tags = [
+            "item",
+            "profile",
+            "profiles",
+            "event",
+            "events",
+            "knowledge",
+            "behavior",
+            "behaviors",
+            "skill",
+            "skills",
+            "tool",
+            "tools",
+        ]
         for tag in root_tags:
             opening = f"<{tag}>"
             closing = f"</{tag}>"
@@ -1294,7 +1307,7 @@ class MemorizeMixin:
         Parse XML memory extraction output into a list of memory items.
 
         Expected XML format (root tag varies by memory type):
-        <profile|behaviors|events|knowledge|skills>
+        <item|profile|event[s]|knowledge|behavior[s]|skill[s]|tool[s]>
             <memory>
                 <content>...</content>
                 <categories>

--- a/src/memu/app/memorize.py
+++ b/src/memu/app/memorize.py
@@ -37,6 +37,8 @@ from memu.workflow.step import WorkflowState, WorkflowStep
 
 logger = logging.getLogger(__name__)
 
+UNCATEGORIZED_CATEGORY_NAME = "uncategorized"
+
 if TYPE_CHECKING:
     from memu.app.service import Context
     from memu.app.settings import MemorizeConfig
@@ -615,6 +617,10 @@ class MemorizeMixin:
                 # existing item
                 continue
             mapped_cat_ids = self._map_category_names_to_ids(cat_names, ctx)
+            if not mapped_cat_ids and self.memorize_config.enable_uncategorized_fallback:
+                fallback_id = ctx.category_name_to_id.get(UNCATEGORIZED_CATEGORY_NAME)
+                if fallback_id is not None:
+                    mapped_cat_ids = [fallback_id]
             for cid in mapped_cat_ids:
                 rels.append(store.category_item_repo.link_item_category(item.id, cid, user_data=dict(user or {})))
                 # Store (item_id, summary) tuple for reference support
@@ -650,19 +656,36 @@ class MemorizeMixin:
     ) -> None:
         if ctx.categories_ready:
             return
-        if not self.category_configs:
+        configs = list(self.category_configs)
+        if self.memorize_config.enable_uncategorized_fallback and not any(
+            cfg.name.lower() == UNCATEGORIZED_CATEGORY_NAME for cfg in configs
+        ):
+            configs.append(
+                CategoryConfig(
+                    name=UNCATEGORIZED_CATEGORY_NAME,
+                    description="Memory items that do not match any other configured category.",
+                )
+            )
+        if not configs:
             ctx.categories_ready = True
             return
-        cat_texts = [self._category_embedding_text(cfg) for cfg in self.category_configs]
+        cat_texts = [self._category_embedding_text(cfg) for cfg in configs]
         cat_vecs = await self._get_llm_client("embedding").embed(cat_texts)
         ctx.category_ids = []
         ctx.category_name_to_id = {}
-        for cfg, vec in zip(self.category_configs, cat_vecs, strict=True):
+        for cfg, vec in zip(configs, cat_vecs, strict=True):
             name = cfg.name.strip() or "Untitled"
             description = cfg.description.strip()
             cat = store.memory_category_repo.get_or_create_category(
                 name=name, description=description, embedding=vec, user_data=dict(user or {})
             )
+            # Seed a static summary for the fallback: _rank_categories_by_summary
+            # in retrieve.py filters on `cat.summary`, and we deliberately skip
+            # dynamic summary updates for this category (see _update_category_summaries).
+            # Must go through update_category so the value persists on SQL backends
+            # whose get_or_create_category returns a detached/copied instance.
+            if name.lower() == UNCATEGORIZED_CATEGORY_NAME and not cat.summary and description:
+                cat = store.memory_category_repo.update_category(category_id=cat.id, summary=description)
             ctx.category_ids.append(cat.id)
             ctx.category_name_to_id[name.lower()] = cat.id
         ctx.categories_ready = True
@@ -1119,6 +1142,11 @@ class MemorizeMixin:
         for cid, memories in updates.items():
             cat = store.memory_category_repo.categories.get(cid)
             if not cat or not memories:
+                continue
+            if cat.name.lower() == UNCATEGORIZED_CATEGORY_NAME:
+                # Summaries over heterogeneous uncategorized items are incoherent and
+                # waste tokens; the category's static description embedding is enough
+                # for route_category to consider it when nothing else matches.
                 continue
             prompt = self._build_category_summary_prompt(category=cat, new_memories=memories)
             tasks.append(client.chat(prompt))

--- a/src/memu/app/memorize.py
+++ b/src/memu/app/memorize.py
@@ -1283,7 +1283,9 @@ class MemorizeMixin:
             categories = [cat_elem.text.strip() for cat_elem in categories_elem.findall("category") if cat_elem.text]
             memory_dict["categories"] = categories
 
-        if memory_dict.get("content") and memory_dict.get("categories"):
+        # `categories` may be empty per the memory type prompts.
+        if memory_dict.get("content"):
+            memory_dict.setdefault("categories", [])
             return memory_dict
         return None
 

--- a/src/memu/app/settings.py
+++ b/src/memu/app/settings.py
@@ -240,6 +240,14 @@ class MemorizeConfig(BaseModel):
         default=False,
         description="Enable reinforcement tracking for memory items.",
     )
+    enable_uncategorized_fallback: bool = Field(
+        default=True,
+        description=(
+            "Auto-create an 'uncategorized' category and link memory items whose "
+            "extracted categories match none of the configured ones, so LLM-mode "
+            "retrieval (which joins items via category relations) can still reach them."
+        ),
+    )
 
 
 class PatchConfig(BaseModel):

--- a/tests/test_uncategorized_fallback.py
+++ b/tests/test_uncategorized_fallback.py
@@ -1,0 +1,200 @@
+"""
+Tests for the uncategorized-fallback feature in MemorizeMixin.
+
+When the LLM extracts a memory item that maps to no configured category,
+it is linked to an auto-created "uncategorized" category so it remains
+reachable from LLM-mode retrieval (which joins items via category relations).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from memu.app.memorize import UNCATEGORIZED_CATEGORY_NAME, MemorizeMixin
+from memu.app.service import Context
+from memu.app.settings import CategoryConfig, DatabaseConfig, DefaultUserModel, MemorizeConfig
+from memu.database.factory import build_database
+from memu.database.interfaces import Database
+
+
+class FakeLLMClient:
+    """Deterministic stand-in for the embedding and chat client."""
+
+    chat_model = "fake-chat"
+    embed_model = "fake-embed"
+
+    async def embed(self, inputs: list[str]) -> list[list[float]]:
+        return [[float(len(s) % 5), 0.0, 0.0] for s in inputs]
+
+    async def chat(self, *_: Any, **__: Any) -> str:
+        return "fake summary"
+
+
+def _build_mixin(
+    *,
+    enable_fallback: bool = True,
+    configured_categories: list[CategoryConfig] | None = None,
+) -> tuple[MemorizeMixin, Context, Database]:
+    cfg = MemorizeConfig(
+        memory_categories=configured_categories or [],
+        enable_uncategorized_fallback=enable_fallback,
+    )
+    mixin = MemorizeMixin.__new__(MemorizeMixin)
+    mixin.memorize_config = cfg
+    mixin.category_configs = list(cfg.memory_categories)
+    mixin._get_llm_client = lambda profile=None, step_context=None: FakeLLMClient()  # type: ignore[method-assign]
+
+    db = build_database(
+        config=DatabaseConfig.model_validate({"metadata_store": {"provider": "inmemory"}}),
+        user_model=DefaultUserModel,
+    )
+    return mixin, Context(), db
+
+
+class TestConfigFlag:
+    def test_defaults_enabled(self):
+        """New deployments get the fallback automatically."""
+        assert MemorizeConfig().enable_uncategorized_fallback is True
+
+    def test_can_be_disabled(self):
+        cfg = MemorizeConfig(enable_uncategorized_fallback=False)
+        assert cfg.enable_uncategorized_fallback is False
+
+
+class TestInitializeCategories:
+    @pytest.mark.asyncio
+    async def test_creates_uncategorized_when_no_user_categories(self):
+        """Even with empty memory_categories, the fallback is created."""
+        mixin, ctx, db = _build_mixin()
+        await mixin._initialize_categories(ctx, db)
+        assert UNCATEGORIZED_CATEGORY_NAME in ctx.category_name_to_id
+        assert ctx.categories_ready is True
+        cat_id = ctx.category_name_to_id[UNCATEGORIZED_CATEGORY_NAME]
+        assert cat_id in db.memory_category_repo.categories
+
+    @pytest.mark.asyncio
+    async def test_appends_uncategorized_alongside_user_categories(self):
+        mixin, ctx, db = _build_mixin(configured_categories=[CategoryConfig(name="habits", description="d")])
+        await mixin._initialize_categories(ctx, db)
+        assert "habits" in ctx.category_name_to_id
+        assert UNCATEGORIZED_CATEGORY_NAME in ctx.category_name_to_id
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_disabled(self):
+        mixin, ctx, db = _build_mixin(enable_fallback=False)
+        await mixin._initialize_categories(ctx, db)
+        assert UNCATEGORIZED_CATEGORY_NAME not in ctx.category_name_to_id
+
+    @pytest.mark.asyncio
+    async def test_fallback_category_has_seeded_summary(self):
+        """route_category filters on cat.summary; only the fallback gets one at init."""
+        mixin, ctx, db = _build_mixin(configured_categories=[CategoryConfig(name="habits", description="user habits")])
+        await mixin._initialize_categories(ctx, db)
+
+        fallback_id = ctx.category_name_to_id[UNCATEGORIZED_CATEGORY_NAME]
+        habits_id = ctx.category_name_to_id["habits"]
+        assert db.memory_category_repo.categories[fallback_id].summary
+        assert not db.memory_category_repo.categories[habits_id].summary
+
+    @pytest.mark.asyncio
+    async def test_not_duplicated_if_user_already_configured_it(self):
+        """User-defined 'uncategorized' takes precedence; no second copy is added."""
+        mixin, ctx, db = _build_mixin(
+            configured_categories=[CategoryConfig(name=UNCATEGORIZED_CATEGORY_NAME, description="user-defined")]
+        )
+        await mixin._initialize_categories(ctx, db)
+        assert (
+            sum(1 for c in db.memory_category_repo.categories.values() if c.name.lower() == UNCATEGORIZED_CATEGORY_NAME)
+            == 1
+        )
+
+
+class TestPersistMemoryItems:
+    @pytest.mark.asyncio
+    async def test_links_uncategorized_item_to_fallback_category(self):
+        """An item with no matching categories ends up linked to the fallback."""
+        mixin, ctx, db = _build_mixin(configured_categories=[CategoryConfig(name="habits", description="d")])
+        await mixin._initialize_categories(ctx, db)
+
+        items, rels, updates = await mixin._persist_memory_items(
+            resource_id="res-1",
+            structured_entries=[("profile", "User uses dark mode.", [])],
+            ctx=ctx,
+            store=db,
+            embed_client=FakeLLMClient(),
+            user={"user_id": "u1"},
+        )
+
+        assert len(items) == 1
+        assert len(rels) == 1
+        fallback_id = ctx.category_name_to_id[UNCATEGORIZED_CATEGORY_NAME]
+        assert rels[0].category_id == fallback_id
+        assert fallback_id in updates
+
+    @pytest.mark.asyncio
+    async def test_keeps_explicit_category_when_provided(self):
+        """If the LLM returns a matching category name, no fallback is applied."""
+        mixin, ctx, db = _build_mixin(configured_categories=[CategoryConfig(name="habits", description="d")])
+        await mixin._initialize_categories(ctx, db)
+
+        _, rels, _ = await mixin._persist_memory_items(
+            resource_id="res-1",
+            structured_entries=[("profile", "User journals daily.", ["habits"])],
+            ctx=ctx,
+            store=db,
+            embed_client=FakeLLMClient(),
+            user={"user_id": "u1"},
+        )
+
+        habits_id = ctx.category_name_to_id["habits"]
+        assert [r.category_id for r in rels] == [habits_id]
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_when_disabled(self):
+        """With the flag off, uncategorized items get no category links at all."""
+        mixin, ctx, db = _build_mixin(
+            enable_fallback=False,
+            configured_categories=[CategoryConfig(name="habits", description="d")],
+        )
+        await mixin._initialize_categories(ctx, db)
+
+        _, rels, updates = await mixin._persist_memory_items(
+            resource_id="res-1",
+            structured_entries=[("profile", "User likes oolong tea.", [])],
+            ctx=ctx,
+            store=db,
+            embed_client=FakeLLMClient(),
+            user={"user_id": "u1"},
+        )
+
+        assert rels == []
+        assert updates == {}
+
+
+class TestUpdateCategorySummaries:
+    @pytest.mark.asyncio
+    async def test_skips_summary_for_uncategorized_category(self):
+        """Heterogeneous uncategorized items should not trigger a summary LLM call."""
+        mixin, ctx, db = _build_mixin()
+        await mixin._initialize_categories(ctx, db)
+        fallback_id = ctx.category_name_to_id[UNCATEGORIZED_CATEGORY_NAME]
+
+        call_count = 0
+
+        class CountingClient(FakeLLMClient):
+            async def chat(self, *_: Any, **__: Any) -> str:
+                nonlocal call_count
+                call_count += 1
+                return "should not happen"
+
+        result = await mixin._update_category_summaries(
+            {fallback_id: [("item-1", "User uses dark mode.")]},
+            ctx,
+            db,
+            llm_client=CountingClient(),
+        )
+
+        assert call_count == 0
+        assert result == {}

--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -1,0 +1,53 @@
+"""
+Tests for _parse_memory_element in MemorizeMixin.
+
+Verifies that memory items with empty `<categories>` are preserved
+(the prompts in src/memu/prompts/memory_type/ allow empty categories).
+"""
+
+from __future__ import annotations
+
+import defusedxml.ElementTree as ET
+
+from memu.app.memorize import MemorizeMixin
+
+
+def _mixin() -> MemorizeMixin:
+    return MemorizeMixin.__new__(MemorizeMixin)
+
+
+class TestParseMemoryElement:
+    """Tests for _parse_memory_element."""
+
+    def test_keeps_item_with_empty_categories(self):
+        """Empty <categories> tag should not cause the item to be dropped."""
+        elem = ET.fromstring("<memory><content>The user prefers dark mode.</content><categories></categories></memory>")
+        assert _mixin()._parse_memory_element(elem) == {
+            "content": "The user prefers dark mode.",
+            "categories": [],
+        }
+
+    def test_keeps_item_without_categories_tag(self):
+        """Missing <categories> tag should not cause the item to be dropped."""
+        elem = ET.fromstring("<memory><content>The user lives in Beijing.</content></memory>")
+        assert _mixin()._parse_memory_element(elem) == {
+            "content": "The user lives in Beijing.",
+            "categories": [],
+        }
+
+    def test_drops_item_without_content(self):
+        """Items without <content> are still dropped."""
+        elem = ET.fromstring("<memory><content></content><categories><category>x</category></categories></memory>")
+        assert _mixin()._parse_memory_element(elem) is None
+
+    def test_keeps_non_empty_categories(self):
+        """Non-empty <categories> is preserved verbatim."""
+        elem = ET.fromstring(
+            "<memory>"
+            "<content>The user drinks coffee daily.</content>"
+            "<categories><category>habits</category><category>preferences</category></categories>"
+            "</memory>"
+        )
+        parsed = _mixin()._parse_memory_element(elem)
+        assert parsed is not None
+        assert parsed["categories"] == ["habits", "preferences"]

--- a/tests/test_xml_parser.py
+++ b/tests/test_xml_parser.py
@@ -1,8 +1,9 @@
 """
-Tests for _parse_memory_element in MemorizeMixin.
+Tests for XML memory extraction parser in MemorizeMixin.
 
-Verifies that memory items with empty `<categories>` are preserved
-(the prompts in src/memu/prompts/memory_type/ allow empty categories).
+Tests cover:
+1. Memory items with empty `categories` are preserved (prompts allow empty).
+2. Root-tag whitelist accepts every MemoryType value (singular and plural).
 """
 
 from __future__ import annotations
@@ -51,3 +52,65 @@ class TestParseMemoryElement:
         parsed = _mixin()._parse_memory_element(elem)
         assert parsed is not None
         assert parsed["categories"] == ["habits", "preferences"]
+
+
+class TestFindXmlBoundaries:
+    """Tests for _find_xml_boundaries root-tag detection."""
+
+    def test_accepts_singular_event(self):
+        raw = "<event><memory><content>x</content></memory></event>"
+        boundaries = _mixin()._find_xml_boundaries(raw)
+        assert boundaries is not None
+        assert boundaries[2] == "</event>"
+
+    def test_accepts_singular_behavior(self):
+        raw = "<behavior><memory><content>x</content></memory></behavior>"
+        assert _mixin()._find_xml_boundaries(raw) is not None
+
+    def test_accepts_singular_skill(self):
+        raw = "<skill><memory><content>x</content></memory></skill>"
+        assert _mixin()._find_xml_boundaries(raw) is not None
+
+    def test_accepts_tool(self):
+        """`tool` is a valid MemoryType (database/models.py) but was missing."""
+        raw = "<tool><memory><content>x</content></memory></tool>"
+        assert _mixin()._find_xml_boundaries(raw) is not None
+
+    def test_accepts_legacy_plural_tags(self):
+        """Original whitelist must keep working."""
+        for tag in ("profile", "behaviors", "events", "knowledge", "skills"):
+            raw = f"<{tag}><memory><content>x</content></memory></{tag}>"
+            assert _mixin()._find_xml_boundaries(raw) is not None, tag
+
+    def test_rejects_unknown_root(self):
+        raw = "<random><memory><content>x</content></memory></random>"
+        assert _mixin()._find_xml_boundaries(raw) is None
+
+
+class TestParseMemoryTypeResponseXml:
+    """End-to-end tests via _parse_memory_type_response_xml."""
+
+    def test_singular_root_with_empty_categories(self):
+        """LLM returns <event> root with one item lacking categories."""
+        raw = (
+            "<event><memory>"
+            "<content>The user attended a meetup in Beijing yesterday.</content>"
+            "<categories></categories>"
+            "</memory></event>"
+        )
+        items = _mixin()._parse_memory_type_response_xml(raw)
+        assert len(items) == 1
+        assert items[0]["categories"] == []
+
+    def test_tool_root_with_mixed_categories(self):
+        """Two memories under <tool>, one categorised, one not."""
+        raw = (
+            "<tool>"
+            "<memory><content>Calculator added 2 and 2.</content>"
+            "<categories><category>math</category></categories></memory>"
+            "<memory><content>Weather queried for Beijing.</content>"
+            "<categories></categories></memory>"
+            "</tool>"
+        )
+        items = _mixin()._parse_memory_type_response_xml(raw)
+        assert [it["categories"] for it in items] == [["math"], []]


### PR DESCRIPTION
## 📝 Pull Request Summary

Two parser bugs in `src/memu/app/memorize.py` that silently drop memory items during `memorize()`, plus a follow-up so the recovered items stay reachable from LLM-mode retrieval.

---

## ✅ What does this PR do?

Three atomic commits in `src/memu/app/memorize.py`:

**1. Preserve memory items with empty `<categories>`** (`cbfac4b`)

`_parse_memory_element` required both `<content>` and `<categories>` to be truthy:

```python
if memory_dict.get("content") and memory_dict.get("categories"):
    return memory_dict
return None
```

But the prompts at `prompts/memory_type/{profile,event,knowledge,behavior}.py` all state `"categories": [...can be empty]`. Memories that don't fit a pre-configured category were dropped with no log line. Now only `<content>` is required; empty categories defaults to `[]`.

**2. Expand the XML root-tag whitelist** (`e116f4d`)

`_find_xml_boundaries` recognised only `["item", "profile", "behaviors", "events", "knowledge", "skills"]`. `MemoryType` in `database/models.py` includes `tool` and singular `behavior`/`event`/`skill`. The whitelist is extended to cover both forms of every MemoryType. Latent today because every built-in prompt wraps in `<item>`, but any custom prompt using semantic root tags returned `[]` with only a `Could not find valid root tag` warning.

**3. Link uncategorized items to a fallback category** (`8284ff1`)

After fix 1, items with no matched category land in the DB but with no `CategoryItem` relation. LLM-mode retrieval joins items via that table (`retrieve.py:_format_items_for_llm`), so those items remained unreachable from the LLM path. (RAG-mode was unaffected because its `recall_items` does a global vector search.)

An `uncategorized` category is now auto-created at category init (`memorize_config.enable_uncategorized_fallback`, default `True`). Items whose extracted category names match nothing get linked to it. The category is seeded with a static summary at creation (equal to its description) because `retrieve.py:_rank_categories_by_summary` filters on `cat.summary`; the seeding goes through `update_category()` so it persists on SQLite and Postgres backends where `get_or_create_category` returns a detached or copied instance. Dynamic summary updates skip the fallback since aggregating heterogeneous items into one summary is noisy and wastes tokens.

---

## 🤔 Why is this change needed?

The first two bugs cause silent data loss during the core `memorize()` flow — extracted facts simply never reach storage and there is no log to attribute the loss to. The third change closes the gap so that data preserved by fix 1 is also retrievable through the LLM-mode path, not just RAG-mode.

Related discussion: the long-term memory drift reported in #381 is made strictly worse by silent drops, so fixing this is upstream of any drift work.

---

## 🔍 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other

---

## ✅ PR Quality Checklist

- [x] PR title follows the conventional format (`fix:` ×3 commits)
- [x] Changes are limited in scope and easy to review (three atomic commits, ~50 source lines, ~330 test lines)
- [x] Documentation updated where applicable (config field has a `description=`; no public API docs needed)
- [x] No breaking changes — the new `enable_uncategorized_fallback` flag defaults to `True` and adds one `uncategorized` entry to `list_memory_categories()`; setting it to `False` restores the old behaviour exactly
- [x] Related issues or discussions linked (see "Why" section)

---

## 📌 Optional

- [x] Edge cases considered:
  - User pre-configures a `CategoryConfig(name="uncategorized")` → not duplicated, user's config wins
  - User's existing uncategorized has a summary → not overwritten (`not cat.summary` guard)
  - Reinforcement skip path: items being reinforced keep their original category links
  - All three DB backends (in-memory, SQLite, Postgres) verified via `update_category()` flow
- [x] Follow-up tasks (left for separate issues):
  - `MemoryCategory.embedding` is set at init but never consumed by retrieval (route_category re-embeds `cat.summary` instead)
  - Cold-start retrieve returns `[]` from `_rank_categories_by_summary` when no category has been summarised yet — the fallback's seeded summary partially mitigates this

---

23 new unit tests across `tests/test_xml_parser.py` and `tests/test_uncategorized_fallback.py`, no API key needed. The fallback tests use the in-memory backend with a deterministic stub LLM client, so they exercise the real category creation, item persistence, relation linking, and summary-update code paths end-to-end. `make test` reports 100 passed, 1 skipped; `make check` passes pre-commit, mypy, and deptry (the pre-existing `uv.lock` 1.5.0 vs `pyproject.toml` 1.5.1 mismatch on `main` is not touched by this PR).
