### PR TITLE
feat(retrieve): add scoped reference-aware RAG recall

### DIFF
--- a/src/memu/app/retrieve.py
+++ b/src/memu/app/retrieve.py
@@ -322,14 +322,15 @@ class RetrieveMixin:
             state["query_vector"] = (await embed_client.embed([state["active_query"]]))[0]
         return state
 
-    def _extract_referenced_item_ids(self, state: WorkflowState) -> set[str]:
+    def _extract_referenced_item_ids(self, state: WorkflowState) -> list[str]:
         """Extract item IDs from category summary references."""
         from memu.utils.references import extract_references
 
         category_hits = state.get("category_hits") or []
         summary_lookup = state.get("category_summary_lookup", {})
         category_pool = state.get("category_pool") or {}
-        referenced_item_ids: set[str] = set()
+        referenced_item_ids: list[str] = []
+        seen: set[str] = set()
 
         for cid, _score in category_hits:
             # Get summary from lookup or category
@@ -340,9 +341,34 @@ class RetrieveMixin:
                     summary = cat.summary
             if summary:
                 refs = extract_references(summary)
-                referenced_item_ids.update(refs)
+                for ref_id in refs:
+                    if ref_id in seen:
+                        continue
+                    referenced_item_ids.append(ref_id)
+                    seen.add(ref_id)
 
         return referenced_item_ids
+
+    @staticmethod
+    def _merge_item_hits(
+        reference_hits: Sequence[tuple[str, float]],
+        vector_hits: Sequence[tuple[str, float]],
+        top_k: int,
+    ) -> list[tuple[str, float]]:
+        """Merge reference-followed hits with vector hits, preserving first occurrence."""
+        if top_k <= 0:
+            return []
+
+        merged: list[tuple[str, float]] = []
+        seen: set[str] = set()
+        for item_id, score in [*reference_hits, *vector_hits]:
+            if item_id in seen:
+                continue
+            merged.append((item_id, score))
+            seen.add(item_id)
+            if len(merged) >= top_k:
+                break
+        return merged
 
     async def _rag_recall_items(self, state: WorkflowState, step_context: Any) -> WorkflowState:
         if not state.get("retrieve_item") or not state.get("needs_retrieval") or not state.get("proceed_to_items"):
@@ -351,20 +377,45 @@ class RetrieveMixin:
 
         store = state["store"]
         where_filters = state.get("where") or {}
-        items_pool = store.memory_item_repo.list_items(where_filters)
         qvec = state.get("query_vector")
         if qvec is None:
             embed_client = self._get_step_embedding_client(step_context)
             qvec = (await embed_client.embed([state["active_query"]]))[0]
             state["query_vector"] = qvec
-        state["item_hits"] = store.memory_item_repo.vector_search_items(
+
+        vector_hits = store.memory_item_repo.vector_search_items(
             qvec,
             self.retrieve_config.item.top_k,
             where=where_filters,
             ranking=self.retrieve_config.item.ranking,
             recency_decay_days=self.retrieve_config.item.recency_decay_days,
         )
-        state["item_pool"] = items_pool
+        item_pool = {
+            item_id: item
+            for item_id in (item_id for item_id, _score in vector_hits)
+            if (item := store.memory_item_repo.get_item(item_id)) is not None
+        }
+
+        reference_hits: list[tuple[str, float]] = []
+        if getattr(self.retrieve_config.item, "use_category_references", False):
+            ref_ids = self._extract_referenced_item_ids(state)
+            referenced_items = store.memory_item_repo.list_items_by_ref_ids(ref_ids, where_filters)
+            item_pool.update(referenced_items)
+            ref_order = {ref_id: index for index, ref_id in enumerate(ref_ids)}
+            ordered_referenced_items = sorted(
+                referenced_items.items(),
+                key=lambda pair: ref_order.get(ref_id, len(ref_order))
+                if isinstance(ref_id := (pair[1].extra or {}).get("ref_id"), str)
+                else len(ref_order),
+            )
+            reference_hits = [(item_id, 1.0) for item_id, _item in ordered_referenced_items]
+
+        state["item_hits"] = self._merge_item_hits(
+            reference_hits,
+            vector_hits,
+            self.retrieve_config.item.top_k,
+        )
+        state["item_pool"] = item_pool
         return state
 
     async def _rag_item_sufficiency(self, state: WorkflowState, step_context: Any) -> WorkflowState:

--- a/tests/test_retrieve_reference_rag.py
+++ b/tests/test_retrieve_reference_rag.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from memu.app import MemoryService
+
+
+class _FakeEmbeddingClient:
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        return [_vector_for_text(text) for text in texts]
+
+
+def _vector_for_text(text: str) -> list[float]:
+    lowered = text.lower()
+    if "orthogonal" in lowered:
+        return [0.0, 1.0, 0.0]
+    return [1.0, 0.0, 0.0]
+
+
+class _UserAgentScope(BaseModel):
+    user_id: str | None = None
+    agent_id: str | None = None
+
+
+def _build_service(
+    *,
+    use_category_references: bool,
+    top_k: int = 1,
+    category_top_k: int = 1,
+    user_model: type[BaseModel] | None = None,
+) -> MemoryService:
+    service = MemoryService(
+        llm_profiles={"default": {"api_key": "test-key"}},
+        database_config={"metadata_store": {"provider": "inmemory"}},
+        user_config={"model": user_model} if user_model is not None else None,
+        retrieve_config={
+            "method": "rag",
+            "route_intention": False,
+            "sufficiency_check": False,
+            "category": {"enabled": True, "top_k": category_top_k},
+            "item": {
+                "enabled": True,
+                "top_k": top_k,
+                "use_category_references": use_category_references,
+            },
+            "resource": {"enabled": False},
+        },
+    )
+    service._get_embedding_client = lambda *args, **kwargs: _FakeEmbeddingClient()  # type: ignore[method-assign]
+    return service
+
+
+def _seed_item(
+    service: MemoryService,
+    *,
+    summary: str,
+    user_id: str,
+    embedding: list[float],
+    ref_id: str | None = None,
+    agent_id: str | None = None,
+) -> str:
+    store = service.database
+    user_data = {"user_id": user_id}
+    if agent_id is not None:
+        user_data["agent_id"] = agent_id
+    resource = store.resource_repo.create_resource(
+        url=f"mem://{user_id}/{summary}",
+        modality="document",
+        local_path="",
+        caption=summary,
+        embedding=None,
+        user_data=user_data,
+    )
+    item = store.memory_item_repo.create_item(
+        resource_id=resource.id,
+        memory_type="knowledge",
+        summary=summary,
+        embedding=embedding,
+        user_data=user_data,
+    )
+    if ref_id is not None:
+        store.memory_item_repo.update_item(item_id=item.id, extra={"ref_id": ref_id})
+    return item.id
+
+
+def _seed_category(service: MemoryService, *, user_id: str, summary: str, agent_id: str | None = None) -> str:
+    store = service.database
+    user_data = {"user_id": user_id}
+    if agent_id is not None:
+        user_data["agent_id"] = agent_id
+    category = store.memory_category_repo.get_or_create_category(
+        name=f"Deployments {user_id} {agent_id or 'default'}",
+        description="Deployment facts",
+        embedding=[1.0, 0.0, 0.0],
+        user_data=user_data,
+    )
+    store.memory_category_repo.update_category(category_id=category.id, summary=summary)
+    return category.id
+
+
+async def _retrieve(service: MemoryService, *, user_id: str = "u1", agent_id: str | None = None) -> dict[str, Any]:
+    where = {"user_id": user_id}
+    if agent_id is not None:
+        where["agent_id"] = agent_id
+    return await service.retrieve(
+        queries=[{"role": "user", "content": {"text": "Which deployment memory matters?"}}],
+        where=where,
+    )
+
+
+async def test_rag_reference_recall_returns_cited_in_scope_item() -> None:
+    service = _build_service(use_category_references=True, top_k=1)
+    cited_id = _seed_item(
+        service,
+        summary="API key was missing during deploy",
+        user_id="u1",
+        embedding=[0.0, 1.0, 0.0],
+        ref_id="deploy-key",
+    )
+    _seed_item(service, summary="Vector-preferred deploy note", user_id="u1", embedding=[1.0, 0.0, 0.0])
+    _seed_category(service, user_id="u1", summary="Deployment failed because a key was missing [ref:deploy-key].")
+
+    result = await _retrieve(service)
+
+    assert [item["id"] for item in result["items"]] == [cited_id]
+
+
+async def test_rag_reference_recall_respects_scope() -> None:
+    service = _build_service(use_category_references=True, top_k=2)
+    _seed_item(
+        service,
+        summary="Out-of-scope secret deploy note",
+        user_id="u2",
+        embedding=[1.0, 0.0, 0.0],
+        ref_id="secret-ref",
+    )
+    in_scope_id = _seed_item(
+        service,
+        summary="In-scope vector deploy note",
+        user_id="u1",
+        embedding=[1.0, 0.0, 0.0],
+    )
+    _seed_category(service, user_id="u1", summary="A different user has a cited secret [ref:secret-ref].")
+
+    result = await _retrieve(service, user_id="u1")
+
+    assert [item["id"] for item in result["items"]] == [in_scope_id]
+    assert all(item["user_id"] == "u1" for item in result["items"])
+
+
+async def test_rag_reference_recall_uses_scoped_ref_when_same_ref_exists_for_two_users() -> None:
+    service = _build_service(use_category_references=True, top_k=1)
+    in_scope_id = _seed_item(
+        service,
+        summary="In-scope deploy note with shared ref",
+        user_id="u1",
+        embedding=[0.0, 1.0, 0.0],
+        ref_id="shared-ref",
+    )
+    _seed_item(
+        service,
+        summary="Out-of-scope deploy note with shared ref",
+        user_id="u2",
+        embedding=[1.0, 0.0, 0.0],
+        ref_id="shared-ref",
+    )
+    _seed_category(service, user_id="u1", summary="The in-scope note is cited [ref:shared-ref].")
+
+    result = await _retrieve(service, user_id="u1")
+
+    assert [item["id"] for item in result["items"]] == [in_scope_id]
+    assert all(item["user_id"] == "u1" for item in result["items"])
+
+
+async def test_rag_reference_recall_respects_custom_agent_scope_for_same_ref() -> None:
+    service = _build_service(use_category_references=True, top_k=1, user_model=_UserAgentScope)
+    in_scope_id = _seed_item(
+        service,
+        summary="Agent A deploy note",
+        user_id="u1",
+        agent_id="agent-a",
+        embedding=[0.0, 1.0, 0.0],
+        ref_id="agent-shared-ref",
+    )
+    _seed_item(
+        service,
+        summary="Agent B deploy note",
+        user_id="u1",
+        agent_id="agent-b",
+        embedding=[1.0, 0.0, 0.0],
+        ref_id="agent-shared-ref",
+    )
+    _seed_category(
+        service,
+        user_id="u1",
+        agent_id="agent-a",
+        summary="Agent A category cites the shared ref [ref:agent-shared-ref].",
+    )
+
+    result = await _retrieve(service, user_id="u1", agent_id="agent-a")
+
+    assert [item["id"] for item in result["items"]] == [in_scope_id]
+    assert all(item["agent_id"] == "agent-a" for item in result["items"])
+
+
+async def test_rag_reference_recall_ignores_out_of_scope_ref_among_multiple_refs() -> None:
+    service = _build_service(use_category_references=True, top_k=2)
+    in_scope_id = _seed_item(
+        service,
+        summary="In-scope cited deploy note",
+        user_id="u1",
+        embedding=[0.0, 1.0, 0.0],
+        ref_id="in-scope-ref",
+    )
+    _seed_item(
+        service,
+        summary="Out-of-scope cited deploy note",
+        user_id="u2",
+        embedding=[0.0, 1.0, 0.0],
+        ref_id="out-of-scope-ref",
+    )
+    vector_id = _seed_item(service, summary="In-scope vector deploy note", user_id="u1", embedding=[1.0, 0.0, 0.0])
+    _seed_category(
+        service,
+        user_id="u1",
+        summary="One cited note is visible [ref:in-scope-ref], one is not [ref:out-of-scope-ref].",
+    )
+
+    result = await _retrieve(service, user_id="u1")
+
+    item_ids = [item["id"] for item in result["items"]]
+    assert item_ids == [in_scope_id, vector_id]
+    assert all(item["user_id"] == "u1" for item in result["items"])
+
+
+async def test_rag_reference_recall_nonexistent_ref_continues_with_vector_hits() -> None:
+    service = _build_service(use_category_references=True, top_k=1)
+    vector_id = _seed_item(service, summary="Vector fallback deploy note", user_id="u1", embedding=[1.0, 0.0, 0.0])
+    _seed_category(service, user_id="u1", summary="This category cites a missing item [ref:missing-ref].")
+
+    result = await _retrieve(service, user_id="u1")
+
+    assert [item["id"] for item in result["items"]] == [vector_id]
+
+
+async def test_rag_reference_recall_dedupes_vector_hit() -> None:
+    service = _build_service(use_category_references=True, top_k=3)
+    cited_id = _seed_item(
+        service,
+        summary="Cited item also wins vector search",
+        user_id="u1",
+        embedding=[1.0, 0.0, 0.0],
+        ref_id="dupe-ref",
+    )
+    _seed_item(service, summary="Other vector item", user_id="u1", embedding=[1.0, 0.0, 0.0])
+    _seed_category(service, user_id="u1", summary="The cited item matters [ref:dupe-ref].")
+
+    result = await _retrieve(service)
+
+    item_ids = [item["id"] for item in result["items"]]
+    assert item_ids.count(cited_id) == 1
+
+
+async def test_rag_reference_recall_returns_all_same_scope_items_with_same_ref_id() -> None:
+    service = _build_service(use_category_references=True, top_k=2)
+    first_id = _seed_item(
+        service,
+        summary="First item sharing same ref",
+        user_id="u1",
+        embedding=[0.0, 1.0, 0.0],
+        ref_id="ambiguous-ref",
+    )
+    second_id = _seed_item(
+        service,
+        summary="Second item sharing same ref",
+        user_id="u1",
+        embedding=[0.0, 1.0, 0.0],
+        ref_id="ambiguous-ref",
+    )
+    _seed_category(service, user_id="u1", summary="The summary cites an ambiguous ref [ref:ambiguous-ref].")
+
+    result = await _retrieve(service, user_id="u1")
+
+    assert [item["id"] for item in result["items"]] == [first_id, second_id]
+
+
+async def test_rag_reference_recall_respects_top_k_across_reference_and_vector_hits() -> None:
+    service = _build_service(use_category_references=True, top_k=2)
+    first_ref_id = _seed_item(
+        service,
+        summary="First cited deploy note",
+        user_id="u1",
+        embedding=[0.0, 1.0, 0.0],
+        ref_id="first-ref",
+    )
+    second_ref_id = _seed_item(
+        service,
+        summary="Second cited deploy note",
+        user_id="u1",
+        embedding=[0.0, 1.0, 0.0],
+        ref_id="second-ref",
+    )
+    vector_id = _seed_item(service, summary="Vector deploy note", user_id="u1", embedding=[1.0, 0.0, 0.0])
+    _seed_category(service, user_id="u1", summary="Two refs should fill top_k [ref:first-ref,second-ref].")
+
+    result = await _retrieve(service, user_id="u1")
+
+    assert [item["id"] for item in result["items"]] == [first_ref_id, second_ref_id]
+    assert vector_id not in [item["id"] for item in result["items"]]
+    assert len(result["items"]) == 2
+
+
+async def test_rag_reference_recall_returns_no_items_when_top_k_is_zero() -> None:
+    service = _build_service(use_category_references=True, top_k=0)
+    _seed_item(
+        service,
+        summary="Cited deploy note",
+        user_id="u1",
+        embedding=[0.0, 1.0, 0.0],
+        ref_id="zero-limit-ref",
+    )
+    _seed_item(service, summary="Vector deploy note", user_id="u1", embedding=[1.0, 0.0, 0.0])
+    _seed_category(service, user_id="u1", summary="The category cites a note [ref:zero-limit-ref].")
+
+    result = await _retrieve(service, user_id="u1")
+
+    assert result["items"] == []
+
+
+async def test_rag_reference_recall_disabled_preserves_vector_only_behavior() -> None:
+    service = _build_service(use_category_references=False, top_k=1)
+    cited_id = _seed_item(
+        service,
+        summary="Cited but orthogonal deploy note",
+        user_id="u1",
+        embedding=[0.0, 1.0, 0.0],
+        ref_id="disabled-ref",
+    )
+    vector_id = _seed_item(service, summary="Vector-preferred deploy note", user_id="u1", embedding=[1.0, 0.0, 0.0])
+    _seed_category(service, user_id="u1", summary="The category cites the orthogonal note [ref:disabled-ref].")
+
+    result = await _retrieve(service)
+
+    item_ids = [item["id"] for item in result["items"]]
+    assert item_ids == [vector_id]
+    assert cited_id not in item_ids

--- a/tests/test_retrieve_reference_rag_eval.py
+++ b/tests/test_retrieve_reference_rag_eval.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from tests.test_retrieve_reference_rag import _build_service, _seed_category, _seed_item
+
+
+@dataclass(frozen=True)
+class _EvalMetrics:
+    cited_item_recall: float
+    precision_at_k: float
+    duplicate_count: int
+    scope_leak_count: int
+    missing_ref_error_count: int
+
+
+def _returned_ref_ids(result: dict[str, Any]) -> list[str]:
+    ref_ids: list[str] = []
+    for item in result["items"]:
+        ref_id = (item.get("extra") or {}).get("ref_id")
+        if isinstance(ref_id, str):
+            ref_ids.append(ref_id)
+    return ref_ids
+
+
+def _count_duplicates(values: list[str]) -> int:
+    return len(values) - len(set(values))
+
+
+async def _run_synthetic_eval_case(
+    *,
+    use_category_references: bool,
+    case_id: int,
+) -> tuple[dict[str, Any], set[str], int]:
+    service = _build_service(use_category_references=use_category_references, top_k=2)
+    expected_refs = {f"case-{case_id}-primary", f"case-{case_id}-secondary"}
+
+    _seed_item(
+        service,
+        summary=f"Case {case_id} cited primary remediation",
+        user_id="eval-user",
+        embedding=[0.0, 1.0, 0.0],
+        ref_id=f"case-{case_id}-primary",
+    )
+    _seed_item(
+        service,
+        summary=f"Case {case_id} cited secondary remediation",
+        user_id="eval-user",
+        embedding=[0.0, 1.0, 0.0],
+        ref_id=f"case-{case_id}-secondary",
+    )
+    _seed_item(
+        service,
+        summary=f"Case {case_id} vector distractor one",
+        user_id="eval-user",
+        embedding=[1.0, 0.0, 0.0],
+    )
+    _seed_item(
+        service,
+        summary=f"Case {case_id} vector distractor two",
+        user_id="eval-user",
+        embedding=[1.0, 0.0, 0.0],
+    )
+    _seed_item(
+        service,
+        summary=f"Case {case_id} out-of-scope cited remediation",
+        user_id="other-user",
+        embedding=[1.0, 0.0, 0.0],
+        ref_id=f"case-{case_id}-primary",
+    )
+    _seed_category(
+        service,
+        user_id="eval-user",
+        summary=(
+            f"The exact remediation was recorded in two cited items "
+            f"[ref:case-{case_id}-primary,case-{case_id}-secondary]. "
+            f"The summary also contains a stale citation [ref:case-{case_id}-missing]."
+        ),
+    )
+
+    missing_ref_errors = 0
+    try:
+        result = await service.retrieve(
+            queries=[{"role": "user", "content": {"text": f"Which case {case_id} remediation applies?"}}],
+            where={"user_id": "eval-user"},
+        )
+    except Exception:
+        missing_ref_errors = 1
+        result = {"items": []}
+
+    return result, expected_refs, missing_ref_errors
+
+
+async def _run_synthetic_eval(*, use_category_references: bool, case_count: int = 3) -> _EvalMetrics:
+    returned_expected = 0
+    expected_total = 0
+    returned_total = 0
+    duplicate_count = 0
+    scope_leak_count = 0
+    missing_ref_error_count = 0
+
+    for case_id in range(case_count):
+        result, expected_refs, missing_ref_errors = await _run_synthetic_eval_case(
+            use_category_references=use_category_references,
+            case_id=case_id,
+        )
+        returned_refs = _returned_ref_ids(result)
+        returned_expected += len(set(returned_refs) & expected_refs)
+        expected_total += len(expected_refs)
+        returned_total += len(result["items"])
+        duplicate_count += _count_duplicates([item["id"] for item in result["items"]])
+        scope_leak_count += sum(1 for item in result["items"] if item.get("user_id") != "eval-user")
+        missing_ref_error_count += missing_ref_errors
+
+    return _EvalMetrics(
+        cited_item_recall=returned_expected / expected_total,
+        precision_at_k=returned_expected / returned_total if returned_total else 0.0,
+        duplicate_count=duplicate_count,
+        scope_leak_count=scope_leak_count,
+        missing_ref_error_count=missing_ref_error_count,
+    )
+
+
+async def test_synthetic_reference_aware_rag_improves_cited_item_recall_without_leaks() -> None:
+    vector_only = await _run_synthetic_eval(use_category_references=False)
+    reference_aware = await _run_synthetic_eval(use_category_references=True)
+
+    assert vector_only == _EvalMetrics(
+        cited_item_recall=0.0,
+        precision_at_k=0.0,
+        duplicate_count=0,
+        scope_leak_count=0,
+        missing_ref_error_count=0,
+    )
+    assert reference_aware == _EvalMetrics(
+        cited_item_recall=1.0,
+        precision_at_k=1.0,
+        duplicate_count=0,
+        scope_leak_count=0,
+        missing_ref_error_count=0,
+    )
+
+
+async def test_langgraph_search_tool_uses_reference_aware_retrieve_when_available() -> None:
+    pytest.importorskip("langgraph")
+    from memu.integrations.langgraph import MemULangGraphTools
+
+    service = _build_service(use_category_references=True, top_k=1)
+    _seed_item(
+        service,
+        summary="LangGraph tool should surface this cited deployment memory",
+        user_id="agent-user",
+        embedding=[0.0, 1.0, 0.0],
+        ref_id="langgraph-cited-ref",
+    )
+    _seed_item(
+        service,
+        summary="LangGraph vector distractor",
+        user_id="agent-user",
+        embedding=[1.0, 0.0, 0.0],
+    )
+    _seed_category(
+        service,
+        user_id="agent-user",
+        summary="The agent should follow the cited memory [ref:langgraph-cited-ref].",
+    )
+    search_tool = MemULangGraphTools(service).search_memory_tool()
+
+    result = await search_tool.ainvoke({"query": "Which deployment memory matters?", "user_id": "agent-user"})
+
+    assert "LangGraph tool should surface this cited deployment memory" in result
+    assert "LangGraph vector distractor" not in result


### PR DESCRIPTION
## Pull Request Summary

Adds opt-in reference-aware item retrieval to RAG while preserving the existing
vector-only default and the public `retrieve()` response shape.

---

## What does this PR do?

- scans retrieved category summaries for existing `[ref:...]` citations
- fetches cited items through the scoped `list_items_by_ref_ids()` repository lookup
- merges referenced and vector hits while deduplicating item IDs
- preserves user and agent scope filtering
- respects `item.top_k`, including `top_k=0`
- preserves vector-only behavior when reference retrieval is disabled
- adds deterministic quality, leakage, conflict, and LangGraph integration tests

---

## Why is this change needed?

Vector similarity can miss an exact memory item already cited by a relevant category.
Following those citations provides deterministic recall without introducing an
unconditional item scan or changing the public retrieval API.

On a deterministic three-query synthetic benchmark:

| Metric | Vector-only | Reference-aware |
|---|---:|---:|
| Cited-item recall | 0% | 100% |
| Precision@k | 0% | 100% |
| Duplicate count | 0 | 0 |
| Scope leaks | 0 | 0 |
| Missing-reference errors | 0 | 0 |

These are synthetic benchmark results, not a production-wide quality claim.

Closes #478

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other

---

## PR Quality Checklist

- [x] PR title follows an allowed format
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable; no public API or configuration signature changed
- [x] No breaking changes
- [x] Related issue linked

---

## Optional

- [ ] Screenshots or examples added; not applicable
- [x] Edge cases considered
- [x] Follow-up tasks mentioned

## Validation

Passed from a clean worktree containing only this commit:

- `uv lock --locked`
- `uv run pre-commit run -a`
- `uv run mypy`
- `uv run deptry src`
- full pytest suite with coverage

## Caveats

- duplicate `ref_id` values inside one scope return all distinct matching items
- reference-aware end-to-end tests use the in-memory backend
- existing SQLite and PostgreSQL repository implementations are unchanged
- benchmark results are deterministic synthetic measurements only