### PR TITLE
chore(dist): retire the memu-py name; memu-cli is the only distribution

### DIFF
--- a/.github/workflows/publish-memu-cli.yml
+++ b/.github/workflows/publish-memu-cli.yml
@@ -1,10 +1,9 @@
-# Publishes the engine snapshot to PyPI under the distribution name `memu-cli`.
+# Publishes the engine to PyPI as `memu-cli` — the one and only distribution.
 #
-# `memu-cli` is the CLI release channel: it ships the same `memu` module and
-# entry points as `memu-py`, but versions independently of the release-please
-# train so the npm launcher and docs can point at a stable install target.
-# The rename happens at build time only — pyproject.toml in the repo always
-# says `memu-py`.
+# `memu-cli` versions independently of the release-please train (which still
+# cuts GitHub releases and the changelog), so the npm launcher and docs can
+# point at a stable install target; the version is set at build time from the
+# workflow input.
 #
 # First-time setup: add a trusted publisher on PyPI for project `memu-cli`
 # (workflow: publish-memu-cli.yml, environment: pypi).
@@ -13,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "memu-cli version to publish (independent of memu-py, e.g. 0.1.1)"
+        description: "memu-cli version to publish (e.g. 0.2.1)"
         required: true
         type: string
 
@@ -57,14 +56,12 @@ jobs:
 
       # No $ anchors: Windows runners check out with CRLF line endings,
       # where a trailing \r sits between the closing quote and the newline.
-      - name: Rename distribution to memu-cli
+      - name: Set memu-cli version
         shell: bash
         run: |
-          perl -pi -e 's/^name = "memu-py"/name = "memu-cli"/' pyproject.toml
           perl -pi -e 's/^version = "[^"]*"/version = "${{ inputs.version }}"/ if $. < 10' pyproject.toml
-          perl -pi -e 's/^description = "[^"]*"/description = "CLI distribution channel for memU (same engine as memu-py). Personal memory as files."/' pyproject.toml
-          grep -q '^name = "memu-cli"' pyproject.toml || { echo "::error::rename to memu-cli did not apply"; exit 1; }
-          grep -E '^(name|version|description) = ' pyproject.toml | head -3
+          grep -q '^name = "memu-cli"' pyproject.toml || { echo "::error::pyproject is not memu-cli"; exit 1; }
+          grep -E '^(name|version) = ' pyproject.toml | head -2
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -108,13 +105,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Rename distribution to memu-cli
+      - name: Set memu-cli version
         shell: bash
         run: |
-          perl -pi -e 's/^name = "memu-py"/name = "memu-cli"/' pyproject.toml
           perl -pi -e 's/^version = "[^"]*"/version = "${{ inputs.version }}"/ if $. < 10' pyproject.toml
-          perl -pi -e 's/^description = "[^"]*"/description = "CLI distribution channel for memU (same engine as memu-py). Personal memory as files."/' pyproject.toml
-          grep -q '^name = "memu-cli"' pyproject.toml || { echo "::error::rename to memu-cli did not apply"; exit 1; }
+          grep -q '^name = "memu-cli"' pyproject.toml || { echo "::error::pyproject is not memu-cli"; exit 1; }
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -120,6 +120,9 @@ jobs:
           path: dist/*.tar.gz
           if-no-files-found: error
 
+  # Release artifacts go to the GitHub release only. PyPI publishing happens
+  # exclusively through publish-memu-cli.yml (the `memu-cli` distribution,
+  # versioned independently of this release train).
   publish:
     name: publish release artifacts
     runs-on: ubuntu-latest
@@ -128,9 +131,7 @@ jobs:
       - build-wheels
       - build-sdist
     if: ${{ needs.release-please.outputs.releases_created == 'true' && needs.release-please.outputs.tag_name != '' }}
-    environment: pypi
     permissions:
-      id-token: write
       contents: write
     steps:
       - name: Download wheel artifacts
@@ -153,8 +154,3 @@ jobs:
           file: dist/*
           tag: ${{ needs.release-please.outputs.tag_name }}
           file_glob: true
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/

--- a/docs/adr/0009-codex-packaging-cli-and-config.md
+++ b/docs/adr/0009-codex-packaging-cli-and-config.md
@@ -48,7 +48,7 @@ silently returns nothing.
 
 ### 1. Distribute via pip; do not ship a parallel npm package
 
-memU is installed as a Python package (`pip install memu-py`), exposing two console entrypoints:
+memU is installed as a Python package (`pip install memu-cli`), exposing two console entrypoints:
 `memu` (the library's own surface) and `memu-codex` (the host adapter — see Decision 2). No npm
 package is built for this integration.
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -38,14 +38,14 @@ State persists in a local SQLite database (`./data/memu.sqlite3` by default), so
 
 ## How it works
 
-This npm package is a thin launcher (a few kB, no dependencies). The engine is the PyPI package [`memu-cli`](https://pypi.org/project/memu-cli/) — the CLI release channel of [`memu-py`](https://pypi.org/project/memu-py/), same module, versioned independently, with prebuilt wheels for Linux (x86_64/aarch64), macOS (Intel/Apple Silicon), and Windows. The shim finds a runner and delegates, in order:
+This npm package is a thin launcher (a few kB, no dependencies). The engine is the PyPI package [`memu-cli`](https://pypi.org/project/memu-cli/) — the memU engine itself, with prebuilt wheels for Linux (x86_64/aarch64), macOS (Intel/Apple Silicon), and Windows. The shim finds a runner and delegates, in order:
 
 1. `$MEMU_PYTHON -m memu` — explicit interpreter override
 2. `uvx --from memu-cli memu` — no install needed, cached by uv (recommended)
 3. `pipx run --spec memu-cli memu` — no install needed, cached by pipx
 4. `python3 -m memu` — requires `pip install memu-cli`
 
-Using Python already? Skip npm entirely: `uvx --from memu-cli memu --help`, or `pip install memu-cli`. For the library API (`MemoryService`, Postgres backends), use [`memu-py`](https://pypi.org/project/memu-py/) — but install only one of the two in a given environment; they ship the same `memu` module.
+Using Python already? Skip npm entirely: `uvx --from memu-cli memu --help`, or `pip install memu-cli`. The same package carries the library API (`MemoryService`, Postgres backends) — one install covers CLI, host adapters, and library use.
 
 See the [main README](https://github.com/NevaMind-AI/MemU#readme) for the memory model, library API, and self-hosting options.
 

--- a/npm/bin/memu.js
+++ b/npm/bin/memu.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-// memu-cli: thin launcher for the PyPI package `memu-cli` (the CLI release
-// channel of the memU engine; same module as memu-py, versioned independently).
+// memu-cli: thin launcher for the PyPI package `memu-cli` (the memU engine).
 //
 // The memU engine is Python (>= 3.13). This shim finds a runner and delegates,
 // in order of preference:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "memu-py"
+name = "memu-cli"
 version = "1.5.1"
 authors = [
     {name = "MemU Team", email = "contact@nevamind.ai"},

--- a/src/memu/hosts/codex/INSTALL.md
+++ b/src/memu/hosts/codex/INSTALL.md
@@ -30,7 +30,7 @@ Python.
 ### 1.1 Install
 
 ```
-pip install memu-py
+pip install memu-cli
 ```
 
 This puts two commands on `PATH`:

--- a/uv.lock
+++ b/uv.lock
@@ -404,7 +404,7 @@ wheels = [
 ]
 
 [[package]]
-name = "memu-py"
+name = "memu-cli"
 version = "1.5.1"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
`pyproject.toml` now says `memu-cli` directly, so the build-time rename hack in `publish-memu-cli.yml` goes away (the workflow still sets the version from its input). release-please keeps cutting GitHub releases and the changelog but no longer publishes to PyPI — publishing there would have clobbered memu-cli's independent version line; `publish-memu-cli.yml` is the one PyPI path.

All docs (host INSTALL guides, ADR 0009, the npm launcher) now say `pip install memu-cli`; no memu-py reference remains in the repo.

Note for existing users: anyone with the old `memu-py` installed should uninstall it before `pip install memu-cli` — they ship the same `memu` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)