### PR TITLE
feat: memu CLI, npm launcher, and agent skills for the workspace pair

### DIFF
--- a/.claude/skills/memu-memorize/SKILL.md
+++ b/.claude/skills/memu-memorize/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: memu-memorize
+description: Save files or a whole workspace folder into memU's persistent memory. Use when the user asks to remember, memorize, or save something for later sessions, when they ask to sync a workspace/folder into memory, or after completing work whose context should survive this session (meeting notes, decisions, agent traces).
+---
+
+# memU: memorize a workspace or file
+
+memU compiles sources into persistent, retrievable memory (SQLite + markdown tree). Writing requires an LLM key; make sure `OPENAI_API_KEY` (or `MEMU_LLM_PROVIDER` + matching key) is set before running, and tell the user if it is missing.
+
+## Locate the CLI
+
+Use the first available runner:
+
+1. `memu` (installed via `pip install memu-py`)
+2. `uvx --from memu-py memu`
+3. `npx memu-cli`
+
+## Sync a folder (preferred)
+
+```bash
+memu memorize-workspace <folder>
+```
+
+- Incremental: diffs against `<folder>/.memu_manifest.json`; only added/modified files are processed, memory from deleted files is removed. Safe to re-run.
+- Top-level directory decides the treatment: `chat/` → memory topics, `agent/` → skills, everything else → indexed workspace context.
+- Writes state to `./data/memu.sqlite3` and the markdown tree to `./data/memory/` (relative to CWD — run from the project root so later retrievals hit the same store).
+
+## Memorize a single file
+
+```bash
+memu memorize <path> [--modality conversation|document|image|video|audio]
+```
+
+Modality is inferred from the extension; only pass `--modality` if the command asks for it.
+
+## After running
+
+Report the printed diff (added/modified/deleted) to the user. Pass `--json` instead if you need to parse the result.

--- a/.claude/skills/memu-retrieve/SKILL.md
+++ b/.claude/skills/memu-retrieve/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: memu-retrieve
+description: Search memU's persistent memory for context from earlier sessions. Use when the user asks what is known/remembered about a person, project, or topic, when starting a task that likely has prior context (preferences, decisions, past attempts), or when the user references something not in the current conversation.
+---
+
+# memU: retrieve memory
+
+memU stores memory in a local store (`./data/memu.sqlite3` + `./data/memory/` markdown tree, relative to CWD). Retrieval embeds the query, so an API key must be set (`OPENAI_API_KEY` by default).
+
+## Locate the CLI
+
+Use the first available runner:
+
+1. `memu` (installed via `pip install memu-py`)
+2. `uvx --from memu-py memu`
+3. `npx memu-cli`
+
+## Fast search (default)
+
+```bash
+memu retrieve-workspace "<query>"
+```
+
+Single-shot embedding search, no LLM calls. Returns JSON with three layers:
+
+- `segments` — the matched slices, ranked by similarity (check `score`)
+- `files` — the memory/skill documents those segments belong to (usually what you want)
+- `resources` — matching raw sources, when summaries are not enough
+
+## Deep retrieval (when fast search misses)
+
+```bash
+memu retrieve "<query>"
+```
+
+LLM-routed: rewrites the query, ranks per layer, checks sufficiency. Slower and costs LLM calls — use only when the fast path returns nothing relevant or the question needs reasoning over scattered memories.
+
+## Notes
+
+- Run from the project root so the CLI hits the store that `memu-memorize` wrote.
+- Low scores across the board usually mean nothing relevant is stored — say so rather than stretching weak matches.
+- You can also read `./data/memory/MEMORY.md` / `SKILL.md` / `INDEX.md` directly for a browsable overview.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ context = await service.retrieve(
 )
 ```
 
+Or straight from the terminal — no code:
+
+```bash
+npx memu-cli memorize-workspace ./workspace
+npx memu-cli retrieve "What should I know about this user's launch preferences?"
+```
+
 That's it. Instead of one giant prompt about a person or their workspace, your agent gets three durable layers it can traverse:
 
 ```txt
@@ -50,7 +57,9 @@ workspace/
 
 - **Index (`INDEX.md`)** — a map of your memories: what exists, where it came from, and where to look first
 - **Memory (`MEMORY.md`)** — personal facts, preferences, goals, events, and decisions extracted from source data
-- **Skill (`SKILL.md`)** — **auto-extracted from tool traces and refined on every `memorize()`** so the agent improves at recurring tasks
+- **Skill (`SKILL.md`)** — **auto-extracted from agent traces and refined on every workspace sync** so the agent improves at recurring tasks
+
+When you sync a folder with `memorize_workspace`, the top-level directory decides the treatment: files under `chat/` become memory, files under `agent/` become skills, and everything else is indexed as workspace context.
 
 Three things make it different from stuffing everything into the prompt:
 
@@ -79,9 +88,11 @@ If you find memU useful or interesting, a GitHub Star ⭐️ would be greatly ap
 | 🧠 **Typed Memory Extraction** | Extract profile, event, knowledge, behavior, skill, and tool memories from raw sources |
 | 🛠️ **Self-Evolving Skills** | Auto-extract reusable tool patterns and workflows from tool traces, then merge and refine them on every `memorize()` instead of relearning |
 | 🧭 **Self-Organizing Folders** | Auto-build categories, links, summaries, and embeddings without manual tagging |
-| 🤖 **Agent-Ready Retrieval** | Find the right files quickly — scoped, ranked context for any agent workflow |
+| 🤖 **Agent-Ready Retrieval** | Two read paths: LLM-routed `retrieve()` for quality, LLM-free `retrieve_workspace()` for speed |
+| 🔄 **Incremental Workspace Sync** | `memorize_workspace()` diffs a folder against a manifest — only changed files are (re)processed, deletions cascade |
 | 🧱 **Pluggable Storage** | Use in-memory, SQLite, or Postgres backends with the same repository contracts |
 | 🔀 **Profile-Based LLM Routing** | Route chat, embedding, vision, and transcription work through configurable LLM profiles |
+| ⌨️ **CLI** | `memu` command (pip) and `npx memu-cli` (npm) — memorize and retrieve from the terminal or CI |
 
 ---
 
@@ -151,13 +162,36 @@ The compiled workspace is hierarchical enough for browsing and structured enough
 
 <img width="100%" alt="structure" src="assets/structure.png" />
 
-| Layer | Primary Role | Retrieval Role |
-|-------|--------------|----------------|
-| **Category (folder)** | Maintain topic-level summaries | Assemble compact context for broad queries |
-| **Item (file)** | Store typed atomic memories | Load precise facts, events, preferences, skills, and tool patterns |
-| **Resource (source)** | Preserve source artifacts and captions | Recall original context when item/category summaries are not enough |
+Memory is stored in three representation layers; retrieval searches the finest layer and rolls up:
 
-See [docs/architecture.md](docs/architecture.md) for the runtime view of `MemoryService`, workflow pipelines, storage backends, and LLM routing.
+| Layer | What it holds | Retrieval Role |
+|-------|---------------|----------------|
+| **File** (`RecallFile`) | A synthesized memory topic or skill document | The unit returned to the agent — hit segments roll up to their file |
+| **Segment** | Fine slices of a file (paragraph lines, skill descriptions) | The embedded search unit — queries rank segments first |
+| **Resource** | The raw source artifact with its caption | Recall original context when synthesized summaries are not enough |
+
+Two read paths share this store: `retrieve()` adds LLM intention routing, query rewriting, and sufficiency checks on top; `retrieve_workspace()` embeds the query once and ranks segments/resources directly with zero LLM calls.
+
+See [docs/architecture.md](docs/architecture.md) for the runtime view of `MemoryService`, workflow pipelines, storage backends, and LLM routing, and [docs/adr/](docs/adr/README.md) for the decision records behind the layered design.
+
+---
+
+## 🧰 Agent Skills
+
+The repo ships [Agent Skills](https://docs.claude.com/en/docs/agents-and-tools/agent-skills) that let Claude Code (and any skills-compatible agent) call the workspace pair directly — the agent decides when to memorize and when to recall:
+
+| Skill | Wraps | Triggers on |
+|-------|-------|-------------|
+| [`memu-memorize`](.claude/skills/memu-memorize/SKILL.md) | `memu memorize-workspace` / `memu memorize` | "remember this", "sync this folder into memory", finishing work worth persisting |
+| [`memu-retrieve`](.claude/skills/memu-retrieve/SKILL.md) | `memu retrieve-workspace` (falls back to `memu retrieve`) | "what do we know about…", starting a task with likely prior context |
+
+They work out of the box inside this repo. To use them in your own project, copy the skill folders into that project's `.claude/skills/` (or `~/.claude/skills/` to enable them everywhere):
+
+```bash
+cp -r .claude/skills/memu-memorize .claude/skills/memu-retrieve /path/to/your-project/.claude/skills/
+```
+
+Both skills locate the CLI automatically (`memu`, `uvx --from memu-py memu`, or `npx memu-cli`) and share state through the project-local `./data/memu.sqlite3`, so what one session memorizes the next can retrieve. For LangGraph agents, see the [LangGraph integration](docs/langgraph_integration.md) instead.
 
 ---
 
@@ -201,10 +235,28 @@ make install
 To install the published package instead:
 
 ```bash
-pip install memu-py
+pip install memu-py        # library + `memu` CLI
+# or from the JS ecosystem (thin launcher over memu-py, uses uvx/pipx automatically):
+npx memu-cli --help
 ```
 
 > **Requirements**: Python 3.13+. The default examples use OpenAI, so set `OPENAI_API_KEY` or pass another provider through `llm_profiles`.
+
+#### Command line
+
+The `memu` command wraps the same service the library exposes. State persists in a local SQLite database (`./data/memu.sqlite3` by default), so memorize in one invocation and retrieve in the next:
+
+```bash
+export OPENAI_API_KEY=your_key
+
+memu memorize notes/meeting.md                  # single file; modality inferred from extension
+memu memorize-workspace ./workspace             # diff-sync a folder (alias: memu sync)
+memu retrieve "launch preferences?"                      # LLM-routed retrieval
+memu retrieve-workspace "deploy checklist"      # LLM-free embedding retrieval (alias: memu search)
+memu export                                     # rebuild the INDEX.md/MEMORY.md/SKILL.md tree
+```
+
+Every flag has a `MEMU_*` environment variable (`--provider`/`MEMU_LLM_PROVIDER`, `--model`/`MEMU_CHAT_MODEL`, `--db`/`MEMU_DB`, ...) — run `memu <command> --help` for the full list. `--db` accepts a SQLite path, a `postgres://` DSN, or `:memory:`.
 
 **Run an in-memory smoke script:**
 ```bash
@@ -234,9 +286,9 @@ uv run python test_postgres.py
 ### Custom LLM and Embedding Providers
 
 ```python
-from memu import MemUService
+from memu import MemoryService
 
-service = MemUService(
+service = MemoryService(
     llm_profiles={
         "default": {
             "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1",
@@ -299,6 +351,24 @@ result = await service.memorize(
 
 ---
 
+### `memorize_workspace()` — Sync a Folder
+
+```python
+result = await service.memorize_workspace(
+    folder="./workspace",              # scanned recursively; modality inferred per file
+    user={"user_id": "123"},           # optional scope
+)
+# Returns the diff plus what changed:
+# { "added": [...], "modified": [...], "deleted": [...],
+#   "resources": [...], "entries": [...], "files": [...] }
+```
+
+- Diffs the folder against a sidecar `.memu_manifest.json` — only added/modified files are processed, memory from deleted files is cascade-removed
+- Routes by top-level directory: `chat/` → memory files, `agent/` → skill files, everything else → indexed workspace context
+- Rebuilds the markdown memory tree (`INDEX.md` / `MEMORY.md` / `SKILL.md`) when `memory_files_config.enabled=True`
+
+---
+
 ### `retrieve()` — Load Agent Context
 
 <img width="100%" alt="retrieve" src="assets/retrieve.png" />
@@ -327,6 +397,23 @@ result = await service.retrieve(
 |--------------------------|----------|------|----------|
 | `rag` | Vector-first category/item/resource recall, with optional LLM routing and sufficiency checks enabled by default | Embeddings plus LLM calls unless `route_intention` and `sufficiency_check` are disabled | Fast scoped recall with controllable reasoning |
 | `llm` | LLM-ranked category/item/resource recall | LLM ranking at each tier | Deeper semantic ranking |
+
+---
+
+### `retrieve_workspace()` — Fast, LLM-Free Retrieval
+
+```python
+result = await service.retrieve_workspace(
+    "deploy checklist",
+    where={"user_id": "123"},
+)
+# Returns:
+# { "segments": [...],    # embedded slices ranked by similarity
+#   "files": [...],       # the memory/skill files those segments roll up to
+#   "resources": [...] }  # workspace resources ranked by similarity
+```
+
+The single-shot counterpart to `retrieve()`: the query is embedded once and ranked by vector similarity — no intention routing, no query rewriting, no sufficiency checks, zero LLM calls. Use it for high-frequency lookups where latency and cost matter more than deep reasoning.
 
 ---
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,32 @@
+# memu-cli
+
+CLI for [memU](https://github.com/NevaMind-AI/MemU) — personal memory as files: fast retrieval, higher accuracy, lower cost.
+
+This package is a thin launcher. The engine is the Python package [`memu-py`](https://pypi.org/project/memu-py/) (Python ≥ 3.13); the shim delegates to `uvx`, `pipx run`, or an installed `python3 -m memu`, in that order. Install [uv](https://docs.astral.sh/uv/) for the smoothest zero-setup experience.
+
+## Usage
+
+```bash
+export OPENAI_API_KEY=sk-...
+
+# memorize a single file (modality inferred from the extension)
+npx memu-cli memorize notes/meeting.md
+
+# diff-sync a workspace folder (chat/ -> memory, agent/ -> skills, other -> index)
+npx memu-cli memorize-workspace ./workspace
+
+# LLM-routed retrieval (heavy, high quality)
+npx memu-cli retrieve "What are this user's launch preferences?"
+
+# single-shot embedding retrieval (LLM-free, fast)
+npx memu-cli retrieve-workspace "deploy checklist"
+
+# rebuild the INDEX.md / MEMORY.md / SKILL.md markdown tree
+npx memu-cli export
+```
+
+State persists in a local SQLite database (`./data/memu.sqlite3` by default), so memorize in one invocation and retrieve in the next. Run `npx memu-cli --help` or see the [main README](https://github.com/NevaMind-AI/MemU#readme) for all flags and `MEMU_*` environment variables.
+
+## License
+
+Apache-2.0

--- a/npm/bin/memu.js
+++ b/npm/bin/memu.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// memu-cli: thin launcher for the Python package `memu-py`.
+//
+// The memU engine is Python (>= 3.13). This shim finds a runner and delegates,
+// in order of preference:
+//   1. $MEMU_PYTHON -m memu            (explicit interpreter override)
+//   2. uvx --from memu-py memu         (no install needed, cached by uv)
+//   3. pipx run --spec memu-py memu    (no install needed, cached by pipx)
+//   4. python3 -m memu                 (requires `pip install memu-py`)
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+
+const args = process.argv.slice(2);
+
+function has(cmd) {
+  const probe = spawnSync(cmd, ["--version"], { stdio: "ignore", shell: false });
+  return probe.error === undefined && probe.status === 0;
+}
+
+function run(cmd, prefix) {
+  const child = spawnSync(cmd, [...prefix, ...args], { stdio: "inherit", shell: false });
+  if (child.error) {
+    console.error(`memu-cli: failed to launch ${cmd}: ${child.error.message}`);
+    process.exit(1);
+  }
+  process.exit(child.status === null ? 1 : child.status);
+}
+
+if (process.env.MEMU_PYTHON) {
+  run(process.env.MEMU_PYTHON, ["-m", "memu"]);
+}
+if (has("uvx")) {
+  run("uvx", ["--from", "memu-py", "memu"]);
+}
+if (has("pipx")) {
+  run("pipx", ["run", "--spec", "memu-py", "memu"]);
+}
+if (has("python3")) {
+  const probe = spawnSync("python3", ["-c", "import memu"], { stdio: "ignore" });
+  if (probe.status === 0) {
+    run("python3", ["-m", "memu"]);
+  }
+}
+
+console.error(
+  [
+    "memu-cli: no Python runner found. The memU engine is the Python package `memu-py` (Python >= 3.13).",
+    "Install one of:",
+    "  - uv    (https://docs.astral.sh/uv/)  -> memu-cli will use `uvx` automatically",
+    "  - pipx  (https://pipx.pypa.io/)       -> memu-cli will use `pipx run` automatically",
+    "  - pip   -> `pip install memu-py`, then re-run",
+    "Or point MEMU_PYTHON at an interpreter that has memu-py installed.",
+  ].join("\n")
+);
+process.exit(1);

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "memu-cli",
+  "version": "1.5.1",
+  "description": "CLI for memU — personal memory as files. Thin launcher for the Python package memu-py.",
+  "bin": {
+    "memu": "bin/memu.js"
+  },
+  "files": [
+    "bin"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "memu",
+    "memory",
+    "agent",
+    "context-engineering",
+    "retrieval",
+    "llm",
+    "cli"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NevaMind-AI/MemU.git",
+    "directory": "npm"
+  },
+  "homepage": "https://github.com/NevaMind-AI/MemU#readme",
+  "bugs": {
+    "url": "https://github.com/NevaMind-AI/MemU/issues"
+  }
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memu-cli",
   "version": "1.5.1",
-  "description": "CLI for memU — personal memory as files. Thin launcher for the Python package memu-py.",
+  "description": "CLI for memU \u2014 personal memory as files. Thin launcher for the Python package memu-py.",
   "bin": {
     "memu": "bin/memu.js"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ lazyllm = ["lazyllm>=0.7.3"]
 # Rich document ingestion (PDF, Word, PowerPoint, Excel, ...) via MarkItDown.
 document = ["markitdown[docx,pptx,xlsx,xls,pdf]>=0.1.0"]
 
+[project.scripts]
+memu = "memu.cli:main"
+
 [project.urls]
 "Homepage" = "https://github.com/NevaMind-AI/MemU"
 "Bug Tracker" = "https://github.com/NevaMind-AI/MemU/issues"

--- a/src/memu/__main__.py
+++ b/src/memu/__main__.py
@@ -1,0 +1,7 @@
+"""Allow ``python -m memu`` to invoke the CLI (used by the npm launcher)."""
+
+import sys
+
+from memu.cli import main
+
+sys.exit(main())

--- a/src/memu/cli.py
+++ b/src/memu/cli.py
@@ -1,0 +1,253 @@
+"""Command-line interface for memU.
+
+A thin wrapper over :class:`memu.app.MemoryService` exposing the four public
+entry points (``memorize``, ``memorize-workspace``, ``retrieve``,
+``retrieve-workspace``) plus the memory-file export. State persists across
+invocations through a SQLite database (``--db``, default ``./data/memu.sqlite3``),
+so the CLI composes like the library: memorize in one call, retrieve in the next.
+
+Configuration mirrors the library defaults; every flag also reads a ``MEMU_*``
+environment variable so CI/agents can configure once and pass only the command.
+
+Usage:
+    memu memorize notes/meeting.md
+    memu memorize-workspace ./workspace
+    memu retrieve "What are this user's launch preferences?"
+    memu retrieve-workspace "deploy checklist"
+    memu export
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import pathlib
+import sys
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+from memu.blob.folder import EXT_MODALITY, infer_modality
+
+MODALITIES = ("conversation", "document", "image", "video", "audio")
+
+
+def _env(name: str, default: str) -> str:
+    return os.environ.get(name, default)
+
+
+def _add_common_options(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_argument_group("service options (env var in parens)")
+    group.add_argument(
+        "--provider",
+        default=_env("MEMU_LLM_PROVIDER", "openai"),
+        help="LLM provider id, e.g. openai, anthropic, deepseek (MEMU_LLM_PROVIDER)",
+    )
+    group.add_argument(
+        "--model",
+        default=os.environ.get("MEMU_CHAT_MODEL"),
+        help="Chat model override; defaults to the provider's default (MEMU_CHAT_MODEL)",
+    )
+    group.add_argument(
+        "--base-url",
+        default=os.environ.get("MEMU_BASE_URL"),
+        help="API base URL override (MEMU_BASE_URL)",
+    )
+    group.add_argument(
+        "--api-key",
+        default=os.environ.get("MEMU_API_KEY"),
+        help="API key value or env-var name; defaults to the provider's env var, e.g. OPENAI_API_KEY (MEMU_API_KEY)",
+    )
+    group.add_argument(
+        "--db",
+        default=_env("MEMU_DB", "./data/memu.sqlite3"),
+        help="SQLite file path, postgres:// DSN, or ':memory:' (MEMU_DB)",
+    )
+    group.add_argument(
+        "--resources-dir",
+        default=_env("MEMU_RESOURCES_DIR", "./data/resources"),
+        help="Directory where ingested source files are copied (MEMU_RESOURCES_DIR)",
+    )
+    group.add_argument(
+        "--memory-dir",
+        default=_env("MEMU_MEMORY_DIR", "./data/memory"),
+        help="Directory for the INDEX.md/MEMORY.md/SKILL.md markdown tree (MEMU_MEMORY_DIR)",
+    )
+    group.add_argument(
+        "--synthesize",
+        action="store_true",
+        default=_env("MEMU_SYNTHESIZE", "") == "1",
+        help="LLM-synthesize MEMORY.md/SKILL.md overviews instead of deterministic indexes (MEMU_SYNTHESIZE=1)",
+    )
+    parser.add_argument("--json", action="store_true", help="Print the raw JSON response")
+
+
+def _database_config(db: str) -> dict[str, Any]:
+    if db in (":memory:", "inmemory"):
+        return {"metadata_store": {"provider": "inmemory"}}
+    if db.startswith(("postgres://", "postgresql://")):
+        return {"metadata_store": {"provider": "postgres", "dsn": db}}
+    path = pathlib.Path(db).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return {"metadata_store": {"provider": "sqlite", "dsn": f"sqlite:///{path}"}}
+
+
+def _build_service(args: argparse.Namespace, *, memory_files: bool) -> Any:
+    # Imported lazily so `memu --help` stays fast and dependency errors surface
+    # only when a command actually runs.
+    from memu.app import MemoryService
+
+    llm: dict[str, Any] = {"provider": args.provider}
+    if args.model:
+        llm["chat_model"] = args.model
+    if args.base_url:
+        llm["base_url"] = args.base_url
+    if args.api_key:
+        llm["api_key"] = args.api_key
+    return MemoryService(
+        llm_profiles={"default": llm},
+        database_config=_database_config(args.db),
+        blob_config={"resources_dir": args.resources_dir},
+        memory_files_config={
+            "enabled": memory_files,
+            "output_dir": args.memory_dir,
+            "synthesize": args.synthesize,
+        },
+    )
+
+
+def _print_json(payload: Any) -> None:
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+async def _cmd_memorize(args: argparse.Namespace) -> int:
+    path = pathlib.Path(args.path).expanduser()
+    if not path.exists():
+        print(f"error: no such file: {path}", file=sys.stderr)
+        return 2
+    modality = args.modality or infer_modality(path)
+    if modality is None:
+        supported = ", ".join(sorted(EXT_MODALITY))
+        print(
+            f"error: cannot infer modality for '{path.suffix}'; pass --modality (supported extensions: {supported})",
+            file=sys.stderr,
+        )
+        return 2
+    service = _build_service(args, memory_files=False)
+    result = await service.memorize(resource_url=str(path), modality=modality)
+    if args.json:
+        _print_json(result)
+        return 0
+    entries = result.get("items", [])
+    files = result.get("categories", [])
+    print(f"memorized {path} ({modality}): {len(entries)} entries across {len(files)} files")
+    for f in files:
+        print(f"  - {f.get('name')}")
+    return 0
+
+
+async def _cmd_memorize_workspace(args: argparse.Namespace) -> int:
+    folder = pathlib.Path(args.folder).expanduser()
+    if not folder.is_dir():
+        print(f"error: no such folder: {folder}", file=sys.stderr)
+        return 2
+    service = _build_service(args, memory_files=not args.no_export)
+    result = await service.memorize_workspace(folder=str(folder))
+    if args.json:
+        _print_json(result)
+        return 0
+    added, modified, deleted = result.get("added", []), result.get("modified", []), result.get("deleted", [])
+    print(f"synced {folder}: +{len(added)} added, ~{len(modified)} modified, -{len(deleted)} deleted")
+    for label, names in (("+", added), ("~", modified), ("-", deleted)):
+        for name in names:
+            print(f"  {label} {name}")
+    if not args.no_export:
+        print(f"memory files written to {args.memory_dir}")
+    return 0
+
+
+async def _cmd_retrieve(args: argparse.Namespace) -> int:
+    service = _build_service(args, memory_files=False)
+    result = await service.retrieve(queries=[{"role": "user", "content": {"text": args.query}}])
+    _print_json(result)
+    return 0
+
+
+async def _cmd_retrieve_workspace(args: argparse.Namespace) -> int:
+    service = _build_service(args, memory_files=False)
+    result = await service.retrieve_workspace(args.query)
+    _print_json(result)
+    return 0
+
+
+async def _cmd_export(args: argparse.Namespace) -> int:
+    service = _build_service(args, memory_files=True)
+    result = await service.export_memory_files()
+    if args.json:
+        _print_json(result)
+    else:
+        print(f"memory files written to {args.memory_dir}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="memu",
+        description="memU — personal memory as files. Memorize sources, retrieve context.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("memorize", help="Memorize a single file (conversation, document, image, audio, video)")
+    p.add_argument("path", help="Path to the source file")
+    p.add_argument("--modality", choices=MODALITIES, help="Override the extension-inferred modality")
+    _add_common_options(p)
+    p.set_defaults(handler=_cmd_memorize)
+
+    p = sub.add_parser(
+        "memorize-workspace",
+        aliases=["sync"],
+        help="Diff-sync a folder into memory (chat/ -> memory, agent/ -> skills, other -> index)",
+    )
+    p.add_argument("folder", help="Workspace folder to scan and sync")
+    p.add_argument("--no-export", action="store_true", help="Skip rebuilding the markdown memory tree")
+    _add_common_options(p)
+    p.set_defaults(handler=_cmd_memorize_workspace)
+
+    p = sub.add_parser("retrieve", help="LLM-routed retrieval over memorized entries (heavy, high quality)")
+    p.add_argument("query", help="Natural-language query")
+    _add_common_options(p)
+    p.set_defaults(handler=_cmd_retrieve)
+
+    p = sub.add_parser(
+        "retrieve-workspace",
+        aliases=["search"],
+        help="Single-shot embedding retrieval over segments/files/resources (LLM-free, fast)",
+    )
+    p.add_argument("query", help="Natural-language query")
+    _add_common_options(p)
+    p.set_defaults(handler=_cmd_retrieve_workspace)
+
+    p = sub.add_parser("export", help="Rebuild the INDEX.md/MEMORY.md/SKILL.md markdown tree from the store")
+    _add_common_options(p)
+    p.set_defaults(handler=_cmd_export)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    handler: Callable[[argparse.Namespace], Coroutine[Any, Any, int]] = args.handler
+    try:
+        return asyncio.run(handler(args))
+    except KeyboardInterrupt:
+        return 130
+    except Exception as exc:
+        if os.environ.get("MEMU_DEBUG") == "1":
+            raise
+        print(f"error: {exc} (set MEMU_DEBUG=1 for a traceback)", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,58 @@
+"""CLI surface tests: argument parsing, config mapping, and error paths.
+
+These never construct a MemoryService (no network, no LLM); they exercise the
+pure argv -> config layer and the pre-service validation in the handlers.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from memu.cli import _database_config, build_parser, main
+
+
+def test_parser_covers_all_entry_points() -> None:
+    parser = build_parser()
+    for argv in (
+        ["memorize", "notes.md"],
+        ["memorize-workspace", "./ws"],
+        ["sync", "./ws"],
+        ["retrieve", "query"],
+        ["retrieve-workspace", "query"],
+        ["search", "query"],
+        ["export"],
+    ):
+        args = parser.parse_args(argv)
+        assert callable(args.handler)
+
+
+def test_database_config_dispatch(tmp_path: pathlib.Path) -> None:
+    assert _database_config(":memory:") == {"metadata_store": {"provider": "inmemory"}}
+    pg = _database_config("postgresql://u:p@localhost/db")
+    assert pg["metadata_store"]["provider"] == "postgres"
+    assert pg["metadata_store"]["dsn"] == "postgresql://u:p@localhost/db"
+
+    db_file = tmp_path / "nested" / "memu.sqlite3"
+    sqlite = _database_config(str(db_file))
+    assert sqlite["metadata_store"]["provider"] == "sqlite"
+    assert sqlite["metadata_store"]["dsn"] == f"sqlite:///{db_file}"
+    assert db_file.parent.is_dir()  # parent directory is created eagerly
+
+
+def test_memorize_missing_file_exits_2(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["memorize", "/definitely/not/a/file.md"]) == 2
+    assert "no such file" in capsys.readouterr().err
+
+
+def test_memorize_unknown_extension_exits_2(tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    target = tmp_path / "data.xyz"
+    target.write_text("hello")
+    assert main(["memorize", str(target)]) == 2
+    assert "cannot infer modality" in capsys.readouterr().err
+
+
+def test_memorize_workspace_missing_folder_exits_2(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["memorize-workspace", "/definitely/not/a/folder"]) == 2
+    assert "no such folder" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- **`memu` CLI** ([src/memu/cli.py](../blob/feat/cli-npm-skills/src/memu/cli.py)): console entry wrapping the five public service entry points — `memorize`, `memorize-workspace` (alias `sync`), `retrieve`, `retrieve-workspace` (alias `search`), `export`. State persists through a local SQLite store (`--db`, default `./data/memu.sqlite3`), so memorize in one invocation and retrieve in the next. Every flag has a `MEMU_*` env var; `--json` emits the raw response; errors are one-line with `MEMU_DEBUG=1` for tracebacks.
- **npm package `memu-cli`** (`npm/`): zero-dependency launcher that delegates to `uvx --from memu-py memu` → `pipx run` → `python3 -m memu`, so `npx memu-cli` works from the JS ecosystem without porting the engine. Note: effective for end users once the next memu-py release (with the CLI) is on PyPI.
- **Agent Skills** (`.claude/skills/memu-memorize`, `.claude/skills/memu-retrieve`): let Claude Code and other skills-compatible agents call the workspace pair directly — memorize on "remember this / sync this folder", retrieve on "what do we know about…", with the LLM-free fast path as default and `retrieve` as fallback.
- **README refresh**: CLI + Agent Skills sections, architecture table updated to the layered File/Segment/Resource model with both read paths, `memorize_workspace()` / `retrieve_workspace()` API docs, `MemUService` → `MemoryService` consistency fix.

## Test plan

- [x] `uv run pytest` — 179 passed (2 pre-existing failures from the missing optional `markitdown` extra, unrelated)
- [x] New `tests/test_cli.py` covers parser wiring, DB config dispatch, and error paths
- [x] `uv run ruff check` / `ruff format --check` / `mypy` / `deptry` all green
- [x] Manual: `memu --help`, error paths (missing file, unknown extension, missing key → clean one-line errors with correct exit codes), npm launcher forwards args/exit codes via `MEMU_PYTHON`

🤖 Generated with [Claude Code](https://claude.com/claude-code)