### PR TITLE
ci: fix memu-cli rename on Windows CRLF checkouts

### DIFF
--- a/.github/workflows/publish-memu-cli.yml
+++ b/.github/workflows/publish-memu-cli.yml
@@ -55,12 +55,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # No $ anchors: Windows runners check out with CRLF line endings,
+      # where a trailing \r sits between the closing quote and the newline.
       - name: Rename distribution to memu-cli
         shell: bash
         run: |
-          perl -pi -e 's/^name = "memu-py"$/name = "memu-cli"/' pyproject.toml
-          perl -pi -e 's/^version = ".*"$/version = "${{ inputs.version }}"/ if $. < 10' pyproject.toml
-          perl -pi -e 's/^description = ".*"$/description = "CLI distribution channel for memU (same engine as memu-py). Personal memory as files."/' pyproject.toml
+          perl -pi -e 's/^name = "memu-py"/name = "memu-cli"/' pyproject.toml
+          perl -pi -e 's/^version = "[^"]*"/version = "${{ inputs.version }}"/ if $. < 10' pyproject.toml
+          perl -pi -e 's/^description = "[^"]*"/description = "CLI distribution channel for memU (same engine as memu-py). Personal memory as files."/' pyproject.toml
+          grep -q '^name = "memu-cli"' pyproject.toml || { echo "::error::rename to memu-cli did not apply"; exit 1; }
           grep -E '^(name|version|description) = ' pyproject.toml | head -3
 
       - name: Install uv
@@ -108,9 +111,10 @@ jobs:
       - name: Rename distribution to memu-cli
         shell: bash
         run: |
-          perl -pi -e 's/^name = "memu-py"$/name = "memu-cli"/' pyproject.toml
-          perl -pi -e 's/^version = ".*"$/version = "${{ inputs.version }}"/ if $. < 10' pyproject.toml
-          perl -pi -e 's/^description = ".*"$/description = "CLI distribution channel for memU (same engine as memu-py). Personal memory as files."/' pyproject.toml
+          perl -pi -e 's/^name = "memu-py"/name = "memu-cli"/' pyproject.toml
+          perl -pi -e 's/^version = "[^"]*"/version = "${{ inputs.version }}"/ if $. < 10' pyproject.toml
+          perl -pi -e 's/^description = "[^"]*"/description = "CLI distribution channel for memU (same engine as memu-py). Personal memory as files."/' pyproject.toml
+          grep -q '^name = "memu-cli"' pyproject.toml || { echo "::error::rename to memu-cli did not apply"; exit 1; }
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Run [29399519155](https://github.com/NevaMind-AI/memU/actions/runs/29399519155) failed on windows-x86_64: the `$`-anchored perl substitutions in the rename step silently no-opped against CRLF line endings, so the wheel built as `memu_py-1.5.1-...-win_amd64.whl` and the smoke test found no `memu_cli-*.whl`. The other four platforms (LF) passed.

Fix: drop the `$` anchors (match up to the closing quote instead, preserving `\r`), and add a hard guard that fails the job if `name = "memu-cli"` did not apply — no more silent no-op. Verified locally against a CRLF copy of pyproject.toml.

After merge, re-dispatch with version `0.1.0` — `skip-existing: true` makes it additive over the wheels already on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)