### PR TITLE
feat(preprocess): classify audio type and add an overview on ingest

### DIFF
--- a/src/memu/prompts/preprocess/audio.py
+++ b/src/memu/prompts/preprocess/audio.py
@@ -1,32 +1,59 @@
 PROMPT = """
 # Task Objective
-Analyze the provided audio transcription and produce two outputs:
-1. A **Processed Content** version that is clean, well-formatted, and easy to read.
-2. A **Caption** that summarizes what the audio is about in one sentence.
+You are given the transcription of an audio recording. Produce two outputs:
+1. A **Processed Content** version that is clean and well-formatted, prefixed with a
+   short overview describing what kind of audio this is.
+2. A **Caption** that summarizes the audio in one sentence, starting with its type.
 
-# Workflow
-1. Read the **Transcription** carefully.
-2. Correct punctuation, capitalization, and obvious transcription artifacts.
-3. Add paragraph breaks where they improve readability or reflect topic shifts.
-4. Preserve the original meaning, wording, and sequence of the audio.
-5. Generate a concise **one-sentence caption** that accurately describes the audio's main topic or purpose.
+# Step 1 - Classify the Audio
+Infer the nature of the audio from the transcription alone. Pick the single
+best-fitting type, for example:
+- conversation / dialogue (two or more speakers talking)
+- monologue / narration / voice memo (a single speaker)
+- lecture / presentation / talk
+- interview
+- podcast / radio segment
+- meeting / phone call
+- song / music (lyrics, repeated chorus, verse structure)
+- announcement / advertisement
+- other (describe it briefly)
+If the type is uncertain, choose the closest match and note that it is approximate.
+
+# Step 2 - Build an Overview
+Write a short "Audio Overview" (a few bullet lines) capturing what can be inferred:
+- Type: the category from Step 1
+- Language: the primary language(s) spoken
+- Speakers: approximate number of distinct speakers, if discernible
+- Topic: the main subject or purpose of the audio
+
+# Step 3 - Clean the Content
+1. Correct punctuation, capitalization, and obvious transcription artifacts.
+2. Add paragraph breaks at topic shifts. For songs, keep verse/chorus line breaks.
+3. Preserve the original meaning, wording, sequence, and language of the audio.
 
 # Rules
+- Base the type and overview only on evidence present in the transcription; do not
+  invent speakers, topics, or details that are not supported by the text.
 - Do not add, remove, or reinterpret content beyond cleaning and formatting.
-- Maintain the speaker's original intent and structure.
-- Avoid introducing new information not present in the transcription.
-- The caption must be **exactly one sentence**.
-- Use clear, neutral language.
+- The caption must be **exactly one sentence** and must begin with the audio type
+  (for example: "A conversation about ...", "A song about ...", "A lecture on ...").
+- Use clear, neutral language and keep the content in its original language.
 
 # Output Format
 Use the following structure:
 
 <processed_content>
+## Audio Overview
+- Type: [audio type]
+- Language: [language(s)]
+- Speakers: [number or "unknown"]
+- Topic: [main topic or purpose]
+
 [Provide the cleaned and formatted transcription here]
 </processed_content>
 
 <caption>
-[Provide a one-sentence summary of what the audio is about]
+[One-sentence summary that begins with the audio type]
 </caption>
 
 # Input

--- a/tests/test_audio_preprocess.py
+++ b/tests/test_audio_preprocess.py
@@ -1,0 +1,96 @@
+"""Tests for audio preprocessing: type classification + overview + caption.
+
+The audio preprocessor turns a transcription into cleaned content prefixed with
+an "Audio Overview" (type/language/speakers/topic) and a one-sentence caption
+that begins with the inferred audio type (song, conversation, lecture, ...).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from memu.preprocess import preprocess_resource
+from memu.preprocess.base import PreprocessContext
+from memu.prompts.preprocess import PROMPTS
+
+
+class _RecordingChatClient:
+    """Chat client that records the prompt and returns a tagged response."""
+
+    def __init__(self, response: str) -> None:
+        self.prompts: list[str] = []
+        self._response = response
+
+    async def chat(self, prompt: str, **_: Any) -> str:
+        self.prompts.append(prompt)
+        return self._response
+
+
+def _make_ctx(client: Any) -> PreprocessContext:
+    return PreprocessContext(
+        get_llm_client=lambda: client,
+        get_vlm_client=lambda: None,
+        escape_prompt_value=lambda s: s,
+        extract_json_blob=lambda s: s,
+        resolve_custom_prompt=lambda _p, _v: "",
+        multimodal_preprocess_prompts={},
+    )
+
+
+def test_audio_prompt_asks_to_classify_type() -> None:
+    template = PROMPTS["audio"]
+    assert "{transcription}" in template
+    # The prompt should steer the model toward classifying the audio nature.
+    for keyword in ("Classify the Audio", "conversation", "song", "Audio Overview", "Type:"):
+        assert keyword in template
+
+
+def test_audio_preprocess_returns_overview_and_typed_caption() -> None:
+    response = (
+        "<processed_content>## Audio Overview\n"
+        "- Type: song\n"
+        "- Language: English\n"
+        "- Speakers: 1\n"
+        "- Topic: love\n\n"
+        "La la la, all you need is love.</processed_content>"
+        "<caption>A song about love and togetherness.</caption>"
+    )
+    client = _RecordingChatClient(response)
+    ctx = _make_ctx(client)
+
+    # Text is already provided, so transcription is skipped and the chat prompt runs.
+    result = asyncio.run(
+        preprocess_resource(
+            modality="audio",
+            local_path="/workspace/track.mp3",
+            text="la la la all you need is love",
+            ctx=ctx,
+            llm_client=client,
+        )
+    )
+
+    # The transcription is injected into the classification prompt.
+    assert "la la la all you need is love" in client.prompts[0]
+    assert "## Audio Overview" in (result[0]["text"] or "")
+    assert "Type: song" in (result[0]["text"] or "")
+    assert result[0]["caption"] == "A song about love and togetherness."
+
+
+def test_audio_preprocess_skips_without_text() -> None:
+    # No text and a non-audio/non-text extension: nothing to transcribe.
+    client = _RecordingChatClient("<processed_content>x</processed_content><caption>y</caption>")
+    ctx = _make_ctx(client)
+
+    result = asyncio.run(
+        preprocess_resource(
+            modality="audio",
+            local_path="/workspace/mystery.bin",
+            text=None,
+            ctx=ctx,
+            llm_client=client,
+        )
+    )
+
+    assert result == [{"text": None, "caption": None}]
+    assert client.prompts == []


### PR DESCRIPTION
## Summary
- Enhance the audio (wav/mp3/...) preprocessing prompt so it first infers the **nature of the recording** — conversation, monologue/voice memo, lecture, interview, podcast, meeting, **song/music**, announcement, etc. — before cleaning the transcription.
- The processed content is now prefixed with a short **Audio Overview** (Type / Language / Speakers / Topic), and the one-sentence caption begins with the inferred type (e.g. `"A song about ..."`, `"A conversation about ..."`).
- Output tags are unchanged (`processed_content` / `caption`), so `parse_multimodal_response` and the rest of the pipeline need no changes.

## Notes
- Classification is inferred from the transcription text (no acoustic model), so purely musical/ambient audio with little transcribable content will be classified weakly. A future improvement could route audio through a dedicated audio-understanding client (like image/video → VLM).

## Test plan
- [x] `uv run python -m pytest tests/test_audio_preprocess.py` (classification prompt, overview + typed caption output, no-text skip path)
- [x] ruff + mypy clean on changed files

Made with [Cursor](https://cursor.com)