### PR TITLE
feat(hosts): add memu-agent, a generic adapter for any other agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ memU runs as a sidecar to a desktop agent (ADR 0008/0009/0010), one binary per h
 | Cursor (Agent/CLI) | `memu-cursor` | `~/.cursor/projects/<project>/agent-transcripts/**.jsonl` | `./AGENTS.md` (per project) |
 | OpenClaw | `memu-openclaw` | `~/.openclaw/agents/<agentId>/sessions/*.jsonl` | `~/.openclaw/workspace/AGENTS.md` |
 | Hermes Agent | `memu-hermes` | `~/.hermes/state.db` (SQLite, read-only) | `~/.hermes/SOUL.md` |
+| **any other agent** | `memu-agent` | found by `memu-agent detect` (JSONL dialect sniffed) | found by `detect` (AGENTS.md / CLAUDE.md / SOUL.md / …) |
+
+For agents without a dedicated binary, `memu-agent detect` probes the machine and reports per agent whether **memorization** works (a recognizable session log exists) and whether **retrieval** works (an instruction file exists to patch) — then the same verbs run against what it found.
 
 All hosts share one store and one embedding space via `~/.memu/config.env` — what one host's sessions taught memU, another host retrieves.
 

--- a/docs/adr/0011-generic-host-adapter.md
+++ b/docs/adr/0011-generic-host-adapter.md
@@ -1,0 +1,85 @@
+ADR 0011: A Generic Host Adapter — Detect First, Then Bind What Works
+
+- Status: Accepted
+- Date: 2026-07-16
+- Builds on: ADR 0008 (two seams), ADR 0010 (multi-host adapters, shared CLI builder)
+- Scope: how memU integrates with agents that have **no dedicated adapter**. It does not
+  change the five dedicated hosts or the pipeline.
+
+## Context
+
+ADR 0010 shipped five dedicated adapters and noted the recipe for a sixth: a `classify`
+method, two paths, two markdown files. That recipe assumes someone writes the adapter. The
+long tail of agents — new CLIs appear monthly — will mostly never get one, yet many of them
+are integrable *today*, because the ecosystem has converged on a handful of session-log
+dialects and a handful of instruction-file names.
+
+Two observations make a generic adapter viable:
+
+1. **Session logs cluster into ~5 JSONL dialects.** Payload-wrapped (Codex lineage), typed
+   message trees (OpenClaw/pi lineage), typed block records (Claude Code lineage),
+   role+message blocks (Cursor lineage), and flat OpenAI-client chat rows. A sniffing
+   `classify` that tries these in order covers most JSONL-logging agents without any
+   per-agent code.
+2. **The two seams degrade independently.** An agent with a readable session log gets
+   *memorization* (the record seam) even if we cannot find its instruction file; an agent
+   with only an `AGENTS.md`/`CLAUDE.md`/`SOUL.md`-style file gets *retrieval* (the inject
+   seam) even if its sessions are unreadable (SQLite, editor state, or absent). Partial
+   integration is still integration — but only if the user is told which half they got.
+
+## Decision
+
+One more binary, `memu-agent` (package `memu.hosts.generic`), with the shared verb surface
+plus one new verb:
+
+- **`detect` probes before anything binds.** With no argument it surveys `~` for agent
+  directories; with a path it probes that directory. For each candidate it answers the two
+  questions in order — *is there a session log whose records sniff as a known dialect?*
+  (memorization), and if not or additionally, *is there an instruction file to patch?*
+  (retrieval) — and prints an explicit per-agent verdict: memorization works / retrieval
+  works / both / neither, with the found paths and the exact next command. Directories of
+  the five dedicated hosts are redirected to their own binaries. Sessions in containers the
+  sniffer cannot read (SQLite and friends) are reported as such — the Hermes precedent, not
+  silence.
+- **The transcript source sniffs per record.** `GenericTranscriptSource.classify` tries the
+  five dialects in order; a record matching none is `OTHER`. This is the same fail-closed
+  posture the dedicated adapters take with their hosts' metadata records: the mining jobs
+  see only what provably is conversation or tool traffic, so a half-recognized log degrades
+  to less input, never to garbage input.
+- **Nothing is defaulted that detect must find.** `prepare --session-dir` is *required* (the
+  `HostSpec` marks no universal location), and `install-instruction` takes the `--path`
+  detect reported. The one machine-specific value the bridging prompt carries is that
+  session dir — a deliberate, documented exception to ADR 0009's "nothing machine-specific
+  in the prompt", because for an unknown agent there is no `PATH`-stable name to hide it
+  behind.
+- **Several generic agents share one binary, not one working tree.** The default tree is
+  `~/.memu/hosts/agent/`; integrating a second unknown agent means passing
+  `--base-dir ~/.memu/hosts/<name>` in that agent's task, keeping ADR 0010's isolation
+  guarantee.
+
+## Consequences
+
+Positive:
+
+- Any agent logging a known JSONL dialect integrates with zero new code, and any agent with
+  a recognizable instruction file gets retrieval regardless.
+- The user always learns *which* seams work and why — the detect report is the contract,
+  so a retrieval-only integration is a stated outcome rather than a silent half-failure.
+- `detect` doubles as the scouting tool for new dedicated adapters: an unrecognized-dialect
+  or SQLite report is exactly the evidence a sixth adapter starts from.
+
+Negative / costs:
+
+- Sniffing is heuristic. A new dialect classifies as `OTHER` (missed memories, safe), and a
+  pathological log could mis-bucket records (wrong-track memories, bounded by the dialects'
+  mutual exclusivity). The dedicated adapters remain the correctness bar.
+- `detect`'s survey reads directory listings across `~/.*` (capped per directory); it is
+  read-only but not free, and its skip-list of non-agent dirs needs occasional tending.
+- The required `--session-dir` bakes one machine-specific path into the generic bridging
+  prompt — accepted, see above.
+
+## Related ADRs
+
+- `docs/adr/0010-multi-host-adapters.md` — the shared CLI builder (`HostSpec`) this reuses,
+  extended here with `register_extra` (host-specific subcommands) and required-when-blank
+  `session_dir`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,3 +10,4 @@
 - [0008: Trajectory as the Source — Zero-Code Hooks over a Programmatic API](0008-two-integration-surfaces-hooks-and-api.md)
 - [0009: Packaging the Codex Integration — pip, a CLI Seam, and One Config Loader](0009-codex-packaging-cli-and-config.md)
 - [0010: Multi-Host Adapters — Claude Code, Cursor, OpenClaw, and Hermes](0010-multi-host-adapters.md)
+- [0011: A Generic Host Adapter — Detect First, Then Bind What Works](0011-generic-host-adapter.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ memu-claude-code = "memu.hosts.claude_code.cli:main"
 memu-cursor = "memu.hosts.cursor.cli:main"
 memu-openclaw = "memu.hosts.openclaw.cli:main"
 memu-hermes = "memu.hosts.hermes.cli:main"
+# The generic adapter: any agent without a dedicated binary. `memu-agent
+# detect` finds the session log and instruction file, then reports which of
+# the two seams (memorization / retrieval) work for that agent.
+memu-agent = "memu.hosts.generic.cli:main"
 
 [project.urls]
 "Homepage" = "https://github.com/NevaMind-AI/MemU"

--- a/src/memu/hosts/generic/BRIDGING_TASK.md
+++ b/src/memu/hosts/generic/BRIDGING_TASK.md
@@ -1,0 +1,107 @@
+---
+name: create-memu-bridging-task
+description: Register a scheduled job that bridges an agent's recent sessions into durable memU memory, skills, and resources via the generic memu-agent adapter. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every day at midnight).
+---
+
+# Create the memU bridging scheduled task (generic `memu-agent`)
+
+Use this when the user asks to **set up (or change) the recurring memU
+"bridging" task** for an agent that has no dedicated memU adapter — the job
+that periodically turns what the agent recently did into durable memU memory
+files, skills, and resource records.
+
+Your goal is to **register a recurring headless run** whose prompt is the
+three-step pipeline below. You are not running the pipeline now.
+
+Part of the full setup in `INSTALL.md` (`memu-agent docs install`), but usable
+on its own.
+
+## Prerequisite: the session directory
+
+This adapter has no built-in session location. `memu-agent detect` must
+already have found one whose records it recognizes (its report says
+"memorization: works"). Call it `<SESSION_DIR>` below — it is the **one**
+machine-specific value in this task, fixed once at registration time.
+
+Also verify `memu-agent doctor` passes; if not, do `INSTALL.md` Part 1 first.
+
+## What the bridging task does (context)
+
+1. **Prepare** — `memu-agent prepare --session-dir <SESSION_DIR>` scans new
+   turns, mirrors the current memU recall files to
+   `~/.memu/hosts/agent/memory` and `~/.memu/hosts/agent/skill`, snapshots
+   them by content hash, and writes numbered **job-instruction files** to
+   `~/.memu/hosts/agent/jobs/` (`1.txt`, `2.txt`, …).
+2. **Self-evolve** — the agent opens each job file **in numeric order** and
+   follows it: mine a session into user **memory**, mine a session into a
+   **skill**, and **describe** the files the sessions touched. "Do nothing" is
+   an allowed, common outcome for any job.
+3. **Commit** — `memu-agent commit` diffs the tracked directories against the
+   step-1 snapshot and submits what the agent actually created or changed back
+   to memU.
+
+Only steps 1 and 3 are code. **Step 2 is real agent work**, so the scheduled
+run's prompt must instruct the agent to do it, not shell out to a script.
+
+## Step 1 — settle the schedule
+
+Ask the user for a schedule if the request doesn't include one. **Default:
+every day at midnight**, cron `0 0 * * *` (local time). Confirm before
+creating.
+
+## Step 2 — register the scheduled run
+
+Use the agent's own scheduler if it has one; otherwise a system cron entry
+invoking the agent headless. The recurring prompt, with `<SESSION_DIR>` filled
+in, **verbatim**:
+
+```
+Run the memU bridging pipeline. Do the three steps strictly in order; do not
+skip a step even if the previous one looks like it produced nothing.
+
+1. PREPARE. Run this exact command with the shell tool:
+
+     memu-agent prepare --session-dir <SESSION_DIR>
+
+   It regenerates ~/.memu/hosts/agent/jobs/. If the command exits non-zero,
+   stop and report the error — do not continue.
+
+2. SELF-EVOLVE. List ~/.memu/hosts/agent/jobs/*.txt and process them in
+   ascending numeric order (1.txt, then 2.txt, …). The count changes every
+   run — always glob and sort; never assume a fixed number. If there are no
+   job files, skip to step 3.
+
+   For each job file: read it and follow its instructions to the letter. Each
+   job is self-contained and already carries the concrete paths it needs.
+   Order matters — finish one job before starting the next. Emitting no files
+   for a job is a valid outcome; do not invent content to fill a job.
+
+3. COMMIT. After every job is done, run this exact command with the shell
+   tool:
+
+     memu-agent commit
+
+   It commits whatever the jobs created or changed. If it exits non-zero,
+   report the error.
+
+Finish with a one-line summary: how many jobs ran and what was committed (or
+that there was nothing to commit).
+```
+
+## Step 3 — confirm
+
+Report back: where the schedule was registered, and the cron in words. Mention
+that the first run only has work to do once there are new sessions since the
+last run.
+
+## Notes
+
+- **Idempotent and incremental.** `prepare` tracks a per-session line cursor
+  in `~/.memu/hosts/agent/.session_manifest.agent.json`.
+- **Several generic agents on one machine** must not share a working tree: add
+  `--base-dir ~/.memu/hosts/<name>` to both `prepare` and `commit` in each
+  task's prompt.
+- **Ordering is load-bearing.** Memory jobs before skill jobs, the
+  resource-describe job last. Always ascending numeric order.
+- **Failure handling.** Steps 1 and 3 are the only failure points that should
+  abort the run. A "do nothing" job in step 2 is normal, not an error.

--- a/src/memu/hosts/generic/INSTALL.md
+++ b/src/memu/hosts/generic/INSTALL.md
@@ -1,0 +1,151 @@
+# Install memU for any agent (`memu-agent`)
+
+> **Audience: the agent.** A user will point you at this file ("follow this guide
+> to install memU"). Work top to bottom. Each part ends with a **verify** gate —
+> do not proceed until the current one passes.
+>
+> Everything on the memU side is a `PATH` command; you should never need to write
+> an absolute path to a script.
+
+This is the **generic** adapter, for agents that do not have a dedicated memU
+binary. It supports two seams, and — unlike the dedicated adapters — either may
+turn out unavailable for a given agent:
+
+- **Memorization (record):** works when the agent keeps a local session log
+  whose records match a known JSONL dialect.
+- **Retrieval (inject):** works when the agent loads an instruction file
+  (`AGENTS.md`, `CLAUDE.md`, `SOUL.md`, a project-root `AGENTS.md`, …) that a
+  standing retrieve instruction can be patched into.
+
+Part 0 determines which of the two you get. **You must report the outcome to
+the user** — "memorization works", "retrieval works", both, or neither — before
+setting anything up.
+
+---
+
+## Part 0 — Detect what this agent supports
+
+```
+pip install memu-cli
+memu-agent detect
+```
+
+`detect` surveys `~` for agent installations (or probes one directory:
+`memu-agent detect ~/.someagent`). For each it reports:
+
+- **memorization: works** — it found session files and recognized their
+  records; note the directory, Part 2 needs it. If it found sessions in a
+  container it cannot read (SQLite), memorization is *not* available through
+  this adapter — say so.
+- **retrieval: works** — it found an instruction file; note the path, Part 3
+  needs it. If none was found but the agent is known to read the project root's
+  `AGENTS.md`, retrieval still works per project.
+- **dedicated adapter** — the agent has its own binary (`memu-codex`,
+  `memu-claude-code`, `memu-cursor`, `memu-openclaw`, `memu-hermes`). Stop and
+  use that instead: `<binary> docs install`.
+
+### ✅ Verify Part 0
+
+Tell the user, in one or two sentences, exactly which seams work for their
+agent and why (what was found, where). If **neither** seam works, stop here —
+memU cannot integrate with this agent yet, and no amount of setup changes that.
+
+---
+
+## Part 1 — Configure the store and provider
+
+If another memU host adapter is already set up on this machine,
+`~/.memu/config.env` exists and **must be reused as is**; skip to the verify
+gate. Otherwise collect from the user:
+
+| Setting | Env var | Example |
+| --- | --- | --- |
+| Database | `MEMU_DB` | `~/.memu/memu.sqlite3`, or a `postgres://…` DSN |
+| Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
+| API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
+
+Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
+never a shell-profile export — a scheduled task does not inherit your shell).
+
+### ✅ Verify Part 1
+
+```
+memu-agent doctor
+```
+
+Must exit cleanly. Zero hits on the smoke-test retrieval is expected on a new
+store.
+
+---
+
+## Part 2 — Memorization (only if detect said it works)
+
+Register the bridging task against the session directory detect found. Follow
+the packaged procedure:
+
+```
+memu-agent docs task
+```
+
+In summary: settle a schedule with the user (default: daily at midnight) and
+register a recurring run — the agent's own scheduler if it has one, system cron
+otherwise — whose prompt runs
+`memu-agent prepare --session-dir <detected dir>`, works through
+`~/.memu/hosts/agent/jobs/*.txt` in order, then `memu-agent commit`.
+
+> Integrating **several** generic agents on one machine? Give each its own
+> working tree (`--base-dir ~/.memu/hosts/<name>` on `prepare` and `commit`) so
+> their runs never share a jobs directory.
+
+### ✅ Verify Part 2
+
+```
+memu-agent prepare --session-dir <detected dir>
+```
+
+It should report how many sessions it prepared (zero is fine and correct when
+nothing is new).
+
+---
+
+## Part 3 — Retrieval (only if detect said it works)
+
+Patch the instruction file detect found:
+
+```
+memu-agent install-instruction --path <detected file>
+```
+
+No global file, but the agent reads the project root's `AGENTS.md`? Run
+`memu-agent install-instruction` inside each project instead.
+
+It writes memU's block into the file, creating it if absent, and prints the
+diff. It appends rather than overwrites (existing content is backed up to
+`<file>.bak`), and it is idempotent: the text sits in a marked block that a
+re-run — or a later memU release — replaces in place.
+
+### ✅ Verify Part 3
+
+```
+cat <detected file>
+memu-agent retrieve "smoke test"
+```
+
+The memU block must appear exactly once, prior content intact, and `retrieve`
+must exit cleanly (empty lists are fine). A fresh session of the agent picks up
+the new instruction file.
+
+---
+
+## Done
+
+Report back to the user:
+
+- **which seams work**: memorization (and from which session directory),
+  retrieval (and into which instruction file), both, or neither;
+- the store (`MEMU_DB`) and provider in use;
+- what was scheduled and where the instruction landed, for the seams that work.
+
+Both seams read `~/.memu/config.env`, so they provably share one store — and
+they share it with every dedicated adapter too: what this agent's sessions
+teach memU, every other integrated agent retrieves.

--- a/src/memu/hosts/generic/__init__.py
+++ b/src/memu/hosts/generic/__init__.py
@@ -1,0 +1,12 @@
+"""The generic host adapter — ``memu-agent``, for agents without a dedicated one.
+
+Binds ADR 0008's two seams onto any agent it can: *record* over a sniffed JSONL
+session log (see :mod:`memu.hosts.generic.sessions`), *inject* into whatever
+instruction file the agent loads. ``memu-agent detect`` is the entry point — it
+finds both and says which seams work.
+"""
+
+from memu.hosts.generic.detect import Probe, probe, scan_home
+from memu.hosts.generic.sessions import GenericTranscriptSource
+
+__all__ = ["GenericTranscriptSource", "Probe", "probe", "scan_home"]

--- a/src/memu/hosts/generic/cli.py
+++ b/src/memu/hosts/generic/cli.py
@@ -1,0 +1,85 @@
+"""``memu-agent`` — the generic host adapter, for every agent without its own.
+
+Where the dedicated binaries hard-code one host's paths, this one starts with a
+question: ``memu-agent detect`` probes the machine (or one agent's directory)
+and reports, per agent, whether **memorization** works (a session log exists and
+its records sniff as a known JSONL dialect) and whether **retrieval** works (an
+instruction file like AGENTS.md / CLAUDE.md / SOUL.md exists for
+``install-instruction --path`` to patch). The remaining verbs are the shared
+host-adapter surface, pointed at whatever detect found.
+
+Usage:
+    memu-agent detect                       # survey ~ for agents; report both seams
+    memu-agent detect ~/.someagent          # probe one agent's directory
+    memu-agent retrieve "<query>"           # the inject seam — what the agent runs each turn
+    memu-agent install-instruction --path F # patch the instruction file detect found
+    memu-agent prepare --session-dir DIR    # slice new sessions into job files
+    memu-agent verify-resources             # filter the touched-file log (run by a job)
+    memu-agent commit                       # submit what the agent produced back to memU
+    memu-agent doctor                       # check config + store before relying on them
+    memu-agent docs install                 # print the agent-facing install guide
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+from memu.hosts.generic.detect import probe, render, scan_home
+from memu.hosts.generic.sessions import GenericTranscriptSource
+from memu.hosts.host_cli import HostSpec, run
+
+HOST = "agent"
+
+AGENTS_MD = "./AGENTS.md"
+"""The fallback inject target: most agents read the project root's AGENTS.md.
+``detect`` reports the agent's real global file when it finds one — pass it
+via ``--path``."""
+
+
+async def _cmd_detect(args: argparse.Namespace) -> int:
+    if args.path:
+        print(render(probe(args.path)))
+        return 0
+
+    results = scan_home()
+    if not results:
+        print("no agent installations found under ~")
+        return 0
+    print("\n\n".join(render(result) for result in results))
+    print(
+        "\nnext steps: for a dedicated adapter, run its install guide; otherwise\n"
+        "  memorization → memu-agent prepare --session-dir <dir>   (schedule via `memu-agent docs task`)\n"
+        "  retrieval    → memu-agent install-instruction --path <file>"
+    )
+    return 0
+
+
+def _register_detect(sub: Any) -> None:
+    parser = sub.add_parser(
+        "detect",
+        help="Probe for agents: does memorization (session log) work, does retrieval (instruction file)?",
+    )
+    parser.add_argument("path", nargs="?", help="Agent directory to probe (default: survey all of ~)")
+    parser.set_defaults(handler=_cmd_detect)
+
+
+SPEC = HostSpec(
+    host=HOST,
+    display="agent",
+    package="memu.hosts.generic",
+    source_factory=GenericTranscriptSource,
+    session_dir="",  # no universal location — detect finds it, prepare requires it
+    session_help="The agent's session-log directory (find it with `memu-agent detect`)",
+    instruction_path=AGENTS_MD,
+    register_extra=_register_detect,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run(SPEC, argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/memu/hosts/generic/detect.py
+++ b/src/memu/hosts/generic/detect.py
@@ -1,0 +1,207 @@
+"""Probe an agent installation: does memorization work here, does retrieval?
+
+The generic adapter's contract with an unknown agent is two questions, asked in
+order (the order the seams matter in):
+
+1. **Memorization (the record seam).** Is there a session log on disk, and do
+   its records sniff as one of the known JSONL dialects? Found and recognized —
+   the bridging task can mine it, memorization works. A log in a container we
+   cannot read (SQLite, editor state) is reported as such rather than silently
+   skipped.
+2. **Retrieval (the inject seam).** No session log is not the end: if the agent
+   loads an instruction file (``AGENTS.md``, ``CLAUDE.md``, ``SOUL.md``, …),
+   ``install-instruction --path`` can still plant the standing retrieve
+   instruction, and retrieval works even though nothing is mined from this
+   agent.
+
+The verdicts are what ``memu-agent detect`` prints. Everything here is
+read-only probing — nothing is written.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from memu.hosts.base import RecordKind
+from memu.hosts.generic.sessions import GenericTranscriptSource
+
+INSTRUCTION_NAMES = (
+    "AGENTS.md",
+    "agents.md",
+    "AGENT.md",
+    "CLAUDE.md",
+    "SOUL.md",
+    "GEMINI.md",
+    "QWEN.md",
+    ".cursorrules",
+)
+"""Instruction-file names the ecosystem's agents load into every session."""
+
+DEDICATED = {
+    ".codex": "memu-codex",
+    ".claude": "memu-claude-code",
+    ".cursor": "memu-cursor",
+    ".openclaw": "memu-openclaw",
+    ".hermes": "memu-hermes",
+}
+"""Agent dirs that already have a dedicated adapter — detect points at it."""
+
+_SKIP_DIRS = frozenset({
+    ".Trash",
+    ".cache",
+    ".cargo",
+    ".config",
+    ".docker",
+    ".git",
+    ".gradle",
+    ".local",
+    ".m2",
+    ".npm",
+    ".nvm",
+    ".ollama",
+    ".pyenv",
+    ".rustup",
+    ".ssh",
+    ".venv",
+    ".vscode",
+    "node_modules",
+})
+"""Home-directory entries that are tooling state, not agents."""
+
+_MAX_FILES_PER_DIR = 2000
+_SAMPLE_FILES = 3
+_SAMPLE_LINES = 200
+
+
+@dataclass
+class Probe:
+    """What one directory yielded, and the two verdicts drawn from it."""
+
+    path: Path
+    session_files: list[Path] = field(default_factory=list)
+    sampled: int = 0
+    messages: int = 0
+    tools: int = 0
+    sqlite_files: list[Path] = field(default_factory=list)
+    instruction_files: list[Path] = field(default_factory=list)
+    dedicated: str | None = None
+
+    @property
+    def memorization(self) -> bool:
+        """Sessions found *and* their records sniff as conversation."""
+        return self.messages > 0
+
+    @property
+    def retrieval(self) -> bool:
+        """An instruction file the agent loads exists — the inject seam has a home."""
+        return bool(self.instruction_files)
+
+
+def _iter_files(root: Path) -> list[Path]:
+    """Files under ``root``, capped so a huge non-agent dir cannot stall detect."""
+    found: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        for name in filenames:
+            found.append(Path(dirpath) / name)
+            if len(found) >= _MAX_FILES_PER_DIR:
+                return found
+    return found
+
+
+def probe(path: str | Path) -> Probe:
+    """Probe one directory. Read-only; safe on anything."""
+    root = Path(os.path.expanduser(str(path)))
+    result = Probe(path=root, dedicated=DEDICATED.get(root.name))
+    if not root.is_dir():
+        return result
+
+    files = _iter_files(root)
+    result.session_files = sorted(
+        (f for f in files if f.suffix == ".jsonl"),
+        key=lambda f: f.stat().st_mtime,
+        reverse=True,
+    )
+    result.sqlite_files = [f for f in files if f.suffix in (".db", ".sqlite", ".sqlite3", ".vscdb")]
+    # An instruction file the agent actually loads sits at the top of its dir
+    # (or one level down, like OpenClaw's workspace/AGENTS.md). Anything deeper
+    # is plugin/checkout content wearing the same name — never the inject target.
+    instruction_candidates = [f for f in files if f.name in INSTRUCTION_NAMES and len(f.relative_to(root).parts) <= 2]
+    result.instruction_files = sorted(instruction_candidates, key=lambda f: len(f.relative_to(root).parts))
+
+    source = GenericTranscriptSource(root)
+    for session in result.session_files[:_SAMPLE_FILES]:
+        try:
+            records = source.read_records(session)[:_SAMPLE_LINES]
+        except (OSError, UnicodeDecodeError):
+            continue
+        for record in records:
+            result.sampled += 1
+            kind = source.classify(record)
+            if kind is RecordKind.MESSAGE:
+                result.messages += 1
+            elif kind is RecordKind.TOOL:
+                result.tools += 1
+    return result
+
+
+def scan_home(home: str | Path = "~") -> list[Probe]:
+    """Probe every plausible agent dir under ``home``, dedicated hosts included."""
+    root = Path(os.path.expanduser(str(home)))
+    probes = []
+    for entry in sorted(root.glob(".*")):
+        if not entry.is_dir() or entry.name in _SKIP_DIRS:
+            continue
+        candidate = probe(entry)
+        if candidate.session_files or candidate.instruction_files or candidate.sqlite_files or candidate.dedicated:
+            probes.append(candidate)
+    return probes
+
+
+def _shorten(path: Path) -> str:
+    home = str(Path.home())
+    text = str(path)
+    return "~" + text[len(home) :] if text.startswith(home) else text
+
+
+def render(result: Probe) -> str:
+    """One directory's verdicts, as ``detect`` prints them."""
+    lines = [f"{_shorten(result.path)}"]
+
+    if result.dedicated:
+        lines.append(f"  dedicated adapter: use `{result.dedicated}` (docs: `{result.dedicated} docs install`)")
+
+    if result.memorization:
+        recognized = result.messages + result.tools
+        lines.append(
+            f"  memorization: works — {len(result.session_files)} session file(s), "
+            f"{recognized}/{result.sampled} sampled record(s) recognized "
+            f"({result.messages} conversation, {result.tools} tool)"
+        )
+    elif result.session_files:
+        lines.append(
+            f"  memorization: no — {len(result.session_files)} .jsonl file(s) found but no record "
+            f"matched a known dialect (not a conversation log, or a new shape)"
+        )
+    elif result.sqlite_files:
+        lines.append(
+            f"  memorization: no — sessions likely live in {_shorten(result.sqlite_files[0])} "
+            f"(SQLite; needs a dedicated adapter, like memu-hermes has)"
+        )
+    else:
+        lines.append("  memorization: no — no session log found")
+
+    if result.retrieval:
+        target = result.instruction_files[0]
+        lines.append(
+            f"  retrieval: works — instruction file {_shorten(target)} "
+            f"(install with `memu-agent install-instruction --path {_shorten(target)}`)"
+        )
+    else:
+        lines.append(
+            "  retrieval: no instruction file found — if this agent reads AGENTS.md from the "
+            "project root, run `memu-agent install-instruction` inside each project"
+        )
+    return "\n".join(lines)

--- a/src/memu/hosts/generic/sessions.py
+++ b/src/memu/hosts/generic/sessions.py
@@ -1,0 +1,141 @@
+"""The generic host: any agent's JSONL session log, dialect sniffed per record.
+
+The five dedicated adapters each hard-code one host's log schema. This source
+covers *everyone else*: agents whose transcripts are JSONL in one of the shapes
+the ecosystem has converged on. Every record is classified by trying the known
+dialects in order — the shapes are mutually exclusive enough that the first
+match is the right one:
+
+1. **payload-wrapped** (Codex lineage): ``{"payload": {"type": "message", "role": …}}``
+2. **typed message tree** (OpenClaw/pi lineage): ``{"type": "message", "message": {"role": …}}``
+3. **typed block records** (Claude Code lineage): ``{"type": "user"|"assistant",
+   "message": {"content": [blocks]}}`` — the block type decides, because tool
+   results ride in user-typed records
+4. **role + message** (Cursor lineage): ``{"role": …, "message": {"content": [blocks]}}``
+5. **flat chat rows** (OpenAI-client lineage, what most new agents log):
+   ``{"role": …, "content": …, "tool_calls": …}``
+
+A record matching no dialect is noise — exactly what the dedicated adapters do
+with their hosts' metadata records, and what keeps a half-recognized log safe:
+the mining jobs see only what provably is conversation or tool traffic.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+from typing import Any, ClassVar
+
+from memu.hosts.base import RecordKind, TranscriptSource
+
+_MESSAGE_ROLES = ("user", "assistant")
+
+
+def _from_epoch(value: float) -> str:
+    seconds = value / 1000 if value > 1e11 else value
+    return datetime.datetime.fromtimestamp(seconds, tz=datetime.UTC).isoformat()
+
+
+def _classify_blocks(content: Any, *, meta: bool = False) -> RecordKind | None:
+    """Shared verdict for block-list content (dialects 3 and 4)."""
+    if isinstance(content, str):
+        return RecordKind.OTHER if meta else RecordKind.MESSAGE
+    if not isinstance(content, list):
+        return None
+    kinds = {block.get("type") for block in content if isinstance(block, dict)}
+    if "text" in kinds:
+        return RecordKind.OTHER if meta else RecordKind.MESSAGE
+    if kinds & {"tool_use", "tool_result", "toolCall", "tool_call"}:
+        return RecordKind.TOOL
+    return RecordKind.OTHER
+
+
+def _classify_payload_wrapped(payload: dict[str, Any]) -> RecordKind:
+    """Dialect 1: the Codex lineage's ``{"payload": {...}}`` wrapper."""
+    kind = payload.get("type")
+    if kind == "message" and payload.get("role") in _MESSAGE_ROLES:
+        return RecordKind.MESSAGE
+    if isinstance(kind, str) and ("function_call" in kind or "tool" in kind):
+        return RecordKind.TOOL
+    return RecordKind.OTHER
+
+
+def _classify_message_tree(message: dict[str, Any]) -> RecordKind:
+    """Dialect 2: the OpenClaw/pi lineage's ``{"type": "message", "message": {...}}``."""
+    role = message.get("role")
+    if role in _MESSAGE_ROLES:
+        return RecordKind.MESSAGE
+    if role in ("toolResult", "tool"):
+        return RecordKind.TOOL
+    return RecordKind.OTHER
+
+
+def _classify_flat_row(entry: dict[str, Any]) -> RecordKind:
+    """Dialect 5: flat OpenAI-client chat rows — role and content at the top level."""
+    role = entry.get("role")
+    if role == "tool" or entry.get("tool_call_id"):
+        return RecordKind.TOOL
+    if role in _MESSAGE_ROLES:
+        if entry.get("content"):
+            verdict = _classify_blocks(entry.get("content"))
+            return verdict if verdict is not None else RecordKind.MESSAGE
+        if entry.get("tool_calls"):
+            return RecordKind.TOOL
+    return RecordKind.OTHER
+
+
+class GenericTranscriptSource(TranscriptSource):
+    """Any agent's JSONL session directory; the record dialect is sniffed."""
+
+    name: ClassVar[str] = "agent"
+
+    def __init__(self, session_dir: str | Path) -> None:
+        import os
+
+        self._root = Path(os.path.expanduser(str(session_dir)))
+
+    def root(self) -> Path:
+        return self._root
+
+    def classify(self, record: str) -> RecordKind:
+        try:
+            entry = json.loads(record)
+        except json.JSONDecodeError:
+            return RecordKind.OTHER
+        if not isinstance(entry, dict):
+            return RecordKind.OTHER
+
+        payload = entry.get("payload")
+        if isinstance(payload, dict):
+            return _classify_payload_wrapped(payload)
+
+        message = entry.get("message")
+        entry_type = entry.get("type")
+        if entry_type == "message" and isinstance(message, dict):
+            return _classify_message_tree(message)
+        if entry_type in _MESSAGE_ROLES and isinstance(message, dict):
+            verdict = _classify_blocks(message.get("content"), meta=bool(entry.get("isMeta")))
+            return verdict if verdict is not None else RecordKind.OTHER
+        if entry.get("role") in _MESSAGE_ROLES and isinstance(message, dict):
+            verdict = _classify_blocks(message.get("content"))
+            return verdict if verdict is not None else RecordKind.OTHER
+        return _classify_flat_row(entry)
+
+    def timestamp(self, record: str) -> str | None:
+        """``timestamp`` wherever the dialect puts it; ISO strings and epochs both."""
+        try:
+            entry = json.loads(record)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(entry, dict):
+            return None
+
+        value = entry.get("timestamp")
+        if value is None and isinstance(entry.get("payload"), dict):
+            value = entry["payload"].get("timestamp")
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (int, float)):
+            return _from_epoch(value)
+        return None

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -68,6 +68,10 @@ class HostSpec:
     extra_flags: dict[str, str] = field(default_factory=dict)
     """Reserved for host-specific flags; unused today."""
 
+    register_extra: Callable[[Any], None] | None = None
+    """Optional hook adding host-specific subcommands (the generic adapter's
+    ``detect``). Called with the subparsers object after the shared verbs."""
+
     @property
     def binary(self) -> str:
         return f"memu-{self.host}"
@@ -171,10 +175,13 @@ def build_parser(spec: HostSpec) -> argparse.ArgumentParser:
     instruction.register(sub, path=spec.instruction_path, binary=spec.binary)
 
     p = with_base(sub.add_parser("prepare", help=f"Slice new {spec.display} sessions into self-evolve job files"))
+    # A host with no universal session location (the generic adapter) leaves
+    # session_dir empty, which makes the flag mandatory instead of defaulted.
     p.add_argument(
         "--session-dir",
-        default=spec.session_dir,
-        help=f"{spec.session_help} (default: {spec.session_dir})",
+        default=spec.session_dir or None,
+        required=not spec.session_dir,
+        help=f"{spec.session_help}" + (f" (default: {spec.session_dir})" if spec.session_dir else ""),
     )
     p.add_argument("--max-jobs", type=int, default=MAX_JOBS, help=f"Sessions per run (default: {MAX_JOBS})")
     p.set_defaults(handler=bind(_cmd_prepare))
@@ -193,6 +200,9 @@ def build_parser(spec: HostSpec) -> argparse.ArgumentParser:
     p = sub.add_parser("docs", help="Print a packaged agent-facing guide")
     p.add_argument("doc", choices=sorted(DOCS), help="install: the setup guide; task: the bridging-task procedure")
     p.set_defaults(handler=bind(_cmd_docs))
+
+    if spec.register_extra is not None:
+        spec.register_extra(sub)
 
     return parser
 

--- a/tests/test_host_generic.py
+++ b/tests/test_host_generic.py
@@ -1,0 +1,144 @@
+"""The generic adapter: does the dialect sniffer read every known shape, and does
+detect() draw the right memorization/retrieval verdicts from a directory?"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+from memu.hosts.base import RecordKind
+from memu.hosts.generic.detect import probe, render, scan_home
+from memu.hosts.generic.sessions import GenericTranscriptSource
+
+
+def _line(entry: dict) -> str:
+    return json.dumps(entry)
+
+
+SOURCE = GenericTranscriptSource("~")
+
+
+# ── the sniffer, one case per dialect ─────────────────────────────────────────
+
+
+def test_sniffs_payload_wrapped_codex_shape() -> None:
+    assert SOURCE.classify(_line({"payload": {"type": "message", "role": "user"}})) is RecordKind.MESSAGE
+    assert SOURCE.classify(_line({"payload": {"type": "function_call", "name": "shell"}})) is RecordKind.TOOL
+    assert SOURCE.classify(_line({"payload": {"type": "reasoning"}})) is RecordKind.OTHER
+
+
+def test_sniffs_typed_message_tree_openclaw_shape() -> None:
+    user = {"type": "message", "message": {"role": "user", "content": "hi"}}
+    tool = {"type": "message", "message": {"role": "toolResult", "content": []}}
+    assert SOURCE.classify(_line(user)) is RecordKind.MESSAGE
+    assert SOURCE.classify(_line(tool)) is RecordKind.TOOL
+    assert SOURCE.classify(_line({"type": "compaction"})) is RecordKind.OTHER
+
+
+def test_sniffs_typed_block_claude_shape() -> None:
+    text = {"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "hey"}]}}
+    tool_result = {"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "content": "ok"}]}}
+    thinking = {"type": "assistant", "message": {"role": "assistant", "content": [{"type": "thinking"}]}}
+    meta = {"type": "user", "isMeta": True, "message": {"role": "user", "content": "<injected>"}}
+    assert SOURCE.classify(_line(text)) is RecordKind.MESSAGE
+    assert SOURCE.classify(_line(tool_result)) is RecordKind.TOOL
+    assert SOURCE.classify(_line(thinking)) is RecordKind.OTHER
+    assert SOURCE.classify(_line(meta)) is RecordKind.OTHER
+
+
+def test_sniffs_role_message_cursor_shape() -> None:
+    user = {"role": "user", "message": {"content": [{"type": "text", "text": "hi"}]}}
+    tool = {"role": "assistant", "message": {"content": [{"type": "tool_use", "name": "Shell"}]}}
+    assert SOURCE.classify(_line(user)) is RecordKind.MESSAGE
+    assert SOURCE.classify(_line(tool)) is RecordKind.TOOL
+
+
+def test_sniffs_flat_openai_chat_rows() -> None:
+    assert SOURCE.classify(_line({"role": "user", "content": "do the thing"})) is RecordKind.MESSAGE
+    assert SOURCE.classify(_line({"role": "assistant", "tool_calls": [{"id": "1"}]})) is RecordKind.TOOL
+    assert SOURCE.classify(_line({"role": "tool", "content": "ok", "tool_call_id": "1"})) is RecordKind.TOOL
+    assert SOURCE.classify(_line({"role": "system", "content": "you are"})) is RecordKind.OTHER
+    assert SOURCE.classify("not json") is RecordKind.OTHER
+
+
+def test_timestamp_handles_iso_epoch_and_payload() -> None:
+    assert SOURCE.timestamp(_line({"timestamp": "2026-07-16T00:00:00Z"})) == "2026-07-16T00:00:00Z"
+    assert SOURCE.timestamp(_line({"timestamp": 1752537600000})) == "2025-07-15T00:00:00+00:00"
+    assert SOURCE.timestamp(_line({"payload": {"timestamp": "2026-07-16T00:00:00Z"}})) == "2026-07-16T00:00:00Z"
+    assert SOURCE.timestamp(_line({"role": "user"})) is None
+
+
+# ── detect: the two verdicts ──────────────────────────────────────────────────
+
+
+def _agent_dir(tmp_path: pathlib.Path, *, sessions: bool, instructions: bool) -> pathlib.Path:
+    root = tmp_path / ".someagent"
+    root.mkdir()
+    if sessions:
+        log = root / "sessions" / "abc.jsonl"
+        log.parent.mkdir()
+        log.write_text(
+            _line({"role": "user", "content": "hello"}) + "\n" + _line({"role": "assistant", "content": "hi"}) + "\n"
+        )
+    if instructions:
+        (root / "AGENTS.md").write_text("# rules\n")
+    return root
+
+
+def test_detect_reports_memorization_when_sessions_sniff(tmp_path: pathlib.Path) -> None:
+    result = probe(_agent_dir(tmp_path, sessions=True, instructions=False))
+    assert result.memorization
+    assert not result.retrieval
+    text = render(result)
+    assert "memorization: works" in text
+    assert "retrieval: no instruction file found" in text
+
+
+def test_detect_falls_back_to_retrieval_when_no_sessions(tmp_path: pathlib.Path) -> None:
+    result = probe(_agent_dir(tmp_path, sessions=False, instructions=True))
+    assert not result.memorization
+    assert result.retrieval
+    text = render(result)
+    assert "memorization: no — no session log found" in text
+    assert "retrieval: works" in text and "AGENTS.md" in text
+
+
+def test_detect_flags_unrecognized_jsonl_and_sqlite(tmp_path: pathlib.Path) -> None:
+    root = tmp_path / ".weird"
+    root.mkdir()
+    (root / "metrics.jsonl").write_text('{"event":"boot","ms":12}\n')
+    (root / "state.db").write_text("not really sqlite")
+
+    result = probe(root)
+    assert not result.memorization and result.session_files
+    text = render(result)
+    assert "no record matched a known dialect" in text
+
+
+def test_detect_points_dedicated_hosts_at_their_binary(tmp_path: pathlib.Path) -> None:
+    root = tmp_path / ".codex"
+    root.mkdir()
+    (root / "AGENTS.md").write_text("# rules\n")
+    assert "memu-codex" in render(probe(root))
+
+
+def test_scan_home_finds_only_plausible_agents(tmp_path: pathlib.Path) -> None:
+    _agent_dir(tmp_path, sessions=True, instructions=True)
+    (tmp_path / ".empty").mkdir()
+    (tmp_path / ".dotfile").write_text("not a dir")
+
+    results = scan_home(tmp_path)
+    assert [result.path.name for result in results] == [".someagent"]
+    assert results[0].memorization and results[0].retrieval
+
+
+def test_generic_prepare_requires_session_dir() -> None:
+    import pytest
+
+    from memu.hosts.generic.cli import SPEC
+    from memu.hosts.host_cli import build_parser
+
+    parser = build_parser(SPEC)
+    with pytest.raises(SystemExit) as excinfo:
+        parser.parse_args(["prepare"])
+    assert excinfo.value.code == 2


### PR DESCRIPTION
Agents without a dedicated binary integrate through **detection** instead of per-host code (ADR 0011).

## `memu-agent detect`

Probes the machine (or one agent's directory) and answers the two seam questions **in order**:

1. **Memorization** — is there a local session log whose records sniff as a known JSONL dialect? Found and recognized → the bridging task can mine it.
2. **Retrieval** — failing (or besides) that, is there an instruction file (`AGENTS.md` / `CLAUDE.md` / `SOUL.md` / `GEMINI.md` / …) for `install-instruction --path` to patch?

It then **tells the user which seams work**, per agent, with the found paths and the exact next command. Dedicated hosts (`~/.codex`, `~/.claude`, …) are redirected to their own binaries; SQLite-contained sessions are reported as needing a dedicated adapter (the Hermes treatment), not silently skipped.

Real output from this machine (excerpt):

```
~/.gemini
  memorization: no — sessions likely live in ~/.gemini/…db (SQLite; needs a dedicated adapter)
  retrieval: works — instruction file ~/.gemini/GEMINI.md
~/.agent-tars
  memorization: no — sessions likely live in ~/.agent-tars/agent-tars.db (SQLite…)
  retrieval: no instruction file found — …
```

## The sniffer

`GenericTranscriptSource.classify` tries the five dialects the ecosystem converged on — payload-wrapped (Codex lineage), typed message tree (OpenClaw/pi), typed block records (Claude Code), role+message blocks (Cursor), flat OpenAI chat rows. Unmatched records are `OTHER`: a half-recognized log degrades to less input, never garbage input.

## Plumbing

`HostSpec` grows `register_extra` (host-specific subcommands) and required `--session-dir` when a host declares no universal session location. Verified end-to-end: `memu-agent prepare --session-dir ~/.claude/projects` sliced a real session via pure sniffing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)