### PR TITLE
feat(npm): point the launcher at the memu-cli PyPI channel

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -4,7 +4,12 @@
 
 CLI for [memU](https://github.com/NevaMind-AI/MemU) — personal memory as files: fast retrieval, higher accuracy, lower cost.
 
-This package is a thin launcher. The engine is the Python package [`memu-py`](https://pypi.org/project/memu-py/) (Python ≥ 3.13); the shim delegates to `uvx`, `pipx run`, or an installed `python3 -m memu`, in that order. Install [uv](https://docs.astral.sh/uv/) for the smoothest zero-setup experience.
+This package is a thin launcher. The engine is the PyPI package [`memu-cli`](https://pypi.org/project/memu-cli/) (the CLI release channel of [`memu-py`](https://pypi.org/project/memu-py/), Python ≥ 3.13); the shim delegates to `uvx`, `pipx run`, or an installed `python3 -m memu`, in that order. Install [uv](https://docs.astral.sh/uv/) for the smoothest zero-setup experience — `uvx` fetches both a Python 3.13 runtime and the engine automatically, no preinstalled Python required:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh   # macOS / Linux
+# or on Windows: powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
 
 ## Usage
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,36 +1,57 @@
 # memu-cli
 
-> 🚧 **Under heavy construction** — memU is undergoing a major rework; commands and flags may change. Expected to stabilize around **July 15, 2026**.
+CLI for [memU](https://github.com/NevaMind-AI/MemU) — personal memory as files. Compile conversations, documents, and agent traces into a Markdown memory tree (`INDEX.md` / `MEMORY.md` / `SKILL.md`), then retrieve compact, ranked context instead of restuffing every prompt.
 
-CLI for [memU](https://github.com/NevaMind-AI/MemU) — personal memory as files: fast retrieval, higher accuracy, lower cost.
+> 🚧 memU is under active rework; the workspace pair below is the primary surface, other commands and flags may still change.
 
-This package is a thin launcher. The engine is the PyPI package [`memu-cli`](https://pypi.org/project/memu-cli/) (the CLI release channel of [`memu-py`](https://pypi.org/project/memu-py/), Python ≥ 3.13); the shim delegates to `uvx`, `pipx run`, or an installed `python3 -m memu`, in that order. Install [uv](https://docs.astral.sh/uv/) for the smoothest zero-setup experience — `uvx` fetches both a Python 3.13 runtime and the engine automatically, no preinstalled Python required:
+## Quick start
+
+The only prerequisite is [uv](https://docs.astral.sh/uv/) — it fetches both a Python 3.13 runtime and the memU engine automatically, so nothing else needs to be preinstalled:
 
 ```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh   # macOS / Linux
-# or on Windows: powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+curl -LsSf https://astral.sh/uv/install.sh | sh    # macOS / Linux
+# Windows: powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
-## Usage
+Then:
 
 ```bash
 export OPENAI_API_KEY=sk-...
 
-# diff-sync a workspace folder (chat/ -> memory, agent/ -> skills, other -> index)
+# diff-sync a workspace folder into memory
+# (chat/ -> memory topics, agent/ -> skills, everything else -> indexed context)
 npx memu-cli memorize-workspace ./workspace
 
-# single-shot embedding retrieval (LLM-free, fast)
+# single-shot embedding retrieval — LLM-free, fast
 npx memu-cli retrieve-workspace "deploy checklist"
 
 # rebuild the INDEX.md / MEMORY.md / SKILL.md markdown tree
 npx memu-cli export
-
-# legacy pair: memorize a single file / LLM-routed retrieval
-npx memu-cli memorize notes/meeting.md
-npx memu-cli retrieve "What are this user's launch preferences?"
 ```
 
-State persists in a local SQLite database (`./data/memu.sqlite3` by default), so memorize in one invocation and retrieve in the next. Run `npx memu-cli --help` or see the [main README](https://github.com/NevaMind-AI/MemU#readme) for all flags and `MEMU_*` environment variables.
+State persists in a local SQLite database (`./data/memu.sqlite3` by default), so memorize in one invocation and retrieve in the next. Every flag has a `MEMU_*` environment variable (`--provider`/`MEMU_LLM_PROVIDER`, `--model`/`MEMU_CHAT_MODEL`, `--db`/`MEMU_DB`, ...) — run `npx memu-cli <command> --help` for the full list.
+
+## Commands
+
+| Command | Alias | What it does |
+|---|---|---|
+| `memorize-workspace <folder>` | `sync` | Diff-sync a folder into memory; only changed files are reprocessed |
+| `retrieve-workspace <query>` | `search` | Rank memory segments, files, and resources by embedding similarity — zero LLM calls |
+| `export` | | Rebuild the markdown memory tree from the store |
+| `memorize <file>` / `retrieve <query>` | | Legacy single-file pair — LLM-routed, heavier; prefer the workspace pair |
+
+## How it works
+
+This npm package is a thin launcher (a few kB, no dependencies). The engine is the PyPI package [`memu-cli`](https://pypi.org/project/memu-cli/) — the CLI release channel of [`memu-py`](https://pypi.org/project/memu-py/), same module, versioned independently, with prebuilt wheels for Linux (x86_64/aarch64), macOS (Intel/Apple Silicon), and Windows. The shim finds a runner and delegates, in order:
+
+1. `$MEMU_PYTHON -m memu` — explicit interpreter override
+2. `uvx --from memu-cli memu` — no install needed, cached by uv (recommended)
+3. `pipx run --spec memu-cli memu` — no install needed, cached by pipx
+4. `python3 -m memu` — requires `pip install memu-cli`
+
+Using Python already? Skip npm entirely: `uvx --from memu-cli memu --help`, or `pip install memu-cli`. For the library API (`MemoryService`, LangGraph integration, Postgres backends), use [`memu-py`](https://pypi.org/project/memu-py/) — but install only one of the two in a given environment; they ship the same `memu` module.
+
+See the [main README](https://github.com/NevaMind-AI/MemU#readme) for the memory model, library API, and self-hosting options.
 
 ## License
 

--- a/npm/bin/memu.js
+++ b/npm/bin/memu.js
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
-// memu-cli: thin launcher for the Python package `memu-py`.
+// memu-cli: thin launcher for the PyPI package `memu-cli` (the CLI release
+// channel of the memU engine; same module as memu-py, versioned independently).
 //
 // The memU engine is Python (>= 3.13). This shim finds a runner and delegates,
 // in order of preference:
 //   1. $MEMU_PYTHON -m memu            (explicit interpreter override)
-//   2. uvx --from memu-py memu         (no install needed, cached by uv)
-//   3. pipx run --spec memu-py memu    (no install needed, cached by pipx)
-//   4. python3 -m memu                 (requires `pip install memu-py`)
+//   2. uvx --from memu-cli memu        (no install needed, cached by uv)
+//   3. pipx run --spec memu-cli memu   (no install needed, cached by pipx)
+//   4. python3 -m memu                 (requires `pip install memu-cli`)
 "use strict";
 
 const { spawnSync } = require("node:child_process");
@@ -31,10 +32,10 @@ if (process.env.MEMU_PYTHON) {
   run(process.env.MEMU_PYTHON, ["-m", "memu"]);
 }
 if (has("uvx")) {
-  run("uvx", ["--from", "memu-py", "memu"]);
+  run("uvx", ["--from", "memu-cli", "memu"]);
 }
 if (has("pipx")) {
-  run("pipx", ["run", "--spec", "memu-py", "memu"]);
+  run("pipx", ["run", "--spec", "memu-cli", "memu"]);
 }
 if (has("python3")) {
   const probe = spawnSync("python3", ["-c", "import memu"], { stdio: "ignore" });
@@ -45,12 +46,12 @@ if (has("python3")) {
 
 console.error(
   [
-    "memu-cli: no Python runner found. The memU engine is the Python package `memu-py` (Python >= 3.13).",
+    "memu-cli: no Python runner found. The memU engine is the PyPI package `memu-cli` (Python >= 3.13).",
     "Install one of:",
     "  - uv    (https://docs.astral.sh/uv/)  -> memu-cli will use `uvx` automatically",
     "  - pipx  (https://pipx.pypa.io/)       -> memu-cli will use `pipx run` automatically",
-    "  - pip   -> `pip install memu-py`, then re-run",
-    "Or point MEMU_PYTHON at an interpreter that has memu-py installed.",
+    "  - pip   -> `pip install memu-cli`, then re-run",
+    "Or point MEMU_PYTHON at an interpreter that has memU installed.",
   ].join("\n")
 );
 process.exit(1);

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memu-cli",
-  "version": "1.5.1",
-  "description": "CLI for memU \u2014 personal memory as files. Thin launcher for the Python package memu-py.",
+  "version": "0.1.0",
+  "description": "CLI for memU \u2014 personal memory as files. Thin launcher for the PyPI package memu-cli.",
   "bin": {
     "memu": "bin/memu.js"
   },


### PR DESCRIPTION
## What

- `npm/bin/memu.js`: uvx/pipx now resolve **`memu-cli`** from PyPI instead of `memu-py` (whose published 1.5.1 predates the `memu` entry point); error message and comments updated to match.
- `npm/package.json`: version aligned with the PyPI channel (**0.1.0**), description updated.
- `npm/README.md`: documents the one-line uv install — `uvx` fetches a Python 3.13 runtime automatically, so no preinstalled Python is needed on any platform.

## Verified

`node npm/bin/memu.js --help` delegates through uvx → PyPI `memu-cli` 0.1.0 (all five platform wheels live) and prints the full command surface. `npm pack --dry-run`: 3 files, 2.2 kB.

## Follow-up

First `npm publish` of `memu-cli` from this branch/main once an npm account is logged in (name currently unclaimed on the npm registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)