### PR TITLE
docs: add SKILL.md, one routing entry point for agent-driven install

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,15 +115,11 @@ For agents without a dedicated binary, `memu-agent detect` probes the machine an
 
 All hosts share one store and one embedding space via `~/.memu/config.env` — what one host's sessions taught memU, another host retrieves.
 
-**Installation is agent-driven.** The install guide is written for the agent, not for you — install the package, then hand the guide to your agent and let it do the rest (configure the store, register the scheduled bridging task, patch the instruction file — each step ends with a verify gate):
+**Installation is agent-driven.** The guides are written for the agent, not for you. One message is the whole setup — tell your agent:
 
-```bash
-pip install memu-cli    # puts memu + the host binaries on PATH
-```
+> Read https://raw.githubusercontent.com/NevaMind-AI/MemU/main/SKILL.md and follow it to install memU.
 
-Then tell your agent (swap in your host's binary):
-
-> Run `memu-codex docs install`, read the guide it prints, and follow it to install memU.
+[SKILL.md](SKILL.md) is the routing skill: it has the agent install the package, identify which host it is (falling back to `memu-agent detect` for anything without a dedicated adapter), print that host's packaged install guide (`<binary> docs install`), and follow it — configure the store, register the scheduled bridging task, patch the instruction file, each step behind a verify gate — then report which seams (memorization / retrieval) are now active.
 
 Afterwards `<binary> doctor` proves the whole loop resolves: config, store, and a live retrieval.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: install-memu
+description: Install memU for whatever agent you are — identify your host, print its packaged install guide, and follow it to wire both seams (record and inject). Use when the user asks to install, set up, or integrate memU.
+---
+
+# Install memU
+
+> **Audience: the agent.** A user has pointed you at this file ("read SKILL.md
+> and follow it to install memU"). This skill does not contain the install
+> steps — it routes you to the right guide, which ships inside the memU package
+> and is always in sync with the installed code. Do not install from memory or
+> from blog posts; print the guide and follow it to the letter.
+
+memU integrates with a host agent through two seams: **record** (a scheduled
+bridging task mines your session log into durable memory) and **inject** (a
+standing instruction in your instruction file makes you retrieve before
+answering). Each supported host has its own adapter binary carrying its own
+install guide. Your job here is three steps: install the package, pick your
+binary, print and follow its guide.
+
+## Step 1 — install the package
+
+```
+pip install memu-cli
+```
+
+This puts `memu` and every host-adapter binary on `PATH`. If `pip` is not the
+right tool for this machine (managed Python, uv-only), use the equivalent —
+what matters is that the binaries below resolve from a bare, non-interactive
+shell.
+
+## Step 2 — pick your host binary
+
+Identify **which agent you are** (not which agents are installed — the one
+executing this skill):
+
+| You are | Your binary |
+| --- | --- |
+| Codex | `memu-codex` |
+| Claude Code | `memu-claude-code` |
+| Cursor (Agent/CLI) | `memu-cursor` |
+| OpenClaw | `memu-openclaw` |
+| Hermes Agent | `memu-hermes` |
+| anything else | `memu-agent` |
+
+Unsure, or not in the table? You are `memu-agent`. Run:
+
+```
+memu-agent detect
+```
+
+It probes this machine and reports, per agent, whether **memorization** works
+(a recognizable session log exists) and whether **retrieval** works (an
+instruction file exists to patch) — and it will redirect you to a dedicated
+binary if your host turns out to have one.
+
+## Step 3 — print your guide and follow it
+
+```
+<your-binary> docs install
+```
+
+Read what it prints, top to bottom, and follow it exactly. Every guide has the
+same shape — configure the store once in `~/.memu/config.env`, register the
+scheduled bridging task (record), patch your instruction file (inject) — and
+every part ends with a **verify gate**; do not proceed past a failing one.
+
+Two rules that hold for every host:
+
+- **One store.** If `~/.memu/config.env` already exists (another agent on this
+  machine is already integrated), reuse it as is. A second store would split
+  the embedding space and both installs would silently retrieve nothing from
+  each other.
+- **Report the outcome.** When done, tell the user which seams are now active —
+  memorization, retrieval, or both — and where (the session log being mined,
+  the instruction file patched). For `memu-agent`, the detect report decides
+  this; a retrieval-only integration is a valid outcome to report, not a
+  failure to hide.


### PR DESCRIPTION
The user-facing install instruction becomes one host-agnostic sentence:

> Read https://raw.githubusercontent.com/NevaMind-AI/MemU/main/SKILL.md and follow it to install memU.

`SKILL.md` (repo root, skill frontmatter) contains no install steps of its own — it routes. The agent installs `memu-cli`, identifies **which host it is** (table of the five dedicated binaries; anything else → `memu-agent detect`), prints that host's packaged guide with `<binary> docs install`, follows it behind its verify gates, and reports which seams — memorization / retrieval — came out active. Two cross-host rules are stated in the skill because they hold everywhere: reuse an existing `~/.memu/config.env` as is (one store, one embedding space), and always report the seam outcome to the user.

README's host-adapter section now leads with the SKILL.md link instead of a binary-specific command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)