### PR TITLE
docs: never fall back to legacy memorize/retrieve

### DIFF
--- a/.claude/skills/memu/SKILL.md
+++ b/.claude/skills/memu/SKILL.md
@@ -7,6 +7,8 @@ description: Give this agent persistent memory via memU. Use to memorize (save f
 
 memU compiles sources into a persistent local store (`./data/memu.sqlite3` + a browsable `./data/memory/` markdown tree, relative to CWD). What one session memorizes, the next can retrieve — always run from the project root so every command hits the same store.
 
+Use only the two commands below. Do not use the legacy `memu memorize` / `memu retrieve` commands.
+
 Both directions need an API key: make sure `OPENAI_API_KEY` (or `MEMU_LLM_PROVIDER` + its matching key) is set, and tell the user if it is missing.
 
 ## Locate the CLI
@@ -19,37 +21,26 @@ Use the first available runner:
 
 ## Memorize
 
-Sync a folder (preferred — incremental and safe to re-run):
-
 ```bash
 memu memorize-workspace <folder>
 ```
 
-- Diffs against `<folder>/.memu_manifest.json`: only added/modified files are processed, memory from deleted files is removed.
-- Top-level directory decides the treatment: `chat/` → memory topics, `agent/` → skills, everything else → indexed workspace context.
-
-Or memorize a single file (modality inferred from the extension):
-
-```bash
-memu memorize <path> [--modality conversation|document|image|video|audio]
-```
+- Incremental and safe to re-run: diffs against `<folder>/.memu_manifest.json`, so only added/modified files are processed and memory from deleted files is removed.
+- Top-level directory decides the treatment: `chat/` → memory topics, `agent/` → skills, everything else → indexed workspace context (modality inferred per file from its extension).
+- To memorize a single file, place (or copy) it into the workspace folder and sync — there is no separate single-file path.
 
 Report the printed diff (added/modified/deleted) to the user; pass `--json` if you need to parse the result.
 
 ## Retrieve
 
-Fast search first (single-shot embedding ranking, no LLM calls):
-
 ```bash
 memu retrieve-workspace "<query>"
 ```
 
-Returns JSON in three layers: `segments` (matched slices with scores), `files` (the memory/skill documents they belong to — usually what you want), `resources` (raw sources, when summaries are not enough).
+Single-shot embedding search, no LLM calls. Returns JSON in three layers:
 
-If the fast path returns nothing relevant, escalate to deep retrieval (LLM-routed query rewriting + ranking + sufficiency checks — slower, costs LLM calls):
+- `segments` — the matched slices, ranked by similarity (check `score`)
+- `files` — the memory/skill documents they belong to (usually what you want)
+- `resources` — matching raw sources, when summaries are not enough
 
-```bash
-memu retrieve "<query>"
-```
-
-Low scores across the board usually mean nothing relevant is stored — say so rather than stretching weak matches. You can also read `./data/memory/MEMORY.md` / `SKILL.md` / `INDEX.md` directly for a browsable overview.
+If a query misses, retry with different phrasing or more specific terms. Low scores across the board usually mean nothing relevant is stored — say so rather than stretching weak matches. You can also read `./data/memory/MEMORY.md` / `SKILL.md` / `INDEX.md` directly for a browsable overview.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Or straight from the terminal — no code:
 
 ```bash
 npx memu-cli memorize-workspace ./workspace
-npx memu-cli retrieve "What should I know about this user's launch preferences?"
+npx memu-cli retrieve-workspace "What should I know about this user's launch preferences?"
 ```
 
 That's it. Instead of one giant prompt about a person or their workspace, your agent gets three durable layers it can traverse:

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ See [docs/architecture.md](docs/architecture.md) for the runtime view of `Memory
 
 The repo ships one [Agent Skill](https://docs.claude.com/en/docs/agents-and-tools/agent-skills) — [`.claude/skills/memu/SKILL.md`](.claude/skills/memu/SKILL.md) — that gives Claude Code (and any skills-compatible agent) the workspace pair. The agent decides when to use each direction:
 
-- **memorize** (`memu memorize-workspace` / `memu memorize`) — "remember this", "sync this folder into memory", finishing work worth persisting
-- **retrieve** (`memu retrieve-workspace`, falling back to `memu retrieve`) — "what do we know about…", starting a task with likely prior context
+- **memorize** (`memu memorize-workspace`) — "remember this", "sync this folder into memory", finishing work worth persisting
+- **retrieve** (`memu retrieve-workspace`) — "what do we know about…", starting a task with likely prior context
 
 It works out of the box inside this repo. To use it in your own project, copy the skill folder into that project's `.claude/skills/` (or `~/.claude/skills/` to enable it everywhere):
 
@@ -316,7 +316,7 @@ service = MemoryService(
 
 ## 📖 Core APIs
 
-The primary pair is `memorize_workspace()` / `retrieve_workspace()` — folder in, ranked context out. The single-file `memorize()` and LLM-routed `retrieve()` are the legacy pair: still supported, but new integrations should start with the workspace pair.
+The primary pair is `memorize_workspace()` / `retrieve_workspace()` — folder in, ranked context out. The single-file `memorize()` and LLM-routed `retrieve()` are the legacy pair, kept for existing integrations — new code should use the workspace pair.
 
 ### `memorize_workspace()` — Sync a Folder
 
@@ -395,7 +395,7 @@ result = await service.retrieve(
 # }
 ```
 
-The deep path: takes multi-turn conversation context, decides whether to retrieve at all, rewrites the query, ranks per layer, and checks sufficiency. Reach for it when `retrieve_workspace()` misses and the question needs reasoning over scattered memories.
+The legacy deep path: takes multi-turn conversation context, decides whether to retrieve at all, rewrites the query, ranks per layer, and checks sufficiency. Kept for existing integrations only — new code should use `retrieve_workspace()`.
 
 | `retrieve_config.method` | Behavior | Cost | Best For |
 |--------------------------|----------|------|----------|


### PR DESCRIPTION
## Summary

- The `memu` agent skill now uses **only** `memorize-workspace` and `retrieve-workspace`: the "deep retrieval" escalation section and the single-file `memu memorize` section are removed (single files go into the workspace folder and sync), with an explicit "do not use the legacy commands" instruction.
- README: removed "falling back to `memu retrieve`" from the Agent Skills section, rewrote the legacy `retrieve()` paragraph ("kept for existing integrations only — new code should use `retrieve_workspace()`"), and fixed the top terminal example still using `retrieve`.

## Test plan

- [x] `pre-commit run` on touched files passes
- [x] Docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)