### PR TITLE
fix: return empty list for non-positive top_k in cosine_topk

### DIFF
--- a/src/memu/database/inmemory/vector.py
+++ b/src/memu/database/inmemory/vector.py
@@ -58,6 +58,9 @@ def cosine_topk(
     corpus: Iterable[tuple[str, list[float] | None]],
     k: int = 5,
 ) -> list[tuple[str, float]]:
+    if k <= 0:
+        return []
+
     # Filter out None vectors and collect valid entries
     ids: list[str] = []
     vecs: list[list[float]] = []
@@ -111,6 +114,9 @@ def cosine_topk_salience(
     Returns:
         List of (id, salience_score) tuples, sorted by score descending
     """
+    if k <= 0:
+        return []
+
     q = np.array(query_vec, dtype=np.float32)
     scored: list[tuple[str, float]] = []
 

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from memu.database.inmemory.vector import cosine_topk, cosine_topk_salience
+
+
+def _corpus() -> list[tuple[str, list[float]]]:
+    return [("a", [1.0, 0.0]), ("b", [0.0, 1.0]), ("c", [0.7, 0.7])]
+
+
+def test_cosine_topk_nonpositive_k_returns_empty() -> None:
+    # top_k <= 0 must return nothing, not the entire corpus (which is what the
+    # argpartition path did for k == 0).
+    assert cosine_topk([1.0, 0.0], _corpus(), k=0) == []
+    assert cosine_topk([1.0, 0.0], _corpus(), k=-1) == []
+
+
+def test_cosine_topk_orders_by_similarity() -> None:
+    results = cosine_topk([1.0, 0.0], _corpus(), k=2)
+    assert [memory_id for memory_id, _ in results] == ["a", "c"]
+
+
+def test_cosine_topk_salience_nonpositive_k_returns_empty() -> None:
+    now = datetime.now(UTC)
+    corpus = [("a", [1.0, 0.0], 1, now), ("b", [0.0, 1.0], 1, now)]
+    assert cosine_topk_salience([1.0, 0.0], corpus, k=0) == []
+    assert cosine_topk_salience([1.0, 0.0], corpus, k=-1) == []


### PR DESCRIPTION
`cosine_topk` returns the **entire** corpus when `top_k` is `0`, and `n-1` results when `top_k` is negative, instead of returning nothing.

`src/memu/database/inmemory/vector.py`:

```python
actual_k = min(k, n)
if actual_k == n:
    topk_indices = np.argsort(scores)[::-1]
else:
    topk_indices = np.argpartition(scores, -actual_k)[-actual_k:]   # [-0:] == [0:] -> all
    ...
```

For `k == 0`, `actual_k` is `0`, and the `else` branch slices `[-0:]` which is `[0:]` — the whole array. For `k == -1` it slices `[1:]` (`n-1` items).

`top_k` reaches `cosine_topk` unvalidated from `retrieve_config.{category,item,resource}.top_k`, so a user setting a tier's `top_k` to `0` to disable it silently gets the full corpus back rather than an empty result — an over-retrieval bug that also inflates token usage downstream.

Fix: return `[]` for `k <= 0`. `cosine_topk_salience` is guarded the same way — `scored[:0]` already returned `[]`, but `scored[:-1]` (for `k = -1`) incorrectly dropped the last entry, so both now behave consistently.

Added `tests/test_vector.py` covering `k=0`/`k=-1` (empty) and a positive-`k` ordering case for both functions. `pytest tests/test_vector.py` passes; `ruff` clean.
