### PR TITLE
feat(vlm,preprocess): native whole-video understanding via OpenRouter

### DIFF
--- a/src/memu/llm/wrapper.py
+++ b/src/memu/llm/wrapper.py
@@ -337,6 +337,38 @@ class LLMClientWrapper:
             response_builder=_build_text_response_view,
         )
 
+    async def video(
+        self,
+        prompt: str,
+        video_path: str,
+        *,
+        max_tokens: int | None = None,
+        system_prompt: str | None = None,
+    ) -> Any:
+        metadata = {
+            "video_path": Path(video_path).name,
+            "video_bytes": _safe_file_size(video_path),
+            "system_prompt_chars": len(system_prompt or ""),
+            "max_tokens": max_tokens,
+        }
+        request_view = _build_text_request_view("video", prompt, metadata=metadata)
+
+        async def _call() -> Any:
+            return await self._client.video(
+                prompt,
+                video_path,
+                max_tokens=max_tokens,
+                system_prompt=system_prompt,
+            )
+
+        return await self._invoke(
+            kind="video",
+            call_fn=_call,
+            request_view=request_view,
+            model=self._chat_model,
+            response_builder=_build_text_response_view,
+        )
+
     async def embed(self, inputs: list[str]) -> Any:
         request_view = _build_embedding_request_view(inputs)
 

--- a/src/memu/preprocess/video.py
+++ b/src/memu/preprocess/video.py
@@ -1,13 +1,15 @@
 """Video preprocessing.
 
-Extracts the middle frame from a video and analyzes it with the Vision API to
-produce a description and caption.
+The whole video file is analyzed natively in a single call (e.g. video-capable
+models via OpenRouter's ``video_url`` content type) so its sampled frames and
+temporal changes inform the description. Native video understanding is required:
+when the configured VLM client does not support it, the video is skipped rather
+than degraded to a single still frame.
 """
 
 from __future__ import annotations
 
 import logging
-import pathlib
 from typing import Any
 
 from memu.preprocess.base import (
@@ -16,7 +18,6 @@ from memu.preprocess.base import (
     PreprocessResult,
     parse_multimodal_response,
 )
-from memu.utils.video import VideoFrameExtractor
 
 logger = logging.getLogger(__name__)
 
@@ -35,26 +36,25 @@ class VideoPreprocessor(Preprocessor):
         llm_client: Any | None = None,
     ) -> PreprocessResult:
         try:
-            if not VideoFrameExtractor.is_ffmpeg_available():
-                logger.warning("ffmpeg not available, cannot process video. Returning None.")
+            client = llm_client or ctx.get_vlm_client()
+
+            if not getattr(client, "supports_video", False):
+                logger.error(
+                    "Video preprocessing requires a VLM client with native video support "
+                    "(supports_video=True), e.g. an OpenRouter video-capable model. "
+                    "Middle-frame fallback is disabled; skipping video: %s",
+                    local_path,
+                )
                 return [{"text": None, "caption": None}]
 
-            logger.info(f"Extracting frame from video: {local_path}")
-            frame_path = VideoFrameExtractor.extract_middle_frame(local_path)
-
-            try:
-                logger.info(f"Analyzing video frame with Vision API: {frame_path}")
-                client = llm_client or ctx.get_vlm_client()
-                processed = await client.vision(prompt=template, image_path=frame_path, system_prompt=None)
-                description, caption = parse_multimodal_response(processed, "detailed_description", "caption")
-                return [{"text": description, "caption": caption}]
-            finally:
-                try:
-                    pathlib.Path(frame_path).unlink(missing_ok=True)
-                    logger.debug(f"Cleaned up temporary frame: {frame_path}")
-                except Exception as e:
-                    logger.warning(f"Failed to clean up frame {frame_path}: {e}")
-
+            return await self._run_native(local_path=local_path, template=template, client=client)
         except Exception as e:
             logger.error(f"Video preprocessing failed: {e}", exc_info=True)
             return [{"text": None, "caption": None}]
+
+    async def _run_native(self, *, local_path: str, template: str, client: Any) -> PreprocessResult:
+        """Analyze the whole video natively (frames + audio) in a single call."""
+        logger.info(f"Analyzing video natively with VLM video API: {local_path}")
+        processed = await client.video(prompt=template, video_path=local_path, system_prompt=None)
+        description, caption = parse_multimodal_response(processed, "detailed_description", "caption")
+        return [{"text": description, "caption": caption}]

--- a/src/memu/vlm/backends/base.py
+++ b/src/memu/vlm/backends/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 
 
 class VLMBackend:
@@ -14,6 +14,13 @@ class VLMBackend:
 
     name: str = "base"
     vision_endpoint: str = "/chat/completions"
+    video_endpoint: str = "/chat/completions"
+
+    # Whether this provider can analyze a whole video file natively (frames +
+    # audio) via :meth:`build_video_payload`. Providers without native video
+    # understanding leave this ``False`` so callers fall back to frame-based
+    # image analysis instead.
+    supports_video: ClassVar[bool] = False
 
     def default_headers(self, api_key: str) -> dict[str, str]:
         """Auth/request headers for this provider.
@@ -37,3 +44,22 @@ class VLMBackend:
 
     def parse_vision_response(self, data: dict[str, Any]) -> str:
         raise NotImplementedError
+
+    def build_video_payload(
+        self,
+        *,
+        prompt: str,
+        video_data_uri: str,
+        system_prompt: str | None,
+        vlm_model: str,
+        max_tokens: int | None,
+    ) -> dict[str, Any]:
+        """Build the request payload for native whole-video understanding.
+
+        Only meaningful when :attr:`supports_video` is ``True``.
+        """
+        raise NotImplementedError
+
+    def parse_video_response(self, data: dict[str, Any]) -> str:
+        """Parse a native video response (defaults to the vision parser)."""
+        return self.parse_vision_response(data)

--- a/src/memu/vlm/backends/openai.py
+++ b/src/memu/vlm/backends/openai.py
@@ -47,3 +47,33 @@ class OpenAIVLMBackend(VLMBackend):
 
     def parse_vision_response(self, data: dict[str, Any]) -> str:
         return cast(str, data["choices"][0]["message"]["content"])
+
+    def build_video_payload(
+        self,
+        *,
+        prompt: str,
+        video_data_uri: str,
+        system_prompt: str | None,
+        vlm_model: str,
+        max_tokens: int | None,
+    ) -> dict[str, Any]:
+        messages: list[dict[str, Any]] = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+
+        messages.append({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {"type": "video_url", "video_url": {"url": video_data_uri}},
+            ],
+        })
+
+        payload: dict[str, Any] = {
+            "model": vlm_model,
+            "messages": messages,
+            "temperature": 0.2,
+        }
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        return payload

--- a/src/memu/vlm/backends/openrouter.py
+++ b/src/memu/vlm/backends/openrouter.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
+from typing import ClassVar
+
 from memu.vlm.backends.openai import OpenAIVLMBackend
 
 
 class OpenRouterVLMBackend(OpenAIVLMBackend):
-    """Backend for OpenRouter vision (OpenAI-compatible)."""
+    """Backend for OpenRouter vision + native video (OpenAI-compatible).
+
+    OpenRouter accepts whole videos via the ``video_url`` content type (a direct
+    URL or a base64 ``data:`` URL) on its chat-completions endpoint, routing them
+    to video-capable models (e.g. ``minimax/minimax-m3``, ``z-ai/glm-4.6v``).
+    """
 
     name = "openrouter"
     vision_endpoint = "/api/v1/chat/completions"
+    video_endpoint = "/api/v1/chat/completions"
+    supports_video: ClassVar[bool] = True

--- a/src/memu/vlm/base.py
+++ b/src/memu/vlm/base.py
@@ -1,9 +1,10 @@
 """Shared types and helpers for vision-language model (VLM) clients.
 
-VLM clients expose a single multimodal capability, :meth:`VLMClient.vision`,
-which analyzes an image alongside a text prompt. Each transport (official SDK or
-raw HTTP) implements this surface so it can be wrapped/swapped like the text LLM
-clients under :mod:`memu.llm`.
+VLM clients expose multimodal understanding capabilities: :meth:`VLMClient.vision`
+analyzes an image alongside a text prompt, and the optional
+:meth:`VLMClient.video` analyzes a whole video natively (when the provider
+supports it). Each transport (official SDK or raw HTTP) implements this surface
+so it can be wrapped/swapped like the text LLM clients under :mod:`memu.llm`.
 """
 
 from __future__ import annotations
@@ -20,6 +21,21 @@ _MIME_BY_SUFFIX = {
     ".webp": "image/webp",
 }
 
+_VIDEO_MIME_BY_SUFFIX = {
+    ".mp4": "video/mp4",
+    ".mov": "video/quicktime",
+    ".mkv": "video/x-matroska",
+    ".avi": "video/x-msvideo",
+    ".webm": "video/webm",
+    ".mpeg": "video/mpeg",
+    ".mpg": "video/mpeg",
+}
+
+
+def video_mime_type(video_path: str) -> str:
+    """Return the MIME type for a video file based on its suffix."""
+    return _VIDEO_MIME_BY_SUFFIX.get(Path(video_path).suffix.lower(), "video/mp4")
+
 
 def encode_image(image_path: str) -> tuple[str, str]:
     """Read an image and return its base64 payload and detected MIME type."""
@@ -34,6 +50,13 @@ class VLMClient:
 
     vlm_model: str
 
+    # Whether this client can analyze a whole video file natively (audio + frames)
+    # via :meth:`video`. Providers without native video understanding leave this
+    # ``False`` so callers can fall back to frame-based image analysis instead.
+    # Not a ``ClassVar`` because transports like :class:`HTTPVLMClient` resolve it
+    # per-instance from the configured provider backend.
+    supports_video: bool = False
+
     async def vision(
         self,
         prompt: str,
@@ -43,4 +66,19 @@ class VLMClient:
         system_prompt: str | None = None,
     ) -> tuple[str, Any]:
         """Analyze ``image_path`` with ``prompt`` and return ``(text, raw_response)``."""
+        raise NotImplementedError
+
+    async def video(
+        self,
+        prompt: str,
+        video_path: str,
+        *,
+        max_tokens: int | None = None,
+        system_prompt: str | None = None,
+    ) -> tuple[str, Any]:
+        """Analyze the whole video at ``video_path`` and return ``(text, raw_response)``.
+
+        Only implemented by providers with native video understanding (see
+        :attr:`supports_video`). The default raises :class:`NotImplementedError`.
+        """
         raise NotImplementedError

--- a/src/memu/vlm/defaults.py
+++ b/src/memu/vlm/defaults.py
@@ -18,7 +18,10 @@ VLM_PROVIDER_DEFAULTS: dict[str, str] = {
     "minimax": "MiniMax-M3",
     "kimi": "kimi-k2.6",
     "doubao": "doubao-seed-2.0-pro",
-    "openrouter": "openai/gpt-5.4",
+    # OpenRouter natively understands whole videos via its ``video_url`` content
+    # type. MiniMax-M3 handles both images and video, tracks temporal changes
+    # across frames, and is region-available (unlike Google/Gemini on OpenRouter).
+    "openrouter": "minimax/minimax-m3",
 }
 
 

--- a/src/memu/vlm/http_client.py
+++ b/src/memu/vlm/http_client.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import base64
 import logging
 import os
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -15,9 +17,13 @@ from memu.vlm.backends.kimi import KimiVLMBackend
 from memu.vlm.backends.minimax import MiniMaxVLMBackend
 from memu.vlm.backends.openai import OpenAIVLMBackend
 from memu.vlm.backends.openrouter import OpenRouterVLMBackend
-from memu.vlm.base import VLMClient, encode_image
+from memu.vlm.base import VLMClient, encode_image, video_mime_type
 
 logger = logging.getLogger(__name__)
+
+# Native video understanding processes far more data than a single image, so it
+# needs a more generous read timeout than the default image-vision call.
+_VIDEO_TIMEOUT_SECONDS = 240
 
 
 def _load_proxy() -> str | None:
@@ -59,6 +65,11 @@ class HTTPVLMClient(VLMClient):
         raw_vision_ep = overrides.get("vision") or overrides.get("chat") or self.backend.vision_endpoint
         # Strip leading "/" so httpx resolves it relative to base_url.
         self.vision_endpoint = raw_vision_ep.lstrip("/")
+        raw_video_ep = overrides.get("video") or overrides.get("chat") or self.backend.video_endpoint
+        self.video_endpoint = raw_video_ep.lstrip("/")
+        # Surface the backend's native-video capability so callers (e.g. the
+        # video preprocessor) can choose whole-video analysis over frame sampling.
+        self.supports_video = self.backend.supports_video
         self.timeout = timeout
         self.proxy = _load_proxy()
 
@@ -85,6 +96,40 @@ class HTTPVLMClient(VLMClient):
             data = resp.json()
         logger.debug("HTTP VLM vision response: %s", data)
         return self.backend.parse_vision_response(data), data
+
+    async def video(
+        self,
+        prompt: str,
+        video_path: str,
+        *,
+        max_tokens: int | None = None,
+        system_prompt: str | None = None,
+    ) -> tuple[str, dict[str, Any]]:
+        if not self.backend.supports_video:
+            msg = f"VLM provider '{self.provider}' does not support native video understanding."
+            raise NotImplementedError(msg)
+
+        data_uri = self._encode_video_data_uri(video_path)
+        payload = self.backend.build_video_payload(
+            prompt=prompt,
+            video_data_uri=data_uri,
+            system_prompt=system_prompt,
+            vlm_model=self.vlm_model,
+            max_tokens=max_tokens,
+        )
+        timeout = max(self.timeout, _VIDEO_TIMEOUT_SECONDS)
+        async with httpx.AsyncClient(base_url=self.base_url, timeout=timeout, proxy=self.proxy) as client:
+            resp = await client.post(self.video_endpoint, json=payload, headers=self._headers())
+            resp.raise_for_status()
+            data = resp.json()
+        logger.debug("HTTP VLM video response: %s", data)
+        return self.backend.parse_video_response(data), data
+
+    @staticmethod
+    def _encode_video_data_uri(video_path: str) -> str:
+        raw = Path(video_path).read_bytes()
+        encoded = base64.b64encode(raw).decode("utf-8")
+        return f"data:{video_mime_type(video_path)};base64,{encoded}"
 
     def _headers(self) -> dict[str, str]:
         return self.backend.default_headers(self.api_key)

--- a/tests/test_vlm_preprocess.py
+++ b/tests/test_vlm_preprocess.py
@@ -16,6 +16,8 @@ from memu.app.service import MemoryService
 from memu.app.settings import LLMConfig, vlm_config_from_llm
 from memu.preprocess import preprocess_resource
 from memu.preprocess.base import PreprocessContext
+from memu.vlm.backends.openrouter import OpenRouterVLMBackend
+from memu.vlm.http_client import HTTPVLMClient
 
 
 class _RecordingVisionClient:
@@ -28,6 +30,24 @@ class _RecordingVisionClient:
     async def vision(self, prompt: str, image_path: str, *, system_prompt: str | None = None, **_: Any) -> str:
         self.vision_calls.append(image_path)
         return "<detailed_description>a cat</detailed_description><caption>cat</caption>"
+
+
+class _RecordingVideoClient:
+    """VLM client with native video support that records image/video calls."""
+
+    supports_video = True
+
+    def __init__(self) -> None:
+        self.video_calls: list[str] = []
+        self.vision_calls: list[str] = []
+
+    async def video(self, prompt: str, video_path: str, *, system_prompt: str | None = None, **_: Any) -> str:
+        self.video_calls.append(video_path)
+        return "<detailed_description>a dog playing fetch</detailed_description><caption>dog playing</caption>"
+
+    async def vision(self, prompt: str, image_path: str, *, system_prompt: str | None = None, **_: Any) -> str:
+        self.vision_calls.append(image_path)
+        return "<detailed_description>a frame</detailed_description><caption>frame</caption>"
 
 
 def _make_ctx(*, llm_client: Any, vlm_client: Any) -> PreprocessContext:
@@ -126,3 +146,74 @@ def test_service_falls_back_to_chat_client_when_vlm_profile_missing(monkeypatch:
     asyncio.run(svc._memorize_preprocess_multimodal(state, {}))
 
     assert captured["client"] == "CHAT_CLIENT"
+
+
+def test_vlm_config_from_llm_openrouter_uses_video_capable_model() -> None:
+    # An OpenRouter LLM profile (httpx transport) derives a VLM config that keeps
+    # the httpx backend and defaults to a video-capable model so native
+    # whole-video understanding works out of the box.
+    cfg = vlm_config_from_llm(LLMConfig(provider="openrouter", client_backend="httpx"))
+    assert cfg.provider == "openrouter"
+    assert cfg.client_backend == "httpx"
+    assert cfg.vlm_model == "minimax/minimax-m3"
+
+
+def test_openrouter_backend_supports_native_video() -> None:
+    backend = OpenRouterVLMBackend()
+    assert backend.supports_video is True
+
+    payload = backend.build_video_payload(
+        prompt="Describe this video.",
+        video_data_uri="data:video/mp4;base64,QUJD",
+        system_prompt=None,
+        vlm_model="minimax/minimax-m3",
+        max_tokens=None,
+    )
+    content = payload["messages"][0]["content"]
+    video_part = next(part for part in content if part["type"] == "video_url")
+    assert video_part["video_url"]["url"] == "data:video/mp4;base64,QUJD"
+
+
+def test_http_vlm_client_exposes_backend_video_capability() -> None:
+    # OpenRouter advertises native video; plain OpenAI-compatible does not.
+    openrouter = HTTPVLMClient(
+        base_url="https://openrouter.ai", api_key="k", vlm_model="minimax/minimax-m3", provider="openrouter"
+    )
+    assert openrouter.supports_video is True
+
+    openai = HTTPVLMClient(
+        base_url="https://api.openai.com/v1", api_key="k", vlm_model="gpt-5.4", provider="openai"
+    )
+    assert openai.supports_video is False
+
+
+def test_video_uses_native_video_when_supported() -> None:
+    # A video-capable client analyzes the whole video file directly; no frame
+    # extraction / image vision call happens.
+    client = _RecordingVideoClient()
+    ctx = _make_ctx(llm_client=client, vlm_client=client)
+    video_path = "/workspace/clip.mp4"
+
+    result = asyncio.run(
+        preprocess_resource(modality="video", local_path=video_path, text=None, ctx=ctx, llm_client=client)
+    )
+
+    assert client.video_calls == [video_path]
+    assert client.vision_calls == []
+    assert result[0]["text"] == "a dog playing fetch"
+    assert result[0]["caption"] == "dog playing"
+
+
+def test_video_without_native_support_skips_no_frame_fallback() -> None:
+    # A client without native video support must NOT degrade to middle-frame image
+    # analysis: the video is skipped (no description) and vision() is never called.
+    client = _RecordingVisionClient("vlm")
+    ctx = _make_ctx(llm_client=client, vlm_client=client)
+
+    result = asyncio.run(
+        preprocess_resource(modality="video", local_path="/workspace/clip.mp4", text=None, ctx=ctx, llm_client=client)
+    )
+
+    assert client.vision_calls == []
+    assert result[0]["text"] is None
+    assert result[0]["caption"] is None


### PR DESCRIPTION
## Summary
- Add **native whole-video understanding**: videos are now analyzed as a full clip (frames + temporal changes) in a single call, instead of extracting one still frame.
- Extend the httpx VLM backend with a `video()` path using a base64 `data:` URI and the OpenAI-compatible `video_url` content type (longer read timeout for video).
- OpenRouter backend advertises `supports_video=True`; the OpenRouter VLM default is now `minimax/minimax-m3` (handles image + video, tracks on-screen/temporal changes, and is region-available — Google/Gemini is geo-blocked in some regions).
- `LLMClientWrapper` proxies `video()` for logging/interception parity with `vision()`/`chat()`.
- **Remove the middle-frame fallback**: when the configured VLM client lacks native video support, the video is skipped (logged) rather than degraded to a single frame.

## Notes
- DashScope was evaluated but its key had `Model.AccessDenied` for all VL models; OpenRouter is used instead. No new dependency added (OpenRouter is OpenAI-compatible via the existing httpx backend).
- Usage: set `provider="openrouter"`, `client_backend="httpx"`, and `OPENROUTER_API_KEY`.

## Test plan
- [x] `uv run python -m pytest tests/test_vlm_preprocess.py` (12 passed)
- [x] `uv run ruff check` on touched files — clean
- [x] `uv run mypy` on touched files — clean
- [x] End-to-end: real `HTTPVLMClient.video()` against OpenRouter correctly described a test clip's SMPTE pattern and tracked the on-screen scene counter incrementing 0→5 over time.

Made with [Cursor](https://cursor.com)