### PR TITLE
feat(hosts): add Claude Code, Cursor, OpenClaw, and Hermes host adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,26 +95,36 @@ Segments are reconciled on every commit: lines that disappeared are deleted, onl
 
 There is no intention routing, sufficiency checking, or summarization — one embedding call in, ranked context out.
 
-## Host adapter: memory for desktop coding agents
+## Host adapters: memory for desktop coding agents
 
-`memu-codex` runs memU as a sidecar to Codex-style agents (ADR 0008/0009). It binds two seams:
+memU runs as a sidecar to a desktop agent (ADR 0008/0009/0010), one binary per host. Each binds two seams:
 
 - **record** — a scheduled bridging task slices new session logs into self-contained job files; the agent itself distills them into memory/skill Markdown; `commit` submits whatever the agent left on disk back through `commit_results`.
-- **inject** — a standing instruction in the host's global instruction file (`~/.codex/AGENTS.md`) tells the agent to run `memu-codex retrieve` (→ `progressive_retrieve`) before answering.
+- **inject** — a standing instruction in the host's instruction file tells the agent to run `<binary> retrieve` (→ `progressive_retrieve`) before answering.
+
+| Host | Binary | Session log it mines | Instruction file it patches |
+| --- | --- | --- | --- |
+| Codex | `memu-codex` | `~/.codex/sessions/**/*.jsonl` | `~/.codex/AGENTS.md` |
+| Claude Code | `memu-claude-code` | `~/.claude/projects/<project>/<session>.jsonl` | `~/.claude/CLAUDE.md` |
+| Cursor (Agent/CLI) | `memu-cursor` | `~/.cursor/projects/<project>/agent-transcripts/**.jsonl` | `./AGENTS.md` (per project) |
+| OpenClaw | `memu-openclaw` | `~/.openclaw/agents/<agentId>/sessions/*.jsonl` | `~/.openclaw/workspace/AGENTS.md` |
+| Hermes Agent | `memu-hermes` | `~/.hermes/state.db` (SQLite, read-only) | `~/.hermes/SOUL.md` |
+
+All hosts share one store and one embedding space via `~/.memu/config.env` — what one host's sessions taught memU, another host retrieves.
 
 **Installation is agent-driven.** The install guide is written for the agent, not for you — install the package, then hand the guide to your agent and let it do the rest (configure the store, register the scheduled bridging task, patch the instruction file — each step ends with a verify gate):
 
 ```bash
-pip install memu-cli    # puts memu + memu-codex on PATH
+pip install memu-cli    # puts memu + the host binaries on PATH
 ```
 
-Then tell your agent:
+Then tell your agent (swap in your host's binary):
 
 > Run `memu-codex docs install`, read the guide it prints, and follow it to install memU.
 
-Afterwards `memu-codex doctor` proves the whole loop resolves: config, store, and a live retrieval.
+Afterwards `<binary> doctor` proves the whole loop resolves: config, store, and a live retrieval.
 
-Adding another host means implementing one `TranscriptSource` (where its session logs live, how its records are shaped) plus a thin CLI — the pipeline and instruction text are shared.
+Adding another host means implementing one `TranscriptSource` (where its session logs live, how its records are shaped) plus a `HostSpec`-sized CLI — the pipeline, verbs, and instruction text are shared (ADR 0010).
 
 ## Installation
 

--- a/docs/adr/0010-multi-host-adapters.md
+++ b/docs/adr/0010-multi-host-adapters.md
@@ -1,0 +1,167 @@
+ADR 0010: Multi-Host Adapters — Claude Code, Cursor, OpenClaw, and Hermes
+
+- Status: Accepted
+- Date: 2026-07-16
+- Builds on: ADR 0008 (two integration surfaces), ADR 0009 (packaging, CLI seam, one config
+  loader)
+- Scope: adding four host adapters beyond Codex, and the two pieces of shared structure that
+  shipping a second host forced: a common CLI builder, and per-host working trees. It does
+  **not** revisit the pipeline, the seams, or the config decisions of 0008/0009.
+
+## Context
+
+ADR 0009 closed with a claim and an IOU. The claim: "a second host is a `TranscriptSource`
+and a CLI, not a forked pipeline." The IOU: the working directories (`~/.memu/jobs`,
+`~/.memu/sessions`, the touched-file log) are shared and wiped per run — "two hosts' bridging
+tasks running at the same time would race. Fine while Codex is the only host; must be settled
+before the second one ships."
+
+Four hosts now ship at once: **Claude Code**, **Cursor**, **OpenClaw**, and **Hermes Agent**.
+Each was located empirically (inspecting a live machine and, for OpenClaw and Hermes, the
+hosts' own source) rather than from documentation alone:
+
+| Host | Session log | Container | Record shape |
+| --- | --- | --- | --- |
+| Codex | `~/.codex/sessions/**/*.jsonl` | JSONL per session | `{timestamp, payload: {type, role, …}}`; `type: message` (user/assistant) vs `function_call`/`function_call_output` |
+| Claude Code | `~/.claude/projects/<escaped-cwd>/<session-uuid>.jsonl` (subagent transcripts in per-session subdirs) | JSONL per session | `{type: user\|assistant, timestamp, message: {role, content}}`, one content block per record: `text` / `tool_use` / `tool_result` / `thinking`; plus non-message noise types (`queue-operation`, `attachment`, `system`, `pr-link`, `last-prompt`) and `isMeta` user records |
+| Cursor (Agent/CLI) | `~/.cursor/projects/<escaped-cwd>/agent-transcripts/<id>/<id>.jsonl` | JSONL per session | `{role, message: {content: [blocks]}}`; `text` and `tool_use` blocks, often in one record; **no timestamps**. The IDE's Composer chats live in the editor's `state.vscdb` SQLite and are out of scope |
+| OpenClaw | `~/.openclaw/agents/<agentId>/sessions/<sessionId>.jsonl` (`-topic-<threadId>` suffix for topic sessions; `sessions.json` index alongside; root moves with `OPENCLAW_STATE_DIR`) | JSONL per session | parent-linked entry tree: `{type: session\|message\|compaction\|custom…, id, parentId, timestamp, message: {role, content}}`; roles `user`/`assistant`/`toolResult` |
+| Hermes Agent | `~/.hermes/state.db` (moves with `HERMES_HOME`; `~/.hermes/sessions/saved/` holds only manual snapshots) | **SQLite**, WAL mode | `sessions` + `messages` tables; OpenAI-shaped rows: `role` (`system`/`user`/`assistant`/`tool`), `content`, `tool_calls`, `tool_call_id`, epoch-seconds `timestamp` |
+
+And the inject seam's landing file per host:
+
+| Host | Instruction file | Why |
+| --- | --- | --- |
+| Codex | `~/.codex/AGENTS.md` | global, loaded every session (ADR 0009) |
+| Claude Code | `~/.claude/CLAUDE.md` | the global memory file, loaded in every project |
+| Cursor | `./AGENTS.md` (per project) | Cursor's CLI honors no global instruction *file*; User Rules are IDE settings out of a CLI's reach |
+| OpenClaw | `~/.openclaw/workspace/AGENTS.md` | the workspace file loaded at the start of every session |
+| Hermes | `~/.hermes/SOUL.md` | the one file loaded from `HERMES_HOME` regardless of cwd; project files (`.hermes.md`, `AGENTS.md`) would miss sessions started elsewhere |
+
+Two of the four break assumptions Codex allowed:
+
+- **Hermes's log is not files.** The `TranscriptSource` defaults (rglob, line reads, string
+  timestamps) assume JSONL-on-disk. 0009's seam anticipated this ("a host with a different
+  container overrides `discover`, `read_records`, `timestamp`"), but no host had exercised it.
+- **Claude Code's roles lie.** A tool result is logged as a *user*-typed record. Any
+  classification keyed on role alone would put tool output in the conversation transcript the
+  memory job reads.
+
+## Decision
+
+### 1. The host CLI is built from a declaration, not copied
+
+Five binaries share one verb set — `retrieve`, `install-instruction`, `prepare`, `commit`,
+`verify-resources`, `doctor`, `docs` — because the behavior behind every verb is host-agnostic.
+So the parser and handlers move to `memu.hosts.host_cli`, built from a `HostSpec`: the host id,
+the session-log default, the instruction-file default, and the docs package. A host's `cli.py`
+is now the spec plus `main`, ~40 lines; `memu-codex` is rebuilt on the same spec with byte-
+identical behavior.
+
+The standing-instruction text (ADR 0009's managed block) is likewise parameterized on the host
+binary rather than hardcoding `memu-codex`; each host's block names its own `retrieve`, and the
+per-binary begin-marker means two hosts pointed at one file manage two independent blocks.
+Codex's rendered block is unchanged, so already-installed markers still match and upgrade in
+place.
+
+What stays per host is exactly what 0009 predicted — a `TranscriptSource` — plus the two paths
+(session log, instruction file) and the packaged guides. Cursor's `discover` is narrowed to
+`*/agent-transcripts/**/*.jsonl` (the project dirs also hold canvases and terminal logs);
+Hermes overrides the container seam wholesale: sessions are *virtual paths* keyed by session
+id, `read_records` serializes message rows to JSON lines ordered by insertion id, and
+`discover` orders by last activity so the manifest's early-stop stays sound. The database is
+opened **read-only** — the bridging task must never contend for Hermes's WAL write lock. The
+line-count cursor carries over untouched: message rows are append-only per session, so "lines
+seen" is "rows seen."
+
+### 2. Working trees are per host; the store stays shared
+
+0009's open issue is settled by removing the sharing, not by locking: every host's `Layout`
+gets its own base directory, `~/.memu/hosts/<host>/`, holding its jobs, sliced sessions,
+mirrors, manifests, and touched-file log. Concurrent bridging runs of different hosts touch
+disjoint trees. **Codex keeps `~/.memu`**: its job-file paths are baked into users' already-
+scheduled task prompts (the exact fragility 0009's `PATH`-command decision was protecting
+against — the prompt references `~/.memu/jobs/*.txt` literally), and breaking every existing
+install to make five directories symmetrical is a bad trade. The asymmetry is recorded in
+`HostSpec.base_dir` with a comment saying why.
+
+What is *not* per host: `~/.memu/config.env` and the store behind `MEMU_DB`. That is the
+point of the whole exercise — a session mined from Claude Code tonight is retrievable from
+Cursor tomorrow. The install guides instruct an agent that finds an existing `config.env` to
+reuse it as is, because a second host writing a second store/provider would silently split the
+embedding space (0009's core invariant).
+
+### 3. Classification is by record shape, not role
+
+Each host's `classify` encodes its log's actual semantics, pinned by tests with hand-written
+records in the host's real shape:
+
+- **Claude Code**: block type decides — `text` (or a raw-string user message) is conversation;
+  `tool_use`/`tool_result` are tool records regardless of the wrapping role; `thinking` blocks,
+  `isMeta` user records, and all non-message types are dropped.
+- **Cursor**: a record with prose is conversation even when it also carries the `tool_use`
+  blocks it narrates; only bare tool-block records go to the tool transcript. No timestamps
+  exist, so the manifest records `null` and the line count alone drives incrementality.
+- **OpenClaw**: `type: message` with role user/assistant is conversation, role `toolResult` is
+  a tool record; session headers, compaction summaries, and extension entries are dropped.
+  Timestamps may be ISO strings or epoch millis; both normalize.
+- **Hermes**: role `tool`, and assistant rows carrying only `tool_calls`, are tool records;
+  user/assistant rows with content are conversation; `system` rows are dropped. Epoch-seconds
+  timestamps normalize to ISO.
+
+## What this changes
+
+- Four new console scripts — `memu-claude-code`, `memu-cursor`, `memu-openclaw`,
+  `memu-hermes` — each with packaged `INSTALL.md` / `BRIDGING_TASK.md` guides printable via
+  `<binary> docs`, alongside the unchanged `memu-codex`.
+- `memu.hosts.host_cli` (new): `HostSpec` + the shared parser/handlers. `codex/cli.py`
+  shrinks to its spec; its public names (`build_parser`, `AGENTS_MD`, `HOST`,
+  `VERIFY_COMMAND`) survive.
+- `memu.hosts.instruction`: `INSTRUCTION`/`BEGIN` constants become `instruction(binary)` /
+  `begin(binary)` templates; `install`/`patch`/`register` take the binary.
+- `memu.hosts.base.TranscriptSource` gains `exists()` (default: root is a directory) so a
+  SQLite-backed host can gate `prepare` on its file instead.
+- New host packages: `hosts/claude_code`, `hosts/cursor`, `hosts/openclaw`, `hosts/hermes` —
+  each a `sessions.py`, a spec-sized `cli.py`, and the two guides.
+
+## Consequences
+
+Positive:
+
+- The 0009 claim is now demonstrated: four hosts, zero pipeline forks, and the next host is a
+  `classify` method, two paths, and two markdown files.
+- Concurrent bridging across hosts is safe by construction (disjoint trees), with no locking
+  protocol to get wrong.
+- One instruction text and one CLI surface to improve; all five binaries pick up fixes at once.
+
+Negative / costs:
+
+- Codex's `~/.memu` vs everyone else's `~/.memu/hosts/<host>` is a visible asymmetry, carried
+  for compatibility. A future major release could migrate Codex in.
+- The recall-file mirror is written once per host per run instead of once per machine —
+  redundant disk writes, accepted for isolation.
+- Cursor's inject seam is per project (no global file), so its instruction install is a
+  per-project step the guides must (and do) call out.
+- Host log formats are observed, not contracted. OpenClaw already has a SQLite session target
+  behind a flag; if it becomes the default, that host needs the Hermes treatment. The
+  per-host fixture tests localize such breaks.
+
+## Open issues (deferred)
+
+- **Same-host concurrency.** Two bridging runs of the *same* host still race on that host's
+  tree; scheduled tasks make this unlikely, and per-run lock files remain available if it
+  bites.
+- **IDE-container hosts.** Cursor's Composer history (`state.vscdb`) and any host whose log
+  lives inside an editor's private state would need the SQLite treatment plus a stability
+  story for schema drift; not attempted.
+- **Session-dir env vars.** OpenClaw (`OPENCLAW_STATE_DIR`) and Hermes (`HERMES_HOME`) can
+  relocate their logs; the adapters take `--session-dir` rather than reading the host's env,
+  keeping the contract explicit. The guides say when to pass it.
+
+## Related ADRs
+
+- Builds on `docs/adr/0008-two-integration-surfaces-hooks-and-api.md` — each new host binds
+  the same two seams.
+- Builds on `docs/adr/0009-codex-packaging-cli-and-config.md` — settles its "concurrent
+  hosts" open issue via per-host working trees; keeps its distribution, CLI-command, and
+  config decisions unchanged.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,3 +9,4 @@
 - [0007: Split Memorize/Retrieve into Three Independent Lines on a Layered Wiki-Graph Kernel](0007-three-independent-memory-lines-wiki-graph.md)
 - [0008: Trajectory as the Source — Zero-Code Hooks over a Programmatic API](0008-two-integration-surfaces-hooks-and-api.md)
 - [0009: Packaging the Codex Integration — pip, a CLI Seam, and One Config Loader](0009-codex-packaging-cli-and-config.md)
+- [0010: Multi-Host Adapters — Claude Code, Cursor, OpenClaw, and Hermes](0010-multi-host-adapters.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,12 @@ postgres = ["pgvector>=0.3.4", "sqlalchemy[postgresql-psycopgbinary]>=2.0.36"]
 [project.scripts]
 memu = "memu.cli:main"
 # Host adapters get their own binary rather than a subcommand: `memu` is the
-# algorithm surface, these are sidecars to a desktop agent (ADR 0008/0009).
+# algorithm surface, these are sidecars to a desktop agent (ADR 0008/0009/0010).
 memu-codex = "memu.hosts.codex.cli:main"
+memu-claude-code = "memu.hosts.claude_code.cli:main"
+memu-cursor = "memu.hosts.cursor.cli:main"
+memu-openclaw = "memu.hosts.openclaw.cli:main"
+memu-hermes = "memu.hosts.hermes.cli:main"
 
 [project.urls]
 "Homepage" = "https://github.com/NevaMind-AI/MemU"

--- a/src/memu/hosts/base.py
+++ b/src/memu/hosts/base.py
@@ -58,6 +58,14 @@ class TranscriptSource(ABC):
     def classify(self, record: str) -> RecordKind:
         """Bucket one raw record. This *is* the host's log schema — the real seam."""
 
+    def exists(self) -> bool:
+        """Whether the host has a session log here at all — the prepare gate.
+
+        Directory-shaped hosts get this for free; a host whose log is a single
+        file (Hermes's SQLite store) overrides it to check that file.
+        """
+        return self.root().is_dir()
+
     def discover(self) -> list[Path]:
         """Session files under :meth:`root`, most-recently-modified first.
 

--- a/src/memu/hosts/claude_code/BRIDGING_TASK.md
+++ b/src/memu/hosts/claude_code/BRIDGING_TASK.md
@@ -1,0 +1,85 @@
+---
+name: create-memu-bridging-task
+description: Register a scheduled job that bridges the agent's recent Claude Code sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every day at midnight).
+---
+
+# Create the memU bridging scheduled task (Claude Code)
+
+Use this when the user asks to **set up (or change) the recurring memU
+"bridging" task** — the job that periodically turns what the agent recently did
+in its Claude Code sessions into durable memU memory files, skills, and resource
+records.
+
+Your goal is to **register a recurring headless Claude Code run** whose prompt is
+the three-step pipeline below. You are not running the pipeline now; you are
+registering the schedule that will run it later.
+
+Part of the full setup in `INSTALL.md` (`memu-claude-code docs install`), but
+usable on its own.
+
+## What the bridging task does (context)
+
+1. **Prepare** — `memu-claude-code prepare` scans new turns under
+   `~/.claude/projects` (one JSONL file per session, one directory per project),
+   mirrors the current memU recall files to `~/.memu/hosts/claude-code/memory`
+   and `~/.memu/hosts/claude-code/skill`, snapshots them by content hash, and
+   writes numbered **job-instruction files** to
+   `~/.memu/hosts/claude-code/jobs/` (`1.txt`, `2.txt`, …).
+2. **Self-evolve** — the agent opens each job file **in numeric order** and
+   follows it: mine a session into user **memory**, mine a session into a
+   **skill**, and **describe** the files the sessions touched. "Do nothing" is an
+   allowed, common outcome for any job.
+3. **Commit** — `memu-claude-code commit` diffs the tracked directories against
+   the step-1 snapshot and submits what the agent actually created or changed
+   back to memU.
+
+Only steps 1 and 3 are code. **Step 2 is real agent work**, so the scheduled
+run's prompt must instruct the agent to do it, not shell out to a script.
+
+## Prerequisites
+
+- **memU is installed and `memu-claude-code` is on `PATH`.** Verify with
+  `memu-claude-code doctor`; if it fails, do `INSTALL.md` Part 1 first.
+- **A headless run can execute the pipeline.** The scheduled run invokes
+  `claude -p` non-interactively, so the commands and paths the pipeline touches
+  must be pre-authorized: allow `Bash(memu-claude-code *)` and writes under
+  `~/.memu/` in `~/.claude/settings.json` permissions. Do **not** reach for a
+  blanket permission-skip flag; the pipeline needs exactly those two things.
+
+## Step 1 — settle the schedule
+
+Ask the user for a schedule if the request doesn't include one. **Default: every
+day at midnight**, cron `0 0 * * *` (local time). Confirm before creating.
+
+## Step 2 — register the scheduled run
+
+Create a system cron entry (or launchd job on macOS, if the user prefers) that
+runs Claude Code headless with the pipeline prompt:
+
+```
+0 0 * * * claude -p 'Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. PREPARE. Run this exact command with bash:  memu-claude-code prepare  — it regenerates ~/.memu/hosts/claude-code/jobs/. If the command exits non-zero, stop and report the error.  2. SELF-EVOLVE. List ~/.memu/hosts/claude-code/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  3. COMMIT. Run this exact command with bash:  memu-claude-code commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran and what was committed.'
+```
+
+The prompt block is fixed; only the cron expression is the user's choice. Nothing
+in it is machine-specific — the pipeline is invoked through `PATH` commands.
+
+## Step 3 — confirm
+
+Report back: where the schedule was registered (crontab/launchd), and the cron in
+words (e.g. "daily at 00:00 local time"). Mention that the first run only has
+work to do once there are new Claude Code sessions since the last run.
+
+## Notes
+
+- **Idempotent and incremental.** `prepare` tracks a per-session line cursor in
+  `~/.memu/hosts/claude-code/.session_manifest.claude-code.json`, so each run
+  only processes turns it hasn't seen.
+- **Ordering is load-bearing.** Memory jobs are numbered before skill jobs, and
+  the resource-describe job is last. Always process in ascending numeric order.
+- **The working tree is host-scoped.** Everything under
+  `~/.memu/hosts/claude-code/` is this adapter's run-scoped working state; other
+  memU host adapters (Codex, Cursor, …) have their own and never race with this
+  one. The durable store they all share is the `MEMU_DB` in
+  `~/.memu/config.env`.
+- **Failure handling.** Steps 1 and 3 are the only failure points that should
+  abort the run. A single "do nothing" job in step 2 is normal, not an error.

--- a/src/memu/hosts/claude_code/INSTALL.md
+++ b/src/memu/hosts/claude_code/INSTALL.md
@@ -1,0 +1,153 @@
+# Install memU for Claude Code
+
+> **Audience: the agent.** A user will point you at this file ("follow this guide
+> to install memU"). Work top to bottom. Each part ends with a **verify** gate —
+> do not proceed until the current one passes.
+>
+> Everything on the memU side is a `PATH` command; you should never need to write
+> an absolute path to a script.
+
+Installing memU on Claude Code is three parts:
+
+1. **Install memU** — a Python package, and the store + provider it writes to.
+2. **Register the bridging task** — the scheduled job that turns recent Claude
+   Code sessions into durable memory (the *record* seam).
+3. **Patch `~/.claude/CLAUDE.md`** — a standing instruction that tells you to pull
+   relevant memory before you answer (the *inject* seam).
+
+Parts 2 and 3 must share one store and one embedding space, or a query is
+compared against vectors written elsewhere and retrieval silently returns
+nothing. Part 1 is what makes them agree.
+
+---
+
+## Part 1 — Install memU
+
+memU is distributed as a **pip package**. A Python runtime is required
+regardless, because the bridging task runs Python.
+
+### 1.1 Install
+
+```
+pip install memu-cli
+```
+
+This puts `memu` (the library's own surface) and **`memu-claude-code`** (the
+Claude Code adapter) on `PATH`. Both Part 2 (record) and Part 3 (inject) go
+through `memu-claude-code`.
+
+Confirm it resolves:
+
+```
+memu-claude-code --help
+```
+
+If it is not found, the install landed in an environment that isn't on your
+`PATH`. Fix that now — the scheduled task in Part 2 runs from a bare,
+non-interactive environment and needs this command to resolve there.
+
+### 1.2 Configure the store and provider
+
+memU needs a **database** and an **LLM/embedding provider**. Both seams read this
+one config, so decide it once, here. Collect from the user (or reuse values they
+already have — if another memU host adapter such as `memu-codex` is already set
+up on this machine, `~/.memu/config.env` exists and **must be reused as is**;
+skip to the verify gate):
+
+| Setting | Env var | Example |
+| --- | --- | --- |
+| Database | `MEMU_DB` | `~/.memu/memu.sqlite3`, or a `postgres://…` DSN |
+| Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
+| API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
+
+Write them to **`~/.memu/config.env`**, which every memU command loads. Use an
+**absolute** path for `MEMU_DB`, and `chmod 600` the file (the key is plaintext —
+tell the user). Do **not** instead export these in a shell profile: the scheduled
+task does not inherit your interactive shell.
+
+### ✅ Verify Part 1
+
+```
+memu-claude-code doctor
+```
+
+It prints the store and provider it resolved and runs a smoke-test retrieval. It
+must exit cleanly. **Zero hits is the expected result** on a new store.
+
+---
+
+## Part 2 — Register the bridging (record) task
+
+The *record* seam: a scheduled job that periodically mines recent sessions under
+`~/.claude/projects` into durable memU memory, skills, and resources.
+
+**Do not reinvent this.** Follow the packaged procedure:
+
+```
+memu-claude-code docs task
+```
+
+It is authoritative. In summary: you will settle a schedule with the user
+(default: daily at midnight) and register a recurring headless Claude Code run —
+via system cron or launchd invoking `claude -p "<the prompt that document gives
+you verbatim>"` — that runs `memu-claude-code prepare`, works through
+`~/.memu/hosts/claude-code/jobs/*.txt` in order, then runs
+`memu-claude-code commit`.
+
+Nothing in that prompt is machine-specific. If you find yourself substituting an
+absolute path into it, you are doing it wrong.
+
+### ✅ Verify Part 2
+
+Confirm the cron/launchd entry exists. Then dry-run the first step by hand:
+
+```
+memu-claude-code prepare
+```
+
+It should report how many sessions it prepared (zero, if there is nothing new
+since the cursor — that is fine and correct).
+
+---
+
+## Part 3 — Patch `~/.claude/CLAUDE.md` with the retrieval instruction
+
+The *inject* seam: a standing instruction in Claude Code's **global memory file**
+telling you to pull relevant memory before you answer. Claude Code loads
+`~/.claude/CLAUDE.md` into every session in every project, so the instruction is
+simply always there — no hook, no wrapper, no per-turn process.
+
+**Do not hand-write the instruction.** memU owns the text and installs it for you:
+
+```
+memu-claude-code install-instruction
+```
+
+It writes memU's block into `~/.claude/CLAUDE.md`, creating the file if it does
+not exist, and prints the diff. It appends rather than overwrites (existing
+content is backed up to `~/.claude/CLAUDE.md.bak`), and it is idempotent: the
+text sits in a marked block that a re-run — or a later memU release — replaces in
+place. `--dry-run` shows the diff without writing; `--print` prints just the
+block.
+
+### ✅ Verify Part 3
+
+```
+cat ~/.claude/CLAUDE.md
+memu-claude-code retrieve "smoke test"
+```
+
+The memU block must appear exactly once, anything the user had there must be
+intact, and `retrieve` must exit cleanly (empty result lists are fine). A *fresh*
+Claude Code session is what picks up the new CLAUDE.md — do not be surprised that
+the instruction is not in your own context yet.
+
+---
+
+## Done
+
+Report back to the user: the store (`MEMU_DB`) and provider in use; the scheduled
+job and its schedule in words; and that the retrieval instruction is now in
+`~/.claude/CLAUDE.md`, taking effect in their next session. Record and inject
+both read `~/.memu/config.env`, so they provably share one store — what the task
+learns tonight is what retrieval finds tomorrow.

--- a/src/memu/hosts/claude_code/__init__.py
+++ b/src/memu/hosts/claude_code/__init__.py
@@ -1,0 +1,11 @@
+"""The Claude Code host adapter — ``memu-claude-code``.
+
+Binds ADR 0008's two seams onto Claude Code: *record* as a scheduled bridging
+task over ``~/.claude/projects`` (see :mod:`memu.hosts.bridging`), *inject* as a
+standing instruction in ``~/.claude/CLAUDE.md`` that points the agent at the
+``memu-claude-code retrieve`` command.
+"""
+
+from memu.hosts.claude_code.sessions import ClaudeCodeTranscriptSource
+
+__all__ = ["ClaudeCodeTranscriptSource"]

--- a/src/memu/hosts/claude_code/cli.py
+++ b/src/memu/hosts/claude_code/cli.py
@@ -1,0 +1,47 @@
+"""``memu-claude-code`` — the Claude Code host adapter's command-line surface.
+
+The verbs are the shared host-adapter surface (:mod:`memu.hosts.host_cli`); this
+module is the Claude Code declaration: where its sessions live, and which file
+its standing instruction lands in.
+
+Usage:
+    memu-claude-code retrieve "<query>"    # the inject seam — what the agent runs each turn
+    memu-claude-code install-instruction   # the inject seam — patch ~/.claude/CLAUDE.md to run it
+    memu-claude-code prepare               # slice new sessions into job files
+    memu-claude-code verify-resources      # filter the touched-file log (run by a job)
+    memu-claude-code commit                # submit what the agent produced back to memU
+    memu-claude-code doctor                # check config + store before relying on them
+    memu-claude-code docs install          # print the agent-facing install guide
+"""
+
+from __future__ import annotations
+
+import sys
+
+from memu.hosts.claude_code.sessions import SESSION_DIR, ClaudeCodeTranscriptSource
+from memu.hosts.host_cli import HostSpec, run
+
+HOST = "claude-code"
+
+CLAUDE_MD = "~/.claude/CLAUDE.md"
+"""Claude Code's global memory file — loaded into every session across every
+project, so the inject seam lands here. (Project-level CLAUDE.md files exist too,
+but the instruction belongs at the level retrieval works at: the user.)"""
+
+SPEC = HostSpec(
+    host=HOST,
+    display="Claude Code",
+    package="memu.hosts.claude_code",
+    source_factory=ClaudeCodeTranscriptSource,
+    session_dir=SESSION_DIR,
+    session_help="Claude Code session log (one project dir per escaped cwd)",
+    instruction_path=CLAUDE_MD,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run(SPEC, argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/memu/hosts/claude_code/sessions.py
+++ b/src/memu/hosts/claude_code/sessions.py
@@ -62,7 +62,9 @@ class ClaudeCodeTranscriptSource(TranscriptSource):
             # are harness-injected context wearing the user role.
             return RecordKind.OTHER if entry.get("isMeta") else RecordKind.MESSAGE
 
-        kinds = {block.get("type") for block in content if isinstance(block, dict)} if isinstance(content, list) else set()
+        kinds = (
+            {block.get("type") for block in content if isinstance(block, dict)} if isinstance(content, list) else set()
+        )
         if "text" in kinds:
             return RecordKind.OTHER if entry.get("isMeta") else RecordKind.MESSAGE
         if kinds & {"tool_use", "tool_result"}:

--- a/src/memu/hosts/claude_code/sessions.py
+++ b/src/memu/hosts/claude_code/sessions.py
@@ -1,0 +1,70 @@
+"""Claude Code's session log: ``~/.claude/projects/<escaped-cwd>/*.jsonl``.
+
+The whole of what makes this host Claude Code. Everything the bridging task does
+with these records is host-agnostic and lives in :mod:`memu.hosts.bridging`.
+
+Claude Code keeps one directory per project — the project's absolute path with
+``/`` flattened to ``-`` (``/Users/a/proj`` → ``-Users-a-proj``) — and one JSONL
+file per session inside it, named by the session UUID. Subagent transcripts land
+in a sibling subdirectory per session and are picked up by the same recursive
+glob.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import ClassVar
+
+from memu.hosts.base import RecordKind, TranscriptSource
+
+SESSION_DIR = "~/.claude/projects"
+
+
+class ClaudeCodeTranscriptSource(TranscriptSource):
+    """Claude Code writes one JSON object per line, one content block per record.
+
+    A record whose ``type`` is ``user`` or ``assistant`` wraps an API-shaped
+    ``message``; its single content block says what the record is. ``text`` (or a
+    plain-string user message) is a conversation turn; ``tool_use`` and
+    ``tool_result`` are the tool record and its output — Claude Code logs the
+    result as a *user*-typed record, so the role alone cannot classify. Everything
+    else — ``thinking`` blocks, meta-injected user records (``isMeta``), and the
+    non-message types (``queue-operation``, ``attachment``, ``system``,
+    ``pr-link``, ``last-prompt``, ``summary``) — is noise the mining jobs should
+    never see.
+    """
+
+    name: ClassVar[str] = "claude-code"
+
+    def __init__(self, session_dir: str | Path = SESSION_DIR) -> None:
+        self._root = Path(os.path.expanduser(str(session_dir)))
+
+    def root(self) -> Path:
+        return self._root
+
+    def classify(self, record: str) -> RecordKind:
+        try:
+            entry = json.loads(record)
+        except json.JSONDecodeError:
+            return RecordKind.OTHER
+        if not isinstance(entry, dict) or entry.get("type") not in ("user", "assistant"):
+            return RecordKind.OTHER
+
+        message = entry.get("message")
+        if not isinstance(message, dict):
+            return RecordKind.OTHER
+
+        content = message.get("content")
+        if isinstance(content, str):
+            # A raw-string user message is the user actually typing; meta records
+            # are harness-injected context wearing the user role.
+            return RecordKind.OTHER if entry.get("isMeta") else RecordKind.MESSAGE
+
+        kinds = {block.get("type") for block in content if isinstance(block, dict)} if isinstance(content, list) else set()
+        if "text" in kinds:
+            return RecordKind.OTHER if entry.get("isMeta") else RecordKind.MESSAGE
+        if kinds & {"tool_use", "tool_result"}:
+            return RecordKind.TOOL
+        return RecordKind.OTHER

--- a/src/memu/hosts/codex/cli.py
+++ b/src/memu/hosts/codex/cli.py
@@ -10,6 +10,9 @@ scheduled bridging task embeds these command strings in its recurring prompt, an
 a command survives the reinstalls and directory moves that a baked-in
 ``<VENV_PYTHON> /abs/path/to/script.py`` pair does not (ADR 0009).
 
+The verbs themselves are shared across every host adapter and live in
+:mod:`memu.hosts.host_cli`; this module is the Codex declaration.
+
 Usage:
     memu-codex retrieve "<query>"    # the inject seam — what the agent runs each turn
     memu-codex install-instruction   # the inject seam — patch ~/.codex/AGENTS.md to run it
@@ -23,18 +26,10 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import asyncio
-import os
 import sys
-from collections.abc import Callable, Coroutine
-from importlib.resources import files
-from typing import Any
 
-from memu.hosts import instruction, retrieval
-from memu.hosts.bridging import Layout, commit, prepare
-from memu.hosts.bridging.pipeline import MAX_JOBS
-from memu.hosts.bridging.resources import verify_resource_log
 from memu.hosts.codex.sessions import SESSION_DIR, CodexTranscriptSource
+from memu.hosts.host_cli import HostSpec, run
 
 HOST = "codex"
 
@@ -45,122 +40,28 @@ AGENTS_MD = "~/.codex/AGENTS.md"
 """Codex's global instruction file — loaded into every session, so the inject seam
 lands here. The path is the only part of that seam that is Codex-specific."""
 
-DOCS = {"install": "INSTALL.md", "task": "BRIDGING_TASK.md"}
-
-
-def _layout(args: argparse.Namespace) -> Layout:
-    return Layout.default(host=HOST, base=args.base_dir)
-
-
-async def _cmd_prepare(args: argparse.Namespace) -> int:
-    source = CodexTranscriptSource(args.session_dir)
-    if not source.root().is_dir():
-        print(f"error: no Codex session log at {source.root()}", file=sys.stderr)
-        return 2
-
-    layout = _layout(args)
-    num_sessions = await prepare(source, layout, verify_command=VERIFY_COMMAND, max_jobs=args.max_jobs)
-    num_jobs = 2 * num_sessions + 1
-    print(f"prepared {num_sessions} session(s) -> {num_jobs} job(s) in {layout.jobs}")
-    if num_sessions == 0:
-        print("no new session turns since the last run; nothing to mine")
-    return 0
-
-
-async def _cmd_commit(args: argparse.Namespace) -> int:
-    result = await commit(_layout(args))
-    recall_files = result.get("recall_files", [])
-    resources = result.get("resources", [])
-    if not recall_files and not resources:
-        print("nothing to commit")
-        return 0
-    print(f"committed {len(recall_files)} recall file(s) and {len(resources)} resource(s)")
-    for recall_file in recall_files:
-        print(f"  - {recall_file.get('track')}/{recall_file.get('name')}")
-    return 0
-
-
-async def _cmd_verify_resources(args: argparse.Namespace) -> int:
-    layout = _layout(args)
-    kept = verify_resource_log(layout.resource_log, layout.resources)
-    print(f"{kept} resource(s) written to {layout.resources}")
-    return 0
-
-
-async def _cmd_doctor(args: argparse.Namespace) -> int:
-    """Prove config resolves and the store answers — the install guide's verify gate.
-
-    Deliberately exercises the same call the inject hook will, so a green doctor
-    means the hook's retrieval works, not merely that some store opened.
-    """
-    from memu.env import CONFIG_ENV, embedding_provider, env
-
-    result = await retrieval.retrieve("smoke test")
-    found = sum(len(result.get(layer, [])) for layer in ("segments", "files", "resources"))
-    print(f"config    {os.path.expanduser(CONFIG_ENV)}")
-    print(f"store     {env('MEMU_DB')}")
-    print(f"provider  {embedding_provider()}")
-    print(f"retrieval ok ({found} hit(s) for a smoke-test query; 0 is fine on a new store)")
-    return 0
-
-
-async def _cmd_docs(args: argparse.Namespace) -> int:
-    print((files("memu.hosts.codex") / DOCS[args.doc]).read_text(encoding="utf-8"))
-    return 0
+SPEC = HostSpec(
+    host=HOST,
+    display="Codex",
+    package="memu.hosts.codex",
+    source_factory=CodexTranscriptSource,
+    session_dir=SESSION_DIR,
+    session_help="Codex session log",
+    instruction_path=AGENTS_MD,
+    # Codex shipped before per-host working trees; its ~/.memu layout is a
+    # compatibility contract with already-scheduled bridging prompts (ADR 0010).
+    base_dir="~/.memu",
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="memu-codex",
-        description="memU's Codex host adapter — the scheduled bridging task and its install guide.",
-    )
-    sub = parser.add_subparsers(dest="command", required=True)
+    from memu.hosts.host_cli import build_parser as _build
 
-    def with_base(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
-        p.add_argument("--base-dir", default="~/.memu", help="memU working directory (default: ~/.memu)")
-        return p
-
-    # Both halves of the inject seam: what the agent runs, and what tells it to.
-    # Shared across hosts, so they are registered, not redefined — only the file
-    # the instruction lands in is ours to name.
-    retrieval.register(sub)
-    instruction.register(sub, path=AGENTS_MD)
-
-    p = with_base(sub.add_parser("prepare", help="Slice new Codex sessions into self-evolve job files"))
-    p.add_argument("--session-dir", default=SESSION_DIR, help=f"Codex session log (default: {SESSION_DIR})")
-    p.add_argument("--max-jobs", type=int, default=MAX_JOBS, help=f"Sessions per run (default: {MAX_JOBS})")
-    p.set_defaults(handler=_cmd_prepare)
-
-    p = with_base(sub.add_parser("commit", help="Submit what the self-evolve jobs produced back into memU"))
-    p.set_defaults(handler=_cmd_commit)
-
-    p = with_base(
-        sub.add_parser("verify-resources", help="Filter the touched-file log into the describe-me resource file")
-    )
-    p.set_defaults(handler=_cmd_verify_resources)
-
-    p = sub.add_parser("doctor", help="Verify MEMU_* config resolves and the store is reachable")
-    p.set_defaults(handler=_cmd_doctor)
-
-    p = sub.add_parser("docs", help="Print a packaged agent-facing guide")
-    p.add_argument("doc", choices=sorted(DOCS), help="install: the setup guide; task: the bridging-task procedure")
-    p.set_defaults(handler=_cmd_docs)
-
-    return parser
+    return _build(SPEC)
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
-    handler: Callable[[argparse.Namespace], Coroutine[Any, Any, int]] = args.handler
-    try:
-        return asyncio.run(handler(args))
-    except KeyboardInterrupt:
-        return 130
-    except Exception as exc:
-        if os.environ.get("MEMU_DEBUG") == "1":
-            raise
-        print(f"error: {exc} (set MEMU_DEBUG=1 for a traceback)", file=sys.stderr)
-        return 1
+    return run(SPEC, argv)
 
 
 if __name__ == "__main__":

--- a/src/memu/hosts/cursor/BRIDGING_TASK.md
+++ b/src/memu/hosts/cursor/BRIDGING_TASK.md
@@ -1,0 +1,80 @@
+---
+name: create-memu-bridging-task
+description: Register a scheduled job that bridges the agent's recent Cursor agent sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every day at midnight).
+---
+
+# Create the memU bridging scheduled task (Cursor)
+
+Use this when the user asks to **set up (or change) the recurring memU
+"bridging" task** — the job that periodically turns what the agent recently did
+in its Cursor agent sessions into durable memU memory files, skills, and
+resource records.
+
+Your goal is to **register a recurring headless Cursor agent run** whose prompt
+is the three-step pipeline below. You are not running the pipeline now.
+
+Part of the full setup in `INSTALL.md` (`memu-cursor docs install`), but usable
+on its own.
+
+## What the bridging task does (context)
+
+1. **Prepare** — `memu-cursor prepare` scans new turns under
+   `~/.cursor/projects/*/agent-transcripts/` (one JSONL transcript per agent
+   session), mirrors the current memU recall files to
+   `~/.memu/hosts/cursor/memory` and `~/.memu/hosts/cursor/skill`, snapshots
+   them by content hash, and writes numbered **job-instruction files** to
+   `~/.memu/hosts/cursor/jobs/` (`1.txt`, `2.txt`, …).
+2. **Self-evolve** — the agent opens each job file **in numeric order** and
+   follows it: mine a session into user **memory**, mine a session into a
+   **skill**, and **describe** the files the sessions touched. "Do nothing" is
+   an allowed, common outcome for any job.
+3. **Commit** — `memu-cursor commit` diffs the tracked directories against the
+   step-1 snapshot and submits what the agent actually created or changed back
+   to memU.
+
+Only steps 1 and 3 are code. **Step 2 is real agent work**, so the scheduled
+run's prompt must instruct the agent to do it, not shell out to a script.
+
+## Prerequisites
+
+- **memU is installed and `memu-cursor` is on `PATH`.** Verify with
+  `memu-cursor doctor`; if it fails, do `INSTALL.md` Part 1 first.
+- **`cursor-agent` runs headless.** The scheduled entry invokes
+  `cursor-agent -p` non-interactively with permission to run `memu-cursor` and
+  write under `~/.memu/`.
+
+## Step 1 — settle the schedule
+
+Ask the user for a schedule if the request doesn't include one. **Default: every
+day at midnight**, cron `0 0 * * *` (local time). Confirm before creating.
+
+## Step 2 — register the scheduled run
+
+Create a system cron entry (or launchd job on macOS, if the user prefers)
+running:
+
+```
+0 0 * * * cursor-agent -p 'Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. PREPARE. Run this exact command with bash:  memu-cursor prepare  — it regenerates ~/.memu/hosts/cursor/jobs/. If the command exits non-zero, stop and report the error.  2. SELF-EVOLVE. List ~/.memu/hosts/cursor/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  3. COMMIT. Run this exact command with bash:  memu-cursor commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran and what was committed.'
+```
+
+The prompt block is fixed; only the cron expression is the user's choice. Nothing
+in it is machine-specific — the pipeline is invoked through `PATH` commands.
+
+## Step 3 — confirm
+
+Report back: where the schedule was registered, and the cron in words. Mention
+that the first run only has work to do once there are new Cursor agent sessions
+since the last run.
+
+## Notes
+
+- **Idempotent and incremental.** `prepare` tracks a per-session line cursor in
+  `~/.memu/hosts/cursor/.session_manifest.cursor.json`.
+- **Ordering is load-bearing.** Memory jobs before skill jobs, the
+  resource-describe job last. Always ascending numeric order.
+- **The working tree is host-scoped.** Everything under `~/.memu/hosts/cursor/`
+  is this adapter's run-scoped working state; other memU host adapters never
+  race with it. The durable store they all share is the `MEMU_DB` in
+  `~/.memu/config.env`.
+- **Failure handling.** Steps 1 and 3 are the only failure points that should
+  abort the run. A "do nothing" job in step 2 is normal, not an error.

--- a/src/memu/hosts/cursor/INSTALL.md
+++ b/src/memu/hosts/cursor/INSTALL.md
@@ -1,0 +1,126 @@
+# Install memU for Cursor
+
+> **Audience: the agent.** A user will point you at this file ("follow this guide
+> to install memU"). Work top to bottom. Each part ends with a **verify** gate —
+> do not proceed until the current one passes.
+>
+> Everything on the memU side is a `PATH` command; you should never need to write
+> an absolute path to a script.
+
+Installing memU on Cursor is three parts:
+
+1. **Install memU** — a Python package, and the store + provider it writes to.
+2. **Register the bridging task** — the scheduled job that turns recent Cursor
+   agent sessions into durable memory (the *record* seam).
+3. **Patch `AGENTS.md`** — a standing instruction that tells the agent to pull
+   relevant memory before answering (the *inject* seam).
+
+Parts 2 and 3 must share one store and one embedding space, or a query is
+compared against vectors written elsewhere and retrieval silently returns
+nothing. Part 1 is what makes them agree.
+
+**Scope note.** This adapter reads the **Cursor Agent** transcripts under
+`~/.cursor/projects/` — the CLI (`cursor-agent`) and background agents. The IDE's
+Composer chat history lives inside the editor's own SQLite state (`state.vscdb`)
+and is not mined.
+
+---
+
+## Part 1 — Install memU
+
+```
+pip install memu-cli
+```
+
+This puts `memu` and **`memu-cursor`** on `PATH`. Confirm: `memu-cursor --help`.
+If it is not found, fix `PATH` now — the scheduled task in Part 2 runs from a
+bare, non-interactive environment.
+
+### 1.2 Configure the store and provider
+
+memU needs a **database** and an **LLM/embedding provider**. Both seams read this
+one config. If another memU host adapter is already set up on this machine,
+`~/.memu/config.env` exists and **must be reused as is**; skip to the verify
+gate. Otherwise collect from the user:
+
+| Setting | Env var | Example |
+| --- | --- | --- |
+| Database | `MEMU_DB` | `~/.memu/memu.sqlite3`, or a `postgres://…` DSN |
+| Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
+| API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
+
+Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
+never a shell-profile export — the scheduled task does not inherit your shell).
+
+### ✅ Verify Part 1
+
+```
+memu-cursor doctor
+```
+
+Must exit cleanly. Zero hits on the smoke-test retrieval is expected on a new
+store.
+
+---
+
+## Part 2 — Register the bridging (record) task
+
+The *record* seam: a scheduled job that mines recent transcripts under
+`~/.cursor/projects/*/agent-transcripts/` into durable memU memory, skills, and
+resources. **Do not reinvent this** — follow the packaged procedure:
+
+```
+memu-cursor docs task
+```
+
+In summary: settle a schedule with the user (default: daily at midnight) and
+register a cron entry that runs `cursor-agent -p "<the prompt that document gives
+you verbatim>"` — the prompt runs `memu-cursor prepare`, works through
+`~/.memu/hosts/cursor/jobs/*.txt` in order, then `memu-cursor commit`. Nothing in
+it is machine-specific.
+
+### ✅ Verify Part 2
+
+Confirm the cron entry exists, then dry-run: `memu-cursor prepare` (zero prepared
+sessions is fine and correct when nothing is new).
+
+---
+
+## Part 3 — Patch `AGENTS.md` with the retrieval instruction
+
+The *inject* seam. Cursor's Agent reads `AGENTS.md` from the **project root** —
+there is no global user-level instruction file the CLI honors (the IDE's User
+Rules live in editor settings, out of reach here). So the instruction is
+installed **per project**:
+
+```
+cd <the project> && memu-cursor install-instruction
+```
+
+It writes memU's block into `./AGENTS.md`, creating the file if absent, and
+prints the diff. It appends rather than overwrites (existing content is backed up
+to `AGENTS.md.bak`), and it is idempotent: the text sits in a marked block that a
+re-run — or a later memU release — replaces in place. `--dry-run` shows the diff
+without writing; `--path` targets another file.
+
+Repeat for each project that should retrieve from memU, and tell the user that a
+new project needs this one command run once.
+
+### ✅ Verify Part 3
+
+```
+cat AGENTS.md
+memu-cursor retrieve "smoke test"
+```
+
+The memU block must appear exactly once, prior content intact, and `retrieve`
+must exit cleanly (empty lists are fine). A fresh Cursor session picks up the new
+AGENTS.md.
+
+---
+
+## Done
+
+Report back to the user: the store and provider in use; the scheduled job and its
+schedule in words; which projects got the `AGENTS.md` instruction. Record and
+inject both read `~/.memu/config.env`, so they provably share one store.

--- a/src/memu/hosts/cursor/__init__.py
+++ b/src/memu/hosts/cursor/__init__.py
@@ -1,0 +1,11 @@
+"""The Cursor host adapter — ``memu-cursor``.
+
+Binds ADR 0008's two seams onto Cursor: *record* as a scheduled bridging task
+over ``~/.cursor/projects/*/agent-transcripts`` (see :mod:`memu.hosts.bridging`),
+*inject* as a standing instruction in the project's ``AGENTS.md`` that points the
+agent at the ``memu-cursor retrieve`` command.
+"""
+
+from memu.hosts.cursor.sessions import CursorTranscriptSource
+
+__all__ = ["CursorTranscriptSource"]

--- a/src/memu/hosts/cursor/cli.py
+++ b/src/memu/hosts/cursor/cli.py
@@ -1,0 +1,48 @@
+"""``memu-cursor`` — the Cursor host adapter's command-line surface.
+
+The verbs are the shared host-adapter surface (:mod:`memu.hosts.host_cli`); this
+module is the Cursor declaration: where its agent transcripts live, and which
+file its standing instruction lands in.
+
+Usage:
+    memu-cursor retrieve "<query>"    # the inject seam — what the agent runs each turn
+    memu-cursor install-instruction   # the inject seam — patch AGENTS.md to run it
+    memu-cursor prepare               # slice new sessions into job files
+    memu-cursor verify-resources      # filter the touched-file log (run by a job)
+    memu-cursor commit                # submit what the agent produced back to memU
+    memu-cursor doctor                # check config + store before relying on them
+    memu-cursor docs install          # print the agent-facing install guide
+"""
+
+from __future__ import annotations
+
+import sys
+
+from memu.hosts.cursor.sessions import SESSION_DIR, CursorTranscriptSource
+from memu.hosts.host_cli import HostSpec, run
+
+HOST = "cursor"
+
+AGENTS_MD = "./AGENTS.md"
+"""Cursor has no global user-level instruction *file* (User Rules are IDE
+settings, out of a CLI's reach) — its Agent reads ``AGENTS.md`` from the project
+root. So the inject seam is per project: run ``install-instruction`` inside each
+project that should retrieve from memU, or pass ``--path``."""
+
+SPEC = HostSpec(
+    host=HOST,
+    display="Cursor",
+    package="memu.hosts.cursor",
+    source_factory=CursorTranscriptSource,
+    session_dir=SESSION_DIR,
+    session_help="Cursor agent-transcript root (one project dir per escaped cwd)",
+    instruction_path=AGENTS_MD,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run(SPEC, argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/memu/hosts/cursor/sessions.py
+++ b/src/memu/hosts/cursor/sessions.py
@@ -1,0 +1,74 @@
+"""Cursor's agent transcripts: ``~/.cursor/projects/<escaped-cwd>/agent-transcripts/<id>/<id>.jsonl``.
+
+The whole of what makes this host Cursor. Everything the bridging task does with
+these records is host-agnostic and lives in :mod:`memu.hosts.bridging`.
+
+This is the **Cursor Agent** log (the CLI and background agents) — one directory
+per project (the project's absolute path with ``/`` flattened to ``-``), one
+transcript directory per session under ``agent-transcripts/``. The IDE's Composer
+chats live elsewhere, inside the editor's ``state.vscdb`` SQLite state, and are
+not read here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import ClassVar
+
+from memu.hosts.base import RecordKind, TranscriptSource
+
+SESSION_DIR = "~/.cursor/projects"
+
+
+class CursorTranscriptSource(TranscriptSource):
+    """Cursor writes one JSON object per line: ``{"role": …, "message": {"content": […]}}``.
+
+    A record is a conversation turn when its content carries a ``text`` block
+    (user queries, and the assistant's prose — which often shares a record with
+    the ``tool_use`` blocks it narrates), and a tool record when it carries only
+    ``tool_use``/``tool_result`` blocks. Records carry no timestamps, so the
+    cursor manifest records ``null`` there — the line count alone drives
+    incremental scans.
+    """
+
+    name: ClassVar[str] = "cursor"
+
+    def __init__(self, session_dir: str | Path = SESSION_DIR) -> None:
+        self._root = Path(os.path.expanduser(str(session_dir)))
+
+    def root(self) -> Path:
+        return self._root
+
+    def discover(self) -> list[Path]:
+        """Only ``agent-transcripts`` JSONL files — the project dirs also hold
+        canvases, terminal logs, and whatever Cursor adds next."""
+        root = self.root()
+        if not root.is_dir():
+            return []
+        files = [path for path in root.glob("*/agent-transcripts/**/*.jsonl") if path.is_file()]
+        files.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+        return files
+
+    def classify(self, record: str) -> RecordKind:
+        try:
+            entry = json.loads(record)
+        except json.JSONDecodeError:
+            return RecordKind.OTHER
+        if not isinstance(entry, dict) or entry.get("role") not in ("user", "assistant"):
+            return RecordKind.OTHER
+
+        message = entry.get("message")
+        content = message.get("content") if isinstance(message, dict) else None
+        if isinstance(content, str):
+            return RecordKind.MESSAGE
+        if not isinstance(content, list):
+            return RecordKind.OTHER
+
+        kinds = {block.get("type") for block in content if isinstance(block, dict)}
+        if "text" in kinds:
+            return RecordKind.MESSAGE
+        if kinds & {"tool_use", "tool_result"}:
+            return RecordKind.TOOL
+        return RecordKind.OTHER

--- a/src/memu/hosts/hermes/BRIDGING_TASK.md
+++ b/src/memu/hosts/hermes/BRIDGING_TASK.md
@@ -1,0 +1,83 @@
+---
+name: create-memu-bridging-task
+description: Register a scheduled job that bridges the agent's recent Hermes sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every day at midnight).
+---
+
+# Create the memU bridging scheduled task (Hermes)
+
+Use this when the user asks to **set up (or change) the recurring memU
+"bridging" task** — the job that periodically turns what the agent recently did
+in its Hermes sessions into durable memU memory files, skills, and resource
+records.
+
+Your goal is to **register a recurring headless Hermes run** whose prompt is the
+three-step pipeline below. You are not running the pipeline now.
+
+Part of the full setup in `INSTALL.md` (`memu-hermes docs install`), but usable
+on its own.
+
+## What the bridging task does (context)
+
+1. **Prepare** — `memu-hermes prepare` scans new message rows in
+   `~/.hermes/state.db` (read-only; sessions ordered by recent activity),
+   mirrors the current memU recall files to `~/.memu/hosts/hermes/memory` and
+   `~/.memu/hosts/hermes/skill`, snapshots them by content hash, and writes
+   numbered **job-instruction files** to `~/.memu/hosts/hermes/jobs/` (`1.txt`,
+   `2.txt`, …).
+2. **Self-evolve** — the agent opens each job file **in numeric order** and
+   follows it: mine a session into user **memory**, mine a session into a
+   **skill**, and **describe** the files the sessions touched. "Do nothing" is
+   an allowed, common outcome for any job.
+3. **Commit** — `memu-hermes commit` diffs the tracked directories against the
+   step-1 snapshot and submits what the agent actually created or changed back
+   to memU.
+
+Only steps 1 and 3 are code. **Step 2 is real agent work**, so the scheduled
+run's prompt must instruct the agent to do it, not shell out to a script.
+
+## Prerequisites
+
+- **memU is installed and `memu-hermes` is on `PATH`.** Verify with
+  `memu-hermes doctor`; if it fails, do `INSTALL.md` Part 1 first.
+- **Hermes runs headless from cron** with permission to run `memu-hermes` and
+  write under `~/.memu/`. If Hermes uses a non-default `HERMES_HOME`, the cron
+  environment must export it and the prompt's prepare step must pass
+  `--session-dir "$HERMES_HOME/state.db"`.
+
+## Step 1 — settle the schedule
+
+Ask the user for a schedule if the request doesn't include one. **Default: every
+day at midnight**, cron `0 0 * * *` (local time). Confirm before creating.
+
+## Step 2 — register the scheduled run
+
+Create a system cron entry that runs Hermes headless with the pipeline prompt:
+
+```
+0 0 * * * hermes -p 'Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. PREPARE. Run this exact command with the shell tool:  memu-hermes prepare  — it regenerates ~/.memu/hosts/hermes/jobs/. If the command exits non-zero, stop and report the error.  2. SELF-EVOLVE. List ~/.memu/hosts/hermes/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  3. COMMIT. Run this exact command with the shell tool:  memu-hermes commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran and what was committed.'
+```
+
+(Adjust the headless invocation to the Hermes CLI the user runs, but keep the
+prompt block verbatim.) Nothing in it is machine-specific — the pipeline is
+invoked through `PATH` commands.
+
+## Step 3 — confirm
+
+Report back: where the schedule was registered, and the cron in words. Mention
+that the first run only has work to do once there are new Hermes sessions since
+the last run.
+
+## Notes
+
+- **Idempotent and incremental.** `prepare` tracks a per-session message-count
+  cursor in `~/.memu/hosts/hermes/.session_manifest.hermes.json`, keyed by
+  session id — messages are append-only per session, so the count-cursor is
+  exactly the line cursor the other hosts use.
+- **Ordering is load-bearing.** Memory jobs before skill jobs, the
+  resource-describe job last. Always ascending numeric order.
+- **The working tree is host-scoped.** Everything under `~/.memu/hosts/hermes/`
+  is this adapter's run-scoped working state; other memU host adapters never
+  race with it. The durable store they all share is the `MEMU_DB` in
+  `~/.memu/config.env`.
+- **Failure handling.** Steps 1 and 3 are the only failure points that should
+  abort the run. A "do nothing" job in step 2 is normal, not an error.

--- a/src/memu/hosts/hermes/INSTALL.md
+++ b/src/memu/hosts/hermes/INSTALL.md
@@ -1,0 +1,128 @@
+# Install memU for Hermes Agent
+
+> **Audience: the agent.** A user will point you at this file ("follow this guide
+> to install memU"). Work top to bottom. Each part ends with a **verify** gate —
+> do not proceed until the current one passes.
+>
+> Everything on the memU side is a `PATH` command; you should never need to write
+> an absolute path to a script.
+
+Installing memU on Hermes is three parts:
+
+1. **Install memU** — a Python package, and the store + provider it writes to.
+2. **Register the bridging task** — the scheduled job that turns recent Hermes
+   sessions into durable memory (the *record* seam).
+3. **Patch `~/.hermes/SOUL.md`** — a standing instruction that tells the agent to
+   pull relevant memory before answering (the *inject* seam).
+
+Parts 2 and 3 must share one store and one embedding space, or a query is
+compared against vectors written elsewhere and retrieval silently returns
+nothing. Part 1 is what makes them agree.
+
+**Scope note.** This adapter reads Hermes's SQLite session store —
+`~/.hermes/state.db` (the `sessions` and `messages` tables), opened read-only so
+it never contends with the gateway's writer. If this install runs a non-default
+home (`HERMES_HOME`, or a profile), pass `--session-dir <home>/state.db` to
+`prepare`. The manual snapshots under `~/.hermes/sessions/saved/` are not mined.
+
+---
+
+## Part 1 — Install memU
+
+```
+pip install memu-cli
+```
+
+This puts `memu` and **`memu-hermes`** on `PATH`. Confirm: `memu-hermes --help`.
+If it is not found, fix `PATH` now — the scheduled task in Part 2 runs from a
+bare, non-interactive environment.
+
+### 1.2 Configure the store and provider
+
+memU needs a **database** and an **LLM/embedding provider**. Both seams read this
+one config. If another memU host adapter is already set up on this machine,
+`~/.memu/config.env` exists and **must be reused as is**; skip to the verify
+gate. Otherwise collect from the user:
+
+| Setting | Env var | Example |
+| --- | --- | --- |
+| Database | `MEMU_DB` | `~/.memu/memu.sqlite3`, or a `postgres://…` DSN |
+| Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
+| API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
+
+Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
+never a shell-profile export — the scheduled task does not inherit your shell).
+
+### ✅ Verify Part 1
+
+```
+memu-hermes doctor
+```
+
+Must exit cleanly. Zero hits on the smoke-test retrieval is expected on a new
+store.
+
+---
+
+## Part 2 — Register the bridging (record) task
+
+The *record* seam: a scheduled job that mines recent sessions out of
+`~/.hermes/state.db` into durable memU memory, skills, and resources. **Do not
+reinvent this** — follow the packaged procedure:
+
+```
+memu-hermes docs task
+```
+
+In summary: settle a schedule with the user (default: daily at midnight) and
+register a recurring headless Hermes run — via system cron invoking `hermes`
+non-interactively with the prompt that document gives you verbatim — that runs
+`memu-hermes prepare`, works through `~/.memu/hosts/hermes/jobs/*.txt` in order,
+then `memu-hermes commit`. Nothing in it is machine-specific.
+
+### ✅ Verify Part 2
+
+Confirm the cron entry exists, then dry-run: `memu-hermes prepare` (zero prepared
+sessions is fine and correct when nothing is new).
+
+---
+
+## Part 3 — Patch `~/.hermes/SOUL.md` with the retrieval instruction
+
+The *inject* seam: a standing instruction in Hermes's **SOUL.md** telling the
+agent to pull relevant memory before answering. SOUL.md is the one file Hermes
+loads from `HERMES_HOME` into every session regardless of working directory, so
+the instruction is simply always there. (Project-level `.hermes.md`/`AGENTS.md`
+files would miss sessions started elsewhere.)
+
+**Do not hand-write the instruction.** memU owns the text and installs it:
+
+```
+memu-hermes install-instruction
+```
+
+It writes memU's block into `~/.hermes/SOUL.md`, creating the file if absent, and
+prints the diff. It appends rather than overwrites (existing content is backed up
+to `SOUL.md.bak`), and it is idempotent: the text sits in a marked block that a
+re-run — or a later memU release — replaces in place. `--dry-run` shows the diff
+without writing; `--path` targets a non-default home or profile.
+
+### ✅ Verify Part 3
+
+```
+cat ~/.hermes/SOUL.md
+memu-hermes retrieve "smoke test"
+```
+
+The memU block must appear exactly once, prior content intact, and `retrieve`
+must exit cleanly (empty lists are fine). A fresh Hermes session picks up the new
+SOUL.md.
+
+---
+
+## Done
+
+Report back to the user: the store and provider in use; the scheduled job and its
+schedule in words; and that the retrieval instruction is now in
+`~/.hermes/SOUL.md`, taking effect next session. Record and inject both read
+`~/.memu/config.env`, so they provably share one store.

--- a/src/memu/hosts/hermes/__init__.py
+++ b/src/memu/hosts/hermes/__init__.py
@@ -1,0 +1,12 @@
+"""The Hermes Agent host adapter — ``memu-hermes``.
+
+Binds ADR 0008's two seams onto Hermes: *record* as a scheduled bridging task
+over the SQLite session store at ``~/.hermes/state.db`` (see
+:mod:`memu.hosts.bridging`), *inject* as a standing instruction in
+``~/.hermes/SOUL.md`` that points the agent at the ``memu-hermes retrieve``
+command.
+"""
+
+from memu.hosts.hermes.sessions import HermesTranscriptSource
+
+__all__ = ["HermesTranscriptSource"]

--- a/src/memu/hosts/hermes/cli.py
+++ b/src/memu/hosts/hermes/cli.py
@@ -1,0 +1,49 @@
+"""``memu-hermes`` — the Hermes Agent host adapter's command-line surface.
+
+The verbs are the shared host-adapter surface (:mod:`memu.hosts.host_cli`); this
+module is the Hermes declaration: where its session store lives (a SQLite
+database, not a transcript directory), and which file its standing instruction
+lands in.
+
+Usage:
+    memu-hermes retrieve "<query>"    # the inject seam — what the agent runs each turn
+    memu-hermes install-instruction   # the inject seam — patch ~/.hermes/SOUL.md to run it
+    memu-hermes prepare               # slice new sessions into job files
+    memu-hermes verify-resources      # filter the touched-file log (run by a job)
+    memu-hermes commit                # submit what the agent produced back to memU
+    memu-hermes doctor                # check config + store before relying on them
+    memu-hermes docs install          # print the agent-facing install guide
+"""
+
+from __future__ import annotations
+
+import sys
+
+from memu.hosts.hermes.sessions import STATE_DB, HermesTranscriptSource
+from memu.hosts.host_cli import HostSpec, run
+
+HOST = "hermes"
+
+SOUL_MD = "~/.hermes/SOUL.md"
+"""Hermes's identity file — the one file loaded from ``HERMES_HOME`` into every
+session regardless of working directory, so the inject seam lands here.
+(Project-level ``.hermes.md``/``AGENTS.md`` files are per-directory and would
+miss sessions started elsewhere.)"""
+
+SPEC = HostSpec(
+    host=HOST,
+    display="Hermes",
+    package="memu.hosts.hermes",
+    source_factory=HermesTranscriptSource,
+    session_dir=STATE_DB,
+    session_help="Hermes SQLite session store (state.db under HERMES_HOME)",
+    instruction_path=SOUL_MD,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run(SPEC, argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/memu/hosts/hermes/sessions.py
+++ b/src/memu/hosts/hermes/sessions.py
@@ -1,0 +1,126 @@
+"""Hermes Agent's session log: the SQLite store at ``~/.hermes/state.db``.
+
+The whole of what makes this host Hermes. Everything the bridging task does with
+these records is host-agnostic and lives in :mod:`memu.hosts.bridging`.
+
+Hermes is the one supported host whose log is not JSONL-on-disk: sessions and
+their full message history live in two tables (``sessions``, ``messages``) of a
+WAL-mode SQLite database under the Hermes home (``~/.hermes`` by default; the
+host honors ``HERMES_HOME``, in which case pass ``--session-dir`` pointing at
+that ``state.db``). ``~/.hermes/sessions/saved/`` holds only manual snapshots and
+is ignored. This is exactly the "different container" seam
+:class:`~memu.hosts.base.TranscriptSource` anticipates: :meth:`discover`,
+:meth:`read_records`, :meth:`key`, and :meth:`timestamp` are overridden; each
+session row plays the role a session *file* plays elsewhere, and each message row
+is serialized to one JSON record so :meth:`classify` still sees one record at a
+time.
+
+The line-count cursor stays sound: messages are append-only per session, and
+sessions are discovered most-recently-active first, so the scan's early stop at
+the first unchanged session cannot hide newer content.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import sqlite3
+from pathlib import Path
+from typing import ClassVar
+
+from memu.hosts.base import RecordKind, TranscriptSource
+
+STATE_DB = "~/.hermes/state.db"
+
+_MESSAGE_ROLES = ("user", "assistant")
+
+_ROW_COLUMNS = ("role", "content", "tool_call_id", "tool_calls", "tool_name", "timestamp")
+
+
+class HermesTranscriptSource(TranscriptSource):
+    """Hermes stores OpenAI-shaped chat rows: ``role`` + ``content`` + tool columns.
+
+    A row is a conversation turn when its role is user or assistant and it says
+    something (non-empty ``content``); an assistant row that only carries
+    ``tool_calls``, and every ``tool`` row (the call's output, keyed by
+    ``tool_call_id``), is a tool record. System rows and anything else are noise
+    the mining jobs should never see.
+    """
+
+    name: ClassVar[str] = "hermes"
+
+    def __init__(self, state_db: str | Path = STATE_DB) -> None:
+        self._db = Path(os.path.expanduser(str(state_db)))
+
+    def root(self) -> Path:
+        return self._db.parent
+
+    def exists(self) -> bool:
+        return self._db.is_file()
+
+    def key(self, path: Path) -> str:
+        """Sessions have no path of their own — the cursor key is the session id."""
+        return path.name
+
+    def _connect(self) -> sqlite3.Connection:
+        # Read-only: the bridging task must never take Hermes's write lock —
+        # the gateway and live CLI sessions share this database in WAL mode.
+        return sqlite3.connect(f"file:{self._db}?mode=ro", uri=True)
+
+    def discover(self) -> list[Path]:
+        """Sessions with messages, most-recently-active first, as virtual paths.
+
+        The paths never touch the filesystem — the pipeline only hands them back
+        to :meth:`key` and :meth:`read_records`.
+        """
+        if not self.exists():
+            return []
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT session_id FROM messages GROUP BY session_id ORDER BY MAX(timestamp) DESC"
+            ).fetchall()
+        return [self.root() / session_id for (session_id,) in rows]
+
+    def read_records(self, path: Path) -> list[str]:
+        """One session's message rows, in insertion order, as JSON lines."""
+        with self._connect() as conn:
+            rows = conn.execute(
+                f"SELECT {', '.join(_ROW_COLUMNS)} FROM messages WHERE session_id = ? ORDER BY id",  # noqa: S608
+                (path.name,),
+            ).fetchall()
+        return [
+            json.dumps(
+                {column: value for column, value in zip(_ROW_COLUMNS, row, strict=True) if value is not None},
+                ensure_ascii=False,
+            )
+            for row in rows
+        ]
+
+    def classify(self, record: str) -> RecordKind:
+        try:
+            row = json.loads(record)
+        except json.JSONDecodeError:
+            return RecordKind.OTHER
+        if not isinstance(row, dict):
+            return RecordKind.OTHER
+
+        role = row.get("role")
+        if role == "tool":
+            return RecordKind.TOOL
+        if role in _MESSAGE_ROLES:
+            if row.get("content"):
+                return RecordKind.MESSAGE
+            if row.get("tool_calls"):
+                return RecordKind.TOOL
+        return RecordKind.OTHER
+
+    def timestamp(self, record: str) -> str | None:
+        """Hermes stamps rows with epoch seconds; the cursor file wants a string."""
+        try:
+            value = json.loads(record).get("timestamp")
+        except (json.JSONDecodeError, AttributeError):
+            return None
+        if isinstance(value, (int, float)):
+            return datetime.datetime.fromtimestamp(value, tz=datetime.UTC).isoformat()
+        return value if isinstance(value, str) else None

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -1,0 +1,211 @@
+"""One command surface, many host binaries.
+
+Every host adapter exposes the same verbs — ``retrieve``, ``install-instruction``,
+``prepare``, ``commit``, ``verify-resources``, ``doctor``, ``docs`` — because the
+pipeline behind them is host-agnostic (ADR 0008/0009). What differs per host is
+data, not code: the binary's name, where the session log lives, which file the
+standing instruction lands in, and the packaged guides. So the parser is built
+once here from a :class:`HostSpec`, and each host's ``cli.py`` shrinks to that
+declaration plus a ``main``.
+
+Working state is per host. Codex predates this module and keeps its original
+``~/.memu`` working tree; every later host defaults to ``~/.memu/hosts/<host>``,
+so two hosts' bridging runs never race over one ``jobs/`` directory (the open
+issue ADR 0009 required settling before a second host shipped — see ADR 0010).
+The durable store is shared regardless: every host reads ``~/.memu/config.env``,
+which is the point — what one host's sessions taught memU, another host retrieves.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass, field
+from importlib.resources import files
+from typing import Any
+
+from memu.hosts import instruction, retrieval
+from memu.hosts.base import TranscriptSource
+from memu.hosts.bridging import Layout, commit, prepare
+from memu.hosts.bridging.pipeline import MAX_JOBS
+from memu.hosts.bridging.resources import verify_resource_log
+
+DOCS = {"install": "INSTALL.md", "task": "BRIDGING_TASK.md"}
+
+
+@dataclass(frozen=True)
+class HostSpec:
+    """Everything host-specific about a host adapter's CLI — data, not code."""
+
+    host: str
+    """Short host id (``codex``). Names the binary and scopes the working tree."""
+
+    display: str
+    """Human name used in help text (``Codex``)."""
+
+    package: str
+    """Dotted package holding the host's ``INSTALL.md`` / ``BRIDGING_TASK.md``."""
+
+    source_factory: Callable[[str], TranscriptSource]
+    """Builds the host's :class:`TranscriptSource` from the ``--session-dir`` value."""
+
+    session_dir: str
+    """Default location of the host's session log (dir, or file for SQLite hosts)."""
+
+    session_help: str
+    """What the session log is, for ``--session-dir``'s help text."""
+
+    instruction_path: str
+    """The host's global instruction file — where the inject seam lands."""
+
+    base_dir: str = ""
+    """memU working tree. Empty means the per-host default ``~/.memu/hosts/<host>``;
+    Codex overrides this with the pre-multi-host ``~/.memu`` it has always used."""
+
+    extra_flags: dict[str, str] = field(default_factory=dict)
+    """Reserved for host-specific flags; unused today."""
+
+    @property
+    def binary(self) -> str:
+        return f"memu-{self.host}"
+
+    @property
+    def verify_command(self) -> str:
+        """What the resource job tells the agent to run. A command, never a path."""
+        return f"{self.binary} verify-resources"
+
+    @property
+    def default_base_dir(self) -> str:
+        return self.base_dir or f"~/.memu/hosts/{self.host}"
+
+
+def _layout(spec: HostSpec, args: argparse.Namespace) -> Layout:
+    return Layout.default(host=spec.host, base=args.base_dir)
+
+
+async def _cmd_prepare(spec: HostSpec, args: argparse.Namespace) -> int:
+    source = spec.source_factory(args.session_dir)
+    if not source.exists():
+        print(f"error: no {spec.display} session log at {source.root()}", file=sys.stderr)
+        return 2
+
+    layout = _layout(spec, args)
+    num_sessions = await prepare(source, layout, verify_command=spec.verify_command, max_jobs=args.max_jobs)
+    num_jobs = 2 * num_sessions + 1
+    print(f"prepared {num_sessions} session(s) -> {num_jobs} job(s) in {layout.jobs}")
+    if num_sessions == 0:
+        print("no new session turns since the last run; nothing to mine")
+    return 0
+
+
+async def _cmd_commit(spec: HostSpec, args: argparse.Namespace) -> int:
+    result = await commit(_layout(spec, args))
+    recall_files = result.get("recall_files", [])
+    resources = result.get("resources", [])
+    if not recall_files and not resources:
+        print("nothing to commit")
+        return 0
+    print(f"committed {len(recall_files)} recall file(s) and {len(resources)} resource(s)")
+    for recall_file in recall_files:
+        print(f"  - {recall_file.get('track')}/{recall_file.get('name')}")
+    return 0
+
+
+async def _cmd_verify_resources(spec: HostSpec, args: argparse.Namespace) -> int:
+    layout = _layout(spec, args)
+    kept = verify_resource_log(layout.resource_log, layout.resources)
+    print(f"{kept} resource(s) written to {layout.resources}")
+    return 0
+
+
+async def _cmd_doctor(spec: HostSpec, args: argparse.Namespace) -> int:
+    """Prove config resolves and the store answers — the install guide's verify gate.
+
+    Deliberately exercises the same call the inject hook will, so a green doctor
+    means the hook's retrieval works, not merely that some store opened.
+    """
+    from memu.env import CONFIG_ENV, embedding_provider, env
+
+    result = await retrieval.retrieve("smoke test")
+    found = sum(len(result.get(layer, [])) for layer in ("segments", "files", "resources"))
+    print(f"config    {os.path.expanduser(CONFIG_ENV)}")
+    print(f"store     {env('MEMU_DB')}")
+    print(f"provider  {embedding_provider()}")
+    print(f"retrieval ok ({found} hit(s) for a smoke-test query; 0 is fine on a new store)")
+    return 0
+
+
+async def _cmd_docs(spec: HostSpec, args: argparse.Namespace) -> int:
+    print((files(spec.package) / DOCS[args.doc]).read_text(encoding="utf-8"))
+    return 0
+
+
+def build_parser(spec: HostSpec) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=spec.binary,
+        description=f"memU's {spec.display} host adapter — the scheduled bridging task and its install guide.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def with_base(p: argparse.ArgumentParser) -> argparse.ArgumentParser:
+        p.add_argument(
+            "--base-dir",
+            default=spec.default_base_dir,
+            help=f"memU working directory (default: {spec.default_base_dir})",
+        )
+        return p
+
+    def bind(handler: Callable[[HostSpec, argparse.Namespace], Coroutine[Any, Any, int]]) -> Any:
+        async def bound(args: argparse.Namespace) -> int:
+            return await handler(spec, args)
+
+        return bound
+
+    # Both halves of the inject seam: what the agent runs, and what tells it to.
+    # Shared across hosts, so they are registered, not redefined — only the file
+    # the instruction lands in and the binary it names are ours to fill in.
+    retrieval.register(sub)
+    instruction.register(sub, path=spec.instruction_path, binary=spec.binary)
+
+    p = with_base(sub.add_parser("prepare", help=f"Slice new {spec.display} sessions into self-evolve job files"))
+    p.add_argument(
+        "--session-dir",
+        default=spec.session_dir,
+        help=f"{spec.session_help} (default: {spec.session_dir})",
+    )
+    p.add_argument("--max-jobs", type=int, default=MAX_JOBS, help=f"Sessions per run (default: {MAX_JOBS})")
+    p.set_defaults(handler=bind(_cmd_prepare))
+
+    p = with_base(sub.add_parser("commit", help="Submit what the self-evolve jobs produced back into memU"))
+    p.set_defaults(handler=bind(_cmd_commit))
+
+    p = with_base(
+        sub.add_parser("verify-resources", help="Filter the touched-file log into the describe-me resource file")
+    )
+    p.set_defaults(handler=bind(_cmd_verify_resources))
+
+    p = sub.add_parser("doctor", help="Verify MEMU_* config resolves and the store is reachable")
+    p.set_defaults(handler=bind(_cmd_doctor))
+
+    p = sub.add_parser("docs", help="Print a packaged agent-facing guide")
+    p.add_argument("doc", choices=sorted(DOCS), help="install: the setup guide; task: the bridging-task procedure")
+    p.set_defaults(handler=bind(_cmd_docs))
+
+    return parser
+
+
+def run(spec: HostSpec, argv: list[str] | None = None) -> int:
+    args = build_parser(spec).parse_args(argv)
+    handler: Callable[[argparse.Namespace], Coroutine[Any, Any, int]] = args.handler
+    try:
+        return asyncio.run(handler(args))
+    except KeyboardInterrupt:
+        return 130
+    except Exception as exc:
+        if os.environ.get("MEMU_DEBUG") == "1":
+            raise
+        print(f"error: {exc} (set MEMU_DEBUG=1 for a traceback)", file=sys.stderr)
+        return 1

--- a/src/memu/hosts/instruction.py
+++ b/src/memu/hosts/instruction.py
@@ -2,20 +2,22 @@
 
 :mod:`memu.hosts.retrieval` is what *runs* when the agent retrieves. This is what
 makes it run: one paragraph, patched into the host's global instruction file
-(Codex's ``~/.codex/AGENTS.md``, and whatever the next host calls its own), which
-that host loads into every session. No hook, no wrapper, no per-turn process.
+(Codex's ``~/.codex/AGENTS.md``, Claude Code's ``~/.claude/CLAUDE.md``, and
+whatever the next host calls its own), which that host loads into every session.
+No hook, no wrapper, no per-turn process.
 
 It lives here for the same reason retrieval does (ADR 0008): the text does not
-differ per host — only the file it lands in does. So the string is owned once,
-and each host CLI registers the command against its own path.
+differ per host — only the file it lands in and the binary it names do. So the
+string is owned once as a template, and each host CLI registers the command
+against its own path and its own binary.
 
 Owning it in code rather than in the install guide is deliberate. A payload
 transcribed out of a Markdown fence by an agent is a payload that gets
 paraphrased, and one pasted into a user's file is one that can never be upgraded:
-when :data:`INSTRUCTION` improves in a later release, the copy already sitting in
-someone's AGENTS.md is inert. Hence :func:`install` writes a *managed block*
-between markers — re-running replaces it in place, so an upgrade is a re-run.
-Everything outside the markers is the user's and is never touched.
+when :data:`INSTRUCTION_TEMPLATE` improves in a later release, the copy already
+sitting in someone's AGENTS.md is inert. Hence :func:`install` writes a *managed
+block* between markers — re-running replaces it in place, so an upgrade is a
+re-run. Everything outside the markers is the user's and is never touched.
 """
 
 from __future__ import annotations
@@ -27,13 +29,13 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-BEGIN = "<!-- memu:begin — managed block, do not edit (memu-codex install-instruction) -->"
+BEGIN_TEMPLATE = "<!-- memu:begin — managed block, do not edit ({binary} install-instruction) -->"
 END = "<!-- memu:end -->"
 
-INSTRUCTION = """\
+INSTRUCTION_TEMPLATE = """\
 ## memU — retrieve before answering
 
-Before answering, run `memu-codex retrieve "<query>"` — where <query> is the
+Before answering, run `{binary} retrieve "<query>"` — where <query> is the
 user's request, reworded into a clearer query or focused keywords when that
 retrieves better (you need not pass their raw words verbatim). Use any relevant
 results as context. If it returns nothing, proceed normally.
@@ -48,7 +50,7 @@ from the summary, and open the raw file only when you need what it leaves out.
 """
 """What the agent is told, every turn, before it answers.
 
-It names ``memu-codex retrieve`` — a ``PATH`` command, never a script path, and
+It names ``<binary> retrieve`` — a ``PATH`` command, never a script path, and
 the LLM-free single-shot retrieval. It fails open, hence "proceed normally" — an
 empty store returns empty lists and the turn goes on.
 
@@ -59,18 +61,30 @@ document that slice came from, a resource is a file on disk. Without the legend
 the reader has to guess which layer to trust, and opens raw files it did not need.
 """
 
-_BLOCK = re.compile(
-    rf"^{re.escape(BEGIN)}\n.*?^{re.escape(END)}\n?",
-    re.DOTALL | re.MULTILINE,
-)
+
+def begin(binary: str) -> str:
+    """The opening marker, naming the host binary that manages the block."""
+    return BEGIN_TEMPLATE.format(binary=binary)
 
 
-def block() -> str:
+def instruction(binary: str) -> str:
+    """The instruction text, telling the agent to run this host's ``retrieve``."""
+    return INSTRUCTION_TEMPLATE.format(binary=binary)
+
+
+def block(binary: str) -> str:
     """The managed block exactly as it is written to disk, markers included."""
-    return f"{BEGIN}\n{INSTRUCTION}{END}\n"
+    return f"{begin(binary)}\n{instruction(binary)}{END}\n"
 
 
-def patch(current: str) -> str:
+def _block_re(binary: str) -> re.Pattern[str]:
+    return re.compile(
+        rf"^{re.escape(begin(binary))}\n.*?^{re.escape(END)}\n?",
+        re.DOTALL | re.MULTILINE,
+    )
+
+
+def patch(current: str, binary: str) -> str:
     """Return ``current`` with the managed block installed — replaced, or appended.
 
     Pure, so the interesting half of :func:`install` is testable without a
@@ -78,15 +92,16 @@ def patch(current: str) -> str:
     a second call replaces the first call's block rather than stacking another
     copy, and text outside them survives untouched.
     """
-    if _BLOCK.search(current):
-        return _BLOCK.sub(lambda _: block(), current, count=1)
+    pattern = _block_re(binary)
+    if pattern.search(current):
+        return pattern.sub(lambda _: block(binary), current, count=1)
     if current and not current.endswith("\n"):
         current += "\n"
     separator = "\n" if current else ""
-    return f"{current}{separator}{block()}"
+    return f"{current}{separator}{block(binary)}"
 
 
-def install(path: Path, *, dry_run: bool = False) -> tuple[bool, str]:
+def install(path: Path, binary: str, *, dry_run: bool = False) -> tuple[bool, str]:
     """Install the managed block into ``path``. Returns ``(changed, diff)``.
 
     Creates the file (and its parent) if absent, and backs up any existing content
@@ -95,7 +110,7 @@ def install(path: Path, *, dry_run: bool = False) -> tuple[bool, str]:
     """
     path = path.expanduser()
     current = path.read_text(encoding="utf-8") if path.is_file() else ""
-    updated = patch(current)
+    updated = patch(current, binary)
     diff = "".join(
         difflib.unified_diff(
             current.splitlines(keepends=True),
@@ -117,10 +132,10 @@ def install(path: Path, *, dry_run: bool = False) -> tuple[bool, str]:
 def _cmd_install_instruction(args: argparse.Namespace) -> int:
     path = Path(args.path)
     if args.print_only:
-        print(block(), end="")
+        print(block(args.binary), end="")
         return 0
 
-    changed, diff = install(path, dry_run=args.dry_run)
+    changed, diff = install(path, args.binary, dry_run=args.dry_run)
     if not diff:
         print(f"{path}: already up to date")
         return 0
@@ -136,8 +151,12 @@ async def _cmd_install_instruction_async(args: argparse.Namespace) -> int:
     return _cmd_install_instruction(args)
 
 
-def register(sub: Any, *, path: str) -> None:
-    """Add ``install-instruction`` to a host CLI, bound to that host's ``path``."""
+def register(sub: Any, *, path: str, binary: str) -> None:
+    """Add ``install-instruction`` to a host CLI, bound to that host's ``path``.
+
+    ``binary`` is the host adapter's own command name (``memu-codex``, …) — it is
+    what the installed instruction tells the agent to run.
+    """
     parser = sub.add_parser(
         "install-instruction",
         help="Patch the host's global instruction file so the agent retrieves before answering",
@@ -145,4 +164,4 @@ def register(sub: Any, *, path: str) -> None:
     parser.add_argument("--path", default=path, help=f"Instruction file to patch (default: {path})")
     parser.add_argument("--dry-run", action="store_true", help="Show the diff without writing")
     parser.add_argument("--print", dest="print_only", action="store_true", help="Print the managed block and exit")
-    parser.set_defaults(handler=_cmd_install_instruction_async)
+    parser.set_defaults(handler=_cmd_install_instruction_async, binary=binary)

--- a/src/memu/hosts/openclaw/BRIDGING_TASK.md
+++ b/src/memu/hosts/openclaw/BRIDGING_TASK.md
@@ -1,0 +1,108 @@
+---
+name: create-memu-bridging-task
+description: Create an OpenClaw cron job that bridges the agent's recent OpenClaw sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every day at midnight).
+---
+
+# Create the memU bridging scheduled task (OpenClaw)
+
+Use this when the user asks to **set up (or change) the recurring memU
+"bridging" task** — the job that periodically turns what the agent recently did
+in its OpenClaw sessions into durable memU memory files, skills, and resource
+records.
+
+Your goal is to **create an OpenClaw cron job** (OpenClaw schedules agent runs
+natively) whose recurring prompt runs the three-step pipeline below. You are not
+running the pipeline now; you are registering the schedule that will run it
+later.
+
+Part of the full setup in `INSTALL.md` (`memu-openclaw docs install`), but
+usable on its own.
+
+## What the bridging task does (context)
+
+1. **Prepare** — `memu-openclaw prepare` scans new turns under
+   `~/.openclaw/agents/*/sessions/` (one JSONL transcript per session, all
+   agents), mirrors the current memU recall files to
+   `~/.memu/hosts/openclaw/memory` and `~/.memu/hosts/openclaw/skill`, snapshots
+   them by content hash, and writes numbered **job-instruction files** to
+   `~/.memu/hosts/openclaw/jobs/` (`1.txt`, `2.txt`, …).
+2. **Self-evolve** — the agent opens each job file **in numeric order** and
+   follows it: mine a session into user **memory**, mine a session into a
+   **skill**, and **describe** the files the sessions touched. "Do nothing" is
+   an allowed, common outcome for any job.
+3. **Commit** — `memu-openclaw commit` diffs the tracked directories against the
+   step-1 snapshot and submits what the agent actually created or changed back
+   to memU.
+
+Only steps 1 and 3 are code. **Step 2 is real agent work**, so the cron job's
+prompt must instruct the agent to do it, not shell out to a script.
+
+## Prerequisites
+
+- **memU is installed and `memu-openclaw` is on `PATH`** for the environment the
+  cron job's shell tool runs in. Verify with `memu-openclaw doctor`; if it
+  fails, do `INSTALL.md` Part 1 first.
+
+## Step 1 — settle the schedule
+
+Ask the user for a schedule if the request doesn't include one. **Default: every
+day at midnight**, cron `0 0 * * *` (local time). Confirm before creating.
+
+## Step 2 — create the cron job
+
+Create an OpenClaw cron job (e.g. named `memu-bridging`) with the chosen
+schedule, and set its recurring prompt to this block **verbatim**:
+
+```
+Run the memU bridging pipeline. Do the three steps strictly in order; do not
+skip a step even if the previous one looks like it produced nothing.
+
+1. PREPARE. Run this exact command with the shell tool:
+
+     memu-openclaw prepare
+
+   It regenerates ~/.memu/hosts/openclaw/jobs/. If the command exits non-zero,
+   stop and report the error — do not continue.
+
+2. SELF-EVOLVE. List ~/.memu/hosts/openclaw/jobs/*.txt and process them in
+   ascending numeric order (1.txt, then 2.txt, …). The count changes every run —
+   always glob and sort; never assume a fixed number. If there are no job
+   files, skip to step 3.
+
+   For each job file: read it and follow its instructions to the letter. Each
+   job is self-contained and already carries the concrete paths it needs. Order
+   matters — finish one job before starting the next. Emitting no files for a
+   job is a valid outcome; do not invent content to fill a job.
+
+3. COMMIT. After every job is done, run this exact command with the shell tool:
+
+     memu-openclaw commit
+
+   It commits whatever the jobs created or changed. If it exits non-zero,
+   report the error.
+
+Finish with a one-line summary: how many jobs ran and what was committed (or
+that there was nothing to commit).
+```
+
+The prompt block is fixed; only the schedule is the user's choice. Nothing in it
+is machine-specific — the pipeline is invoked through `PATH` commands.
+
+## Step 3 — confirm
+
+Report back: the cron job's name and the schedule in words (e.g. "daily at 00:00
+local time"). Mention that the first run only has work to do once there are new
+OpenClaw sessions since the last run.
+
+## Notes
+
+- **Idempotent and incremental.** `prepare` tracks a per-session line cursor in
+  `~/.memu/hosts/openclaw/.session_manifest.openclaw.json`.
+- **Ordering is load-bearing.** Memory jobs before skill jobs, the
+  resource-describe job last. Always ascending numeric order.
+- **The working tree is host-scoped.** Everything under
+  `~/.memu/hosts/openclaw/` is this adapter's run-scoped working state; other
+  memU host adapters never race with it. The durable store they all share is the
+  `MEMU_DB` in `~/.memu/config.env`.
+- **Failure handling.** Steps 1 and 3 are the only failure points that should
+  abort the run. A "do nothing" job in step 2 is normal, not an error.

--- a/src/memu/hosts/openclaw/INSTALL.md
+++ b/src/memu/hosts/openclaw/INSTALL.md
@@ -1,0 +1,129 @@
+# Install memU for OpenClaw
+
+> **Audience: the agent.** A user will point you at this file ("follow this guide
+> to install memU"). Work top to bottom. Each part ends with a **verify** gate —
+> do not proceed until the current one passes.
+>
+> Everything on the memU side is a `PATH` command; you should never need to write
+> an absolute path to a script.
+
+Installing memU on OpenClaw is three parts:
+
+1. **Install memU** — a Python package, and the store + provider it writes to.
+2. **Register the bridging task** — the scheduled job that turns recent OpenClaw
+   sessions into durable memory (the *record* seam).
+3. **Patch `~/.openclaw/workspace/AGENTS.md`** — a standing instruction that
+   tells the agent to pull relevant memory before answering (the *inject* seam).
+
+Parts 2 and 3 must share one store and one embedding space, or a query is
+compared against vectors written elsewhere and retrieval silently returns
+nothing. Part 1 is what makes them agree.
+
+**Scope note.** This adapter reads the JSONL transcripts under
+`~/.openclaw/agents/<agentId>/sessions/` (all agents). If this install runs a
+non-default state dir (`OPENCLAW_STATE_DIR`), pass
+`--session-dir <state-dir>/agents` to `prepare`; if it keeps transcripts in the
+newer SQLite session target, this adapter cannot read them.
+
+---
+
+## Part 1 — Install memU
+
+```
+pip install memu-cli
+```
+
+This puts `memu` and **`memu-openclaw`** on `PATH`. Confirm:
+`memu-openclaw --help`. If it is not found, fix `PATH` now — the scheduled task
+in Part 2 runs from a bare, non-interactive environment.
+
+### 1.2 Configure the store and provider
+
+memU needs a **database** and an **LLM/embedding provider**. Both seams read this
+one config. If another memU host adapter is already set up on this machine,
+`~/.memu/config.env` exists and **must be reused as is**; skip to the verify
+gate. Otherwise collect from the user:
+
+| Setting | Env var | Example |
+| --- | --- | --- |
+| Database | `MEMU_DB` | `~/.memu/memu.sqlite3`, or a `postgres://…` DSN |
+| Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
+| API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
+
+Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
+never a shell-profile export — the scheduled task does not inherit your shell).
+
+### ✅ Verify Part 1
+
+```
+memu-openclaw doctor
+```
+
+Must exit cleanly. Zero hits on the smoke-test retrieval is expected on a new
+store.
+
+---
+
+## Part 2 — Register the bridging (record) task
+
+The *record* seam: a scheduled job that mines recent transcripts under
+`~/.openclaw/agents/*/sessions/` into durable memU memory, skills, and
+resources. **Do not reinvent this** — follow the packaged procedure:
+
+```
+memu-openclaw docs task
+```
+
+In summary: settle a schedule with the user (default: daily at midnight) and
+create an **OpenClaw cron job** — OpenClaw schedules agent runs natively — whose
+recurring prompt is the block that document gives you verbatim: it runs
+`memu-openclaw prepare`, works through `~/.memu/hosts/openclaw/jobs/*.txt` in
+order, then `memu-openclaw commit`. Nothing in it is machine-specific.
+
+### ✅ Verify Part 2
+
+Confirm the cron job exists with the expected schedule, then dry-run:
+`memu-openclaw prepare` (zero prepared sessions is fine and correct when nothing
+is new).
+
+---
+
+## Part 3 — Patch the workspace `AGENTS.md` with the retrieval instruction
+
+The *inject* seam: a standing instruction in OpenClaw's **workspace AGENTS.md**
+telling the agent to pull relevant memory before answering. OpenClaw loads
+`~/.openclaw/workspace/AGENTS.md` at the start of every session, so the
+instruction is simply always there.
+
+**Do not hand-write the instruction.** memU owns the text and installs it:
+
+```
+memu-openclaw install-instruction
+```
+
+It writes memU's block into `~/.openclaw/workspace/AGENTS.md`, creating the file
+if absent, and prints the diff. It appends rather than overwrites (existing
+content is backed up to `AGENTS.md.bak`), and it is idempotent: the text sits in
+a marked block that a re-run — or a later memU release — replaces in place.
+`--dry-run` shows the diff without writing; `--path` targets a non-default
+workspace.
+
+### ✅ Verify Part 3
+
+```
+cat ~/.openclaw/workspace/AGENTS.md
+memu-openclaw retrieve "smoke test"
+```
+
+The memU block must appear exactly once, prior content intact, and `retrieve`
+must exit cleanly (empty lists are fine). A fresh OpenClaw session picks up the
+new AGENTS.md.
+
+---
+
+## Done
+
+Report back to the user: the store and provider in use; the cron job's name and
+schedule in words; and that the retrieval instruction is now in the workspace
+AGENTS.md, taking effect next session. Record and inject both read
+`~/.memu/config.env`, so they provably share one store.

--- a/src/memu/hosts/openclaw/__init__.py
+++ b/src/memu/hosts/openclaw/__init__.py
@@ -1,0 +1,11 @@
+"""The OpenClaw host adapter — ``memu-openclaw``.
+
+Binds ADR 0008's two seams onto OpenClaw: *record* as a scheduled bridging task
+over ``~/.openclaw/agents/*/sessions`` (see :mod:`memu.hosts.bridging`), *inject*
+as a standing instruction in the workspace ``AGENTS.md`` that points the agent at
+the ``memu-openclaw retrieve`` command.
+"""
+
+from memu.hosts.openclaw.sessions import OpenClawTranscriptSource
+
+__all__ = ["OpenClawTranscriptSource"]

--- a/src/memu/hosts/openclaw/cli.py
+++ b/src/memu/hosts/openclaw/cli.py
@@ -1,0 +1,47 @@
+"""``memu-openclaw`` — the OpenClaw host adapter's command-line surface.
+
+The verbs are the shared host-adapter surface (:mod:`memu.hosts.host_cli`); this
+module is the OpenClaw declaration: where its session transcripts live, and which
+file its standing instruction lands in.
+
+Usage:
+    memu-openclaw retrieve "<query>"    # the inject seam — what the agent runs each turn
+    memu-openclaw install-instruction   # the inject seam — patch the workspace AGENTS.md
+    memu-openclaw prepare               # slice new sessions into job files
+    memu-openclaw verify-resources      # filter the touched-file log (run by a job)
+    memu-openclaw commit                # submit what the agent produced back to memU
+    memu-openclaw doctor                # check config + store before relying on them
+    memu-openclaw docs install          # print the agent-facing install guide
+"""
+
+from __future__ import annotations
+
+import sys
+
+from memu.hosts.host_cli import HostSpec, run
+from memu.hosts.openclaw.sessions import SESSION_DIR, OpenClawTranscriptSource
+
+HOST = "openclaw"
+
+AGENTS_MD = "~/.openclaw/workspace/AGENTS.md"
+"""OpenClaw's workspace instruction file — loaded at the start of every session,
+so the inject seam lands here. If the user runs a non-default workspace
+(``OPENCLAW_WORKSPACE_DIR``, or a profile), pass ``--path``."""
+
+SPEC = HostSpec(
+    host=HOST,
+    display="OpenClaw",
+    package="memu.hosts.openclaw",
+    source_factory=OpenClawTranscriptSource,
+    session_dir=SESSION_DIR,
+    session_help="OpenClaw agents dir holding <agentId>/sessions transcripts",
+    instruction_path=AGENTS_MD,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run(SPEC, argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/memu/hosts/openclaw/sessions.py
+++ b/src/memu/hosts/openclaw/sessions.py
@@ -1,0 +1,77 @@
+"""OpenClaw's session transcripts: ``~/.openclaw/agents/<agentId>/sessions/*.jsonl``.
+
+The whole of what makes this host OpenClaw. Everything the bridging task does
+with these records is host-agnostic and lives in :mod:`memu.hosts.bridging`.
+
+One transcript per session, named by session id (Telegram topic sessions add a
+``-topic-<threadId>`` suffix), grouped per agent under the OpenClaw state dir
+(``~/.openclaw`` by default; the host honors ``OPENCLAW_STATE_DIR``, in which
+case pass ``--session-dir``). The mutable ``sessions.json`` index sitting next to
+the transcripts is not JSONL and is naturally skipped by discovery. Newer
+OpenClaw builds can keep transcripts in SQLite instead (a ``sqlite:`` session
+target); those are out of this adapter's reach — it reads the JSONL default.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import ClassVar
+
+from memu.hosts.base import RecordKind, TranscriptSource
+
+SESSION_DIR = "~/.openclaw/agents"
+
+_MESSAGE_ROLES = ("user", "assistant")
+
+
+class OpenClawTranscriptSource(TranscriptSource):
+    """OpenClaw writes one JSON object per line, in a parent-linked entry tree.
+
+    An entry is a conversation turn when its ``type`` is ``message`` and its
+    ``message.role`` is user or assistant (assistant entries carry their tool
+    calls inline as content blocks), and a tool record when the role is
+    ``toolResult`` — the tool output comes back as its own entry. Everything
+    else — the ``session`` header, ``compaction`` summaries, ``custom`` extension
+    state, model/thinking change markers — is noise the mining jobs should never
+    see.
+    """
+
+    name: ClassVar[str] = "openclaw"
+
+    def __init__(self, session_dir: str | Path = SESSION_DIR) -> None:
+        self._root = Path(os.path.expanduser(str(session_dir)))
+
+    def root(self) -> Path:
+        return self._root
+
+    def classify(self, record: str) -> RecordKind:
+        try:
+            entry = json.loads(record)
+        except json.JSONDecodeError:
+            return RecordKind.OTHER
+        if not isinstance(entry, dict) or entry.get("type") != "message":
+            return RecordKind.OTHER
+
+        message = entry.get("message")
+        role = message.get("role") if isinstance(message, dict) else None
+        if role in _MESSAGE_ROLES:
+            return RecordKind.MESSAGE
+        if role == "toolResult":
+            return RecordKind.TOOL
+        return RecordKind.OTHER
+
+    def timestamp(self, record: str) -> str | None:
+        """OpenClaw stamps entries with either an ISO string or epoch millis."""
+        try:
+            value = json.loads(record).get("timestamp")
+        except (json.JSONDecodeError, AttributeError):
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (int, float)):
+            seconds = value / 1000 if value > 1e11 else value
+            return datetime.datetime.fromtimestamp(seconds, tz=datetime.UTC).isoformat()
+        return None

--- a/tests/test_host_instruction.py
+++ b/tests/test_host_instruction.py
@@ -3,7 +3,7 @@
 The target file belongs to the *host*, not to memU, and may already hold a user's
 own global instructions. These pin the three properties that protect it: existing
 content survives, a re-run does not stack a second copy, and a changed
-:data:`INSTRUCTION` upgrades in place rather than appending a stale twin.
+:data:`INSTRUCTION_TEMPLATE` upgrades in place rather than appending a stale twin.
 """
 
 from __future__ import annotations
@@ -13,22 +13,24 @@ import pathlib
 from memu.hosts import instruction
 from memu.hosts.codex.cli import AGENTS_MD, build_parser
 
+BINARY = "memu-codex"
+
 
 def test_creates_file_when_absent(tmp_path: pathlib.Path) -> None:
     path = tmp_path / "nested" / "AGENTS.md"
-    changed, _ = instruction.install(path)
+    changed, _ = instruction.install(path, BINARY)
     assert changed
-    assert instruction.INSTRUCTION in path.read_text()
+    assert instruction.instruction(BINARY) in path.read_text()
 
 
 def test_preserves_existing_content(tmp_path: pathlib.Path) -> None:
     path = tmp_path / "AGENTS.md"
     path.write_text("# My rules\n\nAlways use tabs.\n")
-    instruction.install(path)
+    instruction.install(path, BINARY)
 
     text = path.read_text()
     assert "Always use tabs." in text
-    assert instruction.INSTRUCTION in text
+    assert instruction.instruction(BINARY) in text
     # The user's content is backed up before we touch it.
     assert (tmp_path / "AGENTS.md.bak").read_text() == "# My rules\n\nAlways use tabs.\n"
 
@@ -37,41 +39,54 @@ def test_install_is_idempotent(tmp_path: pathlib.Path) -> None:
     path = tmp_path / "AGENTS.md"
     path.write_text("# My rules\n")
 
-    instruction.install(path)
+    instruction.install(path, BINARY)
     first = path.read_text()
-    changed, diff = instruction.install(path)
+    changed, diff = instruction.install(path, BINARY)
 
     assert not changed and not diff, "a re-run must be a no-op, not a second copy"
     assert path.read_text() == first
-    assert first.count(instruction.BEGIN) == 1
+    assert first.count(instruction.begin(BINARY)) == 1
 
 
 def test_upgrade_replaces_in_place(monkeypatch, tmp_path: pathlib.Path) -> None:
     """The whole reason the block is marker-fenced: a later memU can update it."""
     path = tmp_path / "AGENTS.md"
     path.write_text("# My rules\n")
-    instruction.install(path)
+    instruction.install(path, BINARY)
 
-    monkeypatch.setattr(instruction, "INSTRUCTION", "## memU\n\nNew and improved.\n")
-    changed, _ = instruction.install(path)
+    monkeypatch.setattr(instruction, "INSTRUCTION_TEMPLATE", "## memU\n\nNew and improved.\n")
+    changed, _ = instruction.install(path, BINARY)
 
     text = path.read_text()
     assert changed
     assert "New and improved." in text
     assert "retrieve before answering" not in text, "the old block must be gone, not duplicated"
-    assert text.count(instruction.BEGIN) == 1
+    assert text.count(instruction.begin(BINARY)) == 1
     assert "# My rules" in text
 
 
+def test_each_host_manages_its_own_block(tmp_path: pathlib.Path) -> None:
+    """Two hosts pointed at one file must not clobber each other's block."""
+    path = tmp_path / "AGENTS.md"
+    instruction.install(path, "memu-codex")
+    instruction.install(path, "memu-claude-code")
+
+    text = path.read_text()
+    assert text.count(instruction.begin("memu-codex")) == 1
+    assert text.count(instruction.begin("memu-claude-code")) == 1
+    assert "memu-codex retrieve" in text
+    assert "memu-claude-code retrieve" in text
+
+
 def test_patch_survives_a_file_with_no_trailing_newline() -> None:
-    assert instruction.patch("no newline here").startswith("no newline here\n\n")
+    assert instruction.patch("no newline here", BINARY).startswith("no newline here\n\n")
 
 
 def test_dry_run_writes_nothing(tmp_path: pathlib.Path) -> None:
     path = tmp_path / "AGENTS.md"
     path.write_text("# My rules\n")
 
-    changed, diff = instruction.install(path, dry_run=True)
+    changed, diff = instruction.install(path, BINARY, dry_run=True)
 
     assert not changed
     assert diff, "a dry run still reports what it would do"
@@ -82,10 +97,11 @@ def test_dry_run_writes_nothing(tmp_path: pathlib.Path) -> None:
 def test_cli_defaults_to_the_codex_instruction_file() -> None:
     args = build_parser().parse_args(["install-instruction"])
     assert args.path == AGENTS_MD
+    assert args.binary == BINARY
     assert callable(args.handler)
 
 
 def test_instruction_names_the_llm_free_retrieval() -> None:
     """`memu retrieve` is LLM-routed — one LLM call per turn is what this avoids."""
-    assert "memu-codex retrieve" in instruction.INSTRUCTION
-    assert "`memu retrieve" not in instruction.INSTRUCTION
+    assert "memu-codex retrieve" in instruction.instruction(BINARY)
+    assert "`memu retrieve" not in instruction.instruction(BINARY)

--- a/tests/test_host_sessions.py
+++ b/tests/test_host_sessions.py
@@ -1,0 +1,205 @@
+"""Each host's record seam: does classify() slice its log the way that host writes it?
+
+One test module per invariant class, five hosts. The fixtures are hand-written
+records in each host's real on-disk shape (see the session-location table in ADR
+0010); if a host changes its log format, the fixture — not the pipeline — is what
+these tests localize the break to.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sqlite3
+
+from memu.hosts.base import RecordKind
+from memu.hosts.claude_code.sessions import ClaudeCodeTranscriptSource
+from memu.hosts.codex.sessions import CodexTranscriptSource
+from memu.hosts.cursor.sessions import CursorTranscriptSource
+from memu.hosts.hermes.sessions import HermesTranscriptSource
+from memu.hosts.openclaw.sessions import OpenClawTranscriptSource
+
+
+def _line(entry: dict) -> str:
+    return json.dumps(entry)
+
+
+# ── Codex ──────────────────────────────────────────────────────────────────────
+
+
+def test_codex_classify() -> None:
+    source = CodexTranscriptSource()
+    assert source.classify(_line({"payload": {"type": "message", "role": "user"}})) is RecordKind.MESSAGE
+    assert source.classify(_line({"payload": {"type": "function_call", "name": "shell"}})) is RecordKind.TOOL
+    assert source.classify(_line({"payload": {"type": "reasoning"}})) is RecordKind.OTHER
+
+
+# ── Claude Code ────────────────────────────────────────────────────────────────
+
+
+def test_claude_code_classify_conversation_turns() -> None:
+    source = ClaudeCodeTranscriptSource()
+    user = {"type": "user", "message": {"role": "user", "content": "fix the bug"}}
+    assistant = {
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": "On it."}]},
+    }
+    assert source.classify(_line(user)) is RecordKind.MESSAGE
+    assert source.classify(_line(assistant)) is RecordKind.MESSAGE
+
+
+def test_claude_code_classify_tool_records() -> None:
+    """Claude Code logs a tool's result as a *user*-typed record — the block type,
+    not the role, is what classifies."""
+    source = ClaudeCodeTranscriptSource()
+    tool_use = {
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "tool_use", "name": "Bash", "input": {}}]},
+    }
+    tool_result = {
+        "type": "user",
+        "message": {"role": "user", "content": [{"type": "tool_result", "content": "ok"}]},
+    }
+    assert source.classify(_line(tool_use)) is RecordKind.TOOL
+    assert source.classify(_line(tool_result)) is RecordKind.TOOL
+
+
+def test_claude_code_drops_noise() -> None:
+    source = ClaudeCodeTranscriptSource()
+    thinking = {
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "thinking", "thinking": "hmm"}]},
+    }
+    meta = {"type": "user", "isMeta": True, "message": {"role": "user", "content": "<harness-injected>"}}
+    queue = {"type": "queue-operation", "operation": "enqueue", "content": "next prompt"}
+    assert source.classify(_line(thinking)) is RecordKind.OTHER
+    assert source.classify(_line(meta)) is RecordKind.OTHER
+    assert source.classify(_line(queue)) is RecordKind.OTHER
+    assert source.classify("not json") is RecordKind.OTHER
+
+
+# ── Cursor ─────────────────────────────────────────────────────────────────────
+
+
+def test_cursor_classify() -> None:
+    source = CursorTranscriptSource()
+    user = {"role": "user", "message": {"content": [{"type": "text", "text": "upload to github"}]}}
+    narrated_tool = {
+        "role": "assistant",
+        "message": {
+            "content": [
+                {"type": "text", "text": "Running git."},
+                {"type": "tool_use", "name": "Shell", "input": {"command": "git push"}},
+            ]
+        },
+    }
+    bare_tool = {"role": "assistant", "message": {"content": [{"type": "tool_use", "name": "Shell", "input": {}}]}}
+    assert source.classify(_line(user)) is RecordKind.MESSAGE
+    # Prose sharing a record with the tool calls it narrates stays conversation.
+    assert source.classify(_line(narrated_tool)) is RecordKind.MESSAGE
+    assert source.classify(_line(bare_tool)) is RecordKind.TOOL
+    assert source.classify(_line({"role": "system"})) is RecordKind.OTHER
+
+
+def test_cursor_discovers_only_agent_transcripts(tmp_path: pathlib.Path) -> None:
+    """The project dirs also hold canvases and terminal logs — those must not be mined."""
+    transcript = tmp_path / "Users-a-proj" / "agent-transcripts" / "abc" / "abc.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text('{"role":"user","message":{"content":[{"type":"text","text":"hi"}]}}\n')
+    stray = tmp_path / "Users-a-proj" / "terminals" / "log.jsonl"
+    stray.parent.mkdir(parents=True)
+    stray.write_text("{}\n")
+
+    assert CursorTranscriptSource(tmp_path).discover() == [transcript]
+
+
+# ── OpenClaw ───────────────────────────────────────────────────────────────────
+
+
+def test_openclaw_classify() -> None:
+    source = OpenClawTranscriptSource()
+    user = {"type": "message", "timestamp": 1752537600000, "message": {"role": "user", "content": "hi"}}
+    assistant = {"type": "message", "message": {"role": "assistant", "content": [{"type": "text", "text": "hey"}]}}
+    tool = {"type": "message", "message": {"role": "toolResult", "content": [{"type": "text", "text": "ok"}]}}
+    header = {"type": "session", "id": "s1", "cwd": "/home/user/proj"}
+    compaction = {"type": "compaction", "firstKeptEntryId": "e9"}
+    assert source.classify(_line(user)) is RecordKind.MESSAGE
+    assert source.classify(_line(assistant)) is RecordKind.MESSAGE
+    assert source.classify(_line(tool)) is RecordKind.TOOL
+    assert source.classify(_line(header)) is RecordKind.OTHER
+    assert source.classify(_line(compaction)) is RecordKind.OTHER
+
+
+def test_openclaw_timestamp_accepts_iso_and_epoch_millis() -> None:
+    source = OpenClawTranscriptSource()
+    iso = {"type": "message", "timestamp": "2026-07-15T00:00:00Z", "message": {"role": "user", "content": "hi"}}
+    millis = {"type": "message", "timestamp": 1752537600000, "message": {"role": "user", "content": "hi"}}
+    assert source.timestamp(_line(iso)) == "2026-07-15T00:00:00Z"
+    assert source.timestamp(_line(millis)) == "2025-07-15T00:00:00+00:00"
+
+
+# ── Hermes ─────────────────────────────────────────────────────────────────────
+
+
+def _hermes_db(tmp_path: pathlib.Path) -> pathlib.Path:
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE sessions (id TEXT PRIMARY KEY);
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT,
+            tool_call_id TEXT,
+            tool_calls TEXT,
+            tool_name TEXT,
+            timestamp REAL NOT NULL
+        );
+        """
+    )
+    rows = [
+        ("old", "user", "earlier session", None, None, None, 100.0),
+        ("new", "system", "you are hermes", None, None, None, 200.0),
+        ("new", "user", "delete the temp files", None, None, None, 201.0),
+        ("new", "assistant", None, None, '[{"name":"shell"}]', None, 202.0),
+        ("new", "tool", "removed 3 files", "call_1", None, "shell", 203.0),
+        ("new", "assistant", "Done — removed 3 files.", None, None, None, 204.0),
+    ]
+    conn.executemany(
+        "INSERT INTO messages (session_id, role, content, tool_call_id, tool_calls, tool_name, timestamp)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def test_hermes_discovers_sessions_most_recent_first(tmp_path: pathlib.Path) -> None:
+    source = HermesTranscriptSource(_hermes_db(tmp_path))
+    assert source.exists()
+    assert [source.key(path) for path in source.discover()] == ["new", "old"]
+
+
+def test_hermes_reads_and_classifies_rows(tmp_path: pathlib.Path) -> None:
+    source = HermesTranscriptSource(_hermes_db(tmp_path))
+    (session,) = [path for path in source.discover() if source.key(path) == "new"]
+
+    records = source.read_records(session)
+    kinds = [source.classify(record) for record in records]
+    assert kinds == [
+        RecordKind.OTHER,  # system prompt
+        RecordKind.MESSAGE,  # user turn
+        RecordKind.TOOL,  # assistant tool_calls, no prose
+        RecordKind.TOOL,  # tool output
+        RecordKind.MESSAGE,  # assistant answer
+    ]
+    assert source.timestamp(records[1]) == "1970-01-01T00:03:21+00:00"
+
+
+def test_hermes_missing_db_is_empty_not_an_error(tmp_path: pathlib.Path) -> None:
+    source = HermesTranscriptSource(tmp_path / "state.db")
+    assert not source.exists()
+    assert source.discover() == []


### PR DESCRIPTION
Four new host adapters alongside `memu-codex`, each binding ADR 0008's two seams onto its host's real session log (locations verified empirically — live machine for Claude Code/Cursor, upstream source for OpenClaw/Hermes):

| Host | Binary | Session log | Instruction file |
| --- | --- | --- | --- |
| Claude Code | `memu-claude-code` | `~/.claude/projects/<escaped-cwd>/*.jsonl` | `~/.claude/CLAUDE.md` |
| Cursor (Agent/CLI) | `memu-cursor` | `~/.cursor/projects/*/agent-transcripts/**/*.jsonl` | `./AGENTS.md` (per project) |
| OpenClaw | `memu-openclaw` | `~/.openclaw/agents/<agentId>/sessions/*.jsonl` | `~/.openclaw/workspace/AGENTS.md` |
| Hermes Agent | `memu-hermes` | `~/.hermes/state.db` (SQLite, read-only) | `~/.hermes/SOUL.md` |

Shared structure the second host forced (ADR 0010):
- `memu.hosts.host_cli`: one parser/handler set built from a `HostSpec`; `memu-codex` rebuilt on it with byte-identical behavior
- instruction text parameterized on the host binary; per-binary markers so two hosts can manage blocks in one file
- per-host working trees (`~/.memu/hosts/<host>/`) settle ADR 0009's concurrent-hosts open issue; codex keeps `~/.memu` for compatibility
- Hermes exercises the TranscriptSource container seam: virtual session paths over read-only SQLite; the line cursor becomes a row-count cursor

Tests: per-host classify fixtures, Cursor discover scoping, Hermes against a temp SQLite db. Verified end-to-end locally: `prepare` sliced real Claude Code and Cursor sessions into job files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)