### PR TITLE
ci: publish workflow for the memu-cli PyPI channel

### DIFF
--- a/.github/workflows/publish-memu-cli.yml
+++ b/.github/workflows/publish-memu-cli.yml
@@ -1,0 +1,163 @@
+# Publishes the engine snapshot to PyPI under the distribution name `memu-cli`.
+#
+# `memu-cli` is the CLI release channel: it ships the same `memu` module and
+# entry points as `memu-py`, but versions independently of the release-please
+# train so the npm launcher and docs can point at a stable install target.
+# The rename happens at build time only — pyproject.toml in the repo always
+# says `memu-py`.
+#
+# First-time setup: add a trusted publisher on PyPI for project `memu-cli`
+# (workflow: publish-memu-cli.yml, environment: pypi).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "memu-cli version to publish (independent of memu-py, e.g. 0.1.1)"
+        required: true
+        type: string
+
+name: publish-memu-cli
+
+jobs:
+  build-wheels:
+    name: build wheels (${{ matrix.label }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux-x86_64
+            target: x86_64-unknown-linux-gnu
+            extra-args: "--compatibility manylinux_2_39"
+            python-version: "3.13"
+          - os: ubuntu-latest
+            label: linux-aarch64
+            target: aarch64-unknown-linux-gnu
+            extra-args: "--compatibility manylinux_2_39"
+            python-version: "3.13"
+          - os: macos-15-intel
+            label: macos-x86_64
+            target: ""
+            extra-args: ""
+            python-version: "3.13"
+          - os: macos-latest
+            label: macos-aarch64
+            target: ""
+            extra-args: ""
+            python-version: "3.13"
+          - os: windows-latest
+            label: windows-x86_64
+            target: ""
+            extra-args: ""
+            python-version: "3.13"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Rename distribution to memu-cli
+        shell: bash
+        run: |
+          perl -pi -e 's/^name = "memu-py"$/name = "memu-cli"/' pyproject.toml
+          perl -pi -e 's/^version = ".*"$/version = "${{ inputs.version }}"/ if $. < 10' pyproject.toml
+          perl -pi -e 's/^description = ".*"$/description = "CLI distribution channel for memU (same engine as memu-py). Personal memory as files."/' pyproject.toml
+          grep -E '^(name|version|description) = ' pyproject.toml | head -3
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install maturin
+        run: uv tool install maturin
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Setup cross-compilation for Linux ARM64
+        if: matrix.label == 'linux-aarch64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Build wheel
+        run: uvx maturin build --release --out dist ${{ matrix.extra-args }} ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+
+      - name: Smoke test wheel
+        if: matrix.label != 'linux-aarch64'
+        shell: bash
+        run: uvx --isolated --from ./dist/memu_cli-*.whl memu --help
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: memu-cli-wheels-${{ matrix.label }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  build-sdist:
+    name: build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Rename distribution to memu-cli
+        shell: bash
+        run: |
+          perl -pi -e 's/^name = "memu-py"$/name = "memu-cli"/' pyproject.toml
+          perl -pi -e 's/^version = ".*"$/version = "${{ inputs.version }}"/ if $. < 10' pyproject.toml
+          perl -pi -e 's/^description = ".*"$/description = "CLI distribution channel for memU (same engine as memu-py). Personal memory as files."/' pyproject.toml
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install maturin
+        run: uv tool install maturin
+
+      - name: Build sdist
+        run: uvx maturin sdist --out dist
+
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: memu-cli-sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: publish memu-cli to PyPI
+    runs-on: ubuntu-latest
+    needs:
+      - build-wheels
+      - build-sdist
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: memu-cli-wheels-*
+          merge-multiple: true
+          path: dist
+
+      - name: Download sdist artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: memu-cli-sdist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          skip-existing: true


### PR DESCRIPTION
## What

Adds a `workflow_dispatch` pipeline that publishes the engine snapshot to PyPI under the distribution name **`memu-cli`** — the CLI release channel, versioned independently of the release-please train. `memu-py` is untouched: the rename to `memu-cli` happens at build time only (perl patch of `pyproject.toml` in CI), and the module name / `memu` entry point stay the same.

## Why

The npm launcher (`npm/bin/memu.js`) resolves `memu-py` from PyPI at runtime, but PyPI's memu-py (1.5.1) predates the CLI entry point — so the npm package can't ship until something installable exists. `memu-cli` on PyPI decouples the CLI/npm channel from memu-py's release cadence permanently.

**`memu-cli` 0.1.0 is already live**: https://pypi.org/project/memu-cli/0.1.0/ (published manually: macOS arm64 wheel + sdist, smoke-tested end-to-end via `uvx --from memu-cli memu --help`). This workflow adds the remaining platform wheels (linux x86_64/aarch64, macOS intel, windows) — `skip-existing: true` makes re-publishing 0.1.0 additive.

## Setup required before first run

On PyPI, add a **trusted publisher** for project `memu-cli`: repo `NevaMind-AI/MemU`, workflow `publish-memu-cli.yml`, environment `pypi`.

## Follow-ups (separate PRs)

- Point the npm shim at `--from memu-cli` and publish `memu-cli` to npm
- Note the memu-py/memu-cli file-collision caveat (install one or the other in a given environment) in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)