### PR TITLE
chore(npm): bump memu-cli launcher to 0.2.0

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memu-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "CLI for memU \u2014 personal memory as files. Thin launcher for the PyPI package memu-cli.",
   "bin": {
     "memu": "bin/memu.js"


### PR DESCRIPTION
Version bump for the npm launcher, released alongside PyPI memu-cli 0.2.0 (the agentic-only rework: retrieve/list-files/commit CLI). The launcher itself is unchanged — it always delegates to the latest PyPI memu-cli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)