### PR TITLE
chore: improve memU maintenance path

### DIFF
--- a/src/memu/app/crud.py
+++ b/src/memu/app/crud.py
@@ -650,7 +650,7 @@ class CRUDMixin:
 
     async def _patch_category_summaries(
         self,
-        updates: dict[str, list[str]],
+        updates: dict[str, tuple[Any, Any]],
         ctx: Context,
         store: Database,
         llm_client: Any | None = None,

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -68,11 +68,17 @@ async def main():
         # RAG-based retrieval
         service.retrieve_config.method = "rag"
         result_rag = await service.retrieve(queries=queries, where={"user_id": "123"})
+        assert isinstance(result_rag, dict)
+        assert "items" in result_rag
+        assert "categories" in result_rag
         _print_results("RAG", result_rag)
 
         # LLM-based retrieval
         service.retrieve_config.method = "llm"
         result_llm = await service.retrieve(queries=queries, where={"user_id": "123"})
+        assert isinstance(result_llm, dict)
+        assert "items" in result_llm
+        assert "categories" in result_llm
         _print_results("LLM", result_llm)
 
         print("\n[SQLITE] Test completed!")


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in src/memu/app/crud.py, tests/test_sqlite.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.