### PR TITLE
fix(vector): validate embedding dimensions before scoring

### DIFF
--- a/src/memu/vector.py
+++ b/src/memu/vector.py
@@ -20,6 +20,17 @@ def _cosine(a: np.ndarray, b: np.ndarray) -> float:
     return float(np.dot(a, b) / denom)
 
 
+def _validate_embedding_dimension(_id: str, query_vec: list[float], stored_vec: list[float]) -> None:
+    query_dimension = len(query_vec)
+    stored_dimension = len(stored_vec)
+    if stored_dimension != query_dimension:
+        msg = (
+            f"Embedding dimension mismatch for {_id!r}: query has {query_dimension} dimensions, "
+            f"but stored vector has {stored_dimension}. Re-embed stored data with the active embedding model."
+        )
+        raise ValueError(msg)
+
+
 def cosine_topk(
     query_vec: list[float],
     corpus: Iterable[tuple[str, list[float] | None]],
@@ -33,6 +44,7 @@ def cosine_topk(
     vecs: list[list[float]] = []
     for _id, vec in corpus:
         if vec is not None:
+            _validate_embedding_dimension(_id, query_vec, vec)
             ids.append(_id)
             vecs.append(cast(list[float], vec))
 

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from memu.database.inmemory.vector import cosine_topk
 
 
@@ -17,3 +19,13 @@ def test_cosine_topk_nonpositive_k_returns_empty() -> None:
 def test_cosine_topk_orders_by_similarity() -> None:
     results = cosine_topk([1.0, 0.0], _corpus(), k=2)
     assert [memory_id for memory_id, _ in results] == ["a", "c"]
+
+
+def test_cosine_topk_rejects_embedding_dimension_mismatch() -> None:
+    corpus = [("valid", [1.0, 0.0, 0.0]), ("invalid", [1.0, 0.0])]
+
+    with pytest.raises(
+        ValueError,
+        match=r"invalid.*query has 3 dimensions.*stored vector has 2",
+    ):
+        cosine_topk([1.0, 0.0, 0.0], corpus)


### PR DESCRIPTION
## Summary

- validate stored embedding dimensions against the query before vectorized cosine scoring
- raise an actionable error containing the record ID and both dimensions
- keep the validation in the shared, storage-neutral vector module

## Motivation

Switching embedding models can leave existing stored vectors with a different dimension from newly generated query vectors. Previously this surfaced as an opaque NumPy ragged-array or dot-product error.

## Rebase notes

Rebased onto the current `main` after the vector-layer refactor. The removed `cosine_topk_salience` path was dropped from this PR; the fix now targets the surviving shared `cosine_topk` implementation.

## Testing

- `tests/test_vector.py` — 3 passed
- `ruff check src/memu/vector.py tests/test_vector.py`
- `ruff format --check src/memu/vector.py tests/test_vector.py`
- `mypy src/memu/vector.py`