### PR TITLE
fix(tests): pin UTF-8 on test file I/O so the suite passes on non-UTF-8-locale Windows

### DIFF
--- a/tests/test_host_generic.py
+++ b/tests/test_host_generic.py
@@ -78,10 +78,11 @@ def _agent_dir(tmp_path: pathlib.Path, *, sessions: bool, instructions: bool) ->
         log = root / "sessions" / "abc.jsonl"
         log.parent.mkdir()
         log.write_text(
-            _line({"role": "user", "content": "hello"}) + "\n" + _line({"role": "assistant", "content": "hi"}) + "\n"
+            _line({"role": "user", "content": "hello"}) + "\n" + _line({"role": "assistant", "content": "hi"}) + "\n",
+            encoding="utf-8",
         )
     if instructions:
-        (root / "AGENTS.md").write_text("# rules\n")
+        (root / "AGENTS.md").write_text("# rules\n", encoding="utf-8")
     return root
 
 
@@ -106,8 +107,8 @@ def test_detect_falls_back_to_retrieval_when_no_sessions(tmp_path: pathlib.Path)
 def test_detect_flags_unrecognized_jsonl_and_sqlite(tmp_path: pathlib.Path) -> None:
     root = tmp_path / ".weird"
     root.mkdir()
-    (root / "metrics.jsonl").write_text('{"event":"boot","ms":12}\n')
-    (root / "state.db").write_text("not really sqlite")
+    (root / "metrics.jsonl").write_text('{"event":"boot","ms":12}\n', encoding="utf-8")
+    (root / "state.db").write_text("not really sqlite", encoding="utf-8")
 
     result = probe(root)
     assert not result.memorization and result.session_files
@@ -118,14 +119,14 @@ def test_detect_flags_unrecognized_jsonl_and_sqlite(tmp_path: pathlib.Path) -> N
 def test_detect_points_dedicated_hosts_at_their_binary(tmp_path: pathlib.Path) -> None:
     root = tmp_path / ".codex"
     root.mkdir()
-    (root / "AGENTS.md").write_text("# rules\n")
+    (root / "AGENTS.md").write_text("# rules\n", encoding="utf-8")
     assert "memu-codex" in render(probe(root))
 
 
 def test_scan_home_finds_only_plausible_agents(tmp_path: pathlib.Path) -> None:
     _agent_dir(tmp_path, sessions=True, instructions=True)
     (tmp_path / ".empty").mkdir()
-    (tmp_path / ".dotfile").write_text("not a dir")
+    (tmp_path / ".dotfile").write_text("not a dir", encoding="utf-8")
 
     results = scan_home(tmp_path)
     assert [result.path.name for result in results] == [".someagent"]

--- a/tests/test_host_instruction.py
+++ b/tests/test_host_instruction.py
@@ -20,44 +20,44 @@ def test_creates_file_when_absent(tmp_path: pathlib.Path) -> None:
     path = tmp_path / "nested" / "AGENTS.md"
     changed, _ = instruction.install(path, BINARY)
     assert changed
-    assert instruction.instruction(BINARY) in path.read_text()
+    assert instruction.instruction(BINARY) in path.read_text(encoding="utf-8")
 
 
 def test_preserves_existing_content(tmp_path: pathlib.Path) -> None:
     path = tmp_path / "AGENTS.md"
-    path.write_text("# My rules\n\nAlways use tabs.\n")
+    path.write_text("# My rules\n\nAlways use tabs.\n", encoding="utf-8")
     instruction.install(path, BINARY)
 
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     assert "Always use tabs." in text
     assert instruction.instruction(BINARY) in text
     # The user's content is backed up before we touch it.
-    assert (tmp_path / "AGENTS.md.bak").read_text() == "# My rules\n\nAlways use tabs.\n"
+    assert (tmp_path / "AGENTS.md.bak").read_text(encoding="utf-8") == "# My rules\n\nAlways use tabs.\n"
 
 
 def test_install_is_idempotent(tmp_path: pathlib.Path) -> None:
     path = tmp_path / "AGENTS.md"
-    path.write_text("# My rules\n")
+    path.write_text("# My rules\n", encoding="utf-8")
 
     instruction.install(path, BINARY)
-    first = path.read_text()
+    first = path.read_text(encoding="utf-8")
     changed, diff = instruction.install(path, BINARY)
 
     assert not changed and not diff, "a re-run must be a no-op, not a second copy"
-    assert path.read_text() == first
+    assert path.read_text(encoding="utf-8") == first
     assert first.count(instruction.begin(BINARY)) == 1
 
 
 def test_upgrade_replaces_in_place(monkeypatch, tmp_path: pathlib.Path) -> None:
     """The whole reason the block is marker-fenced: a later memU can update it."""
     path = tmp_path / "AGENTS.md"
-    path.write_text("# My rules\n")
+    path.write_text("# My rules\n", encoding="utf-8")
     instruction.install(path, BINARY)
 
     monkeypatch.setattr(instruction, "INSTRUCTION_TEMPLATE", "## memU\n\nNew and improved.\n")
     changed, _ = instruction.install(path, BINARY)
 
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     assert changed
     assert "New and improved." in text
     assert "retrieve before answering" not in text, "the old block must be gone, not duplicated"
@@ -71,7 +71,7 @@ def test_each_host_manages_its_own_block(tmp_path: pathlib.Path) -> None:
     instruction.install(path, "memu-codex")
     instruction.install(path, "memu-claude-code")
 
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     assert text.count(instruction.begin("memu-codex")) == 1
     assert text.count(instruction.begin("memu-claude-code")) == 1
     assert "memu-codex retrieve" in text
@@ -84,13 +84,13 @@ def test_patch_survives_a_file_with_no_trailing_newline() -> None:
 
 def test_dry_run_writes_nothing(tmp_path: pathlib.Path) -> None:
     path = tmp_path / "AGENTS.md"
-    path.write_text("# My rules\n")
+    path.write_text("# My rules\n", encoding="utf-8")
 
     changed, diff = instruction.install(path, BINARY, dry_run=True)
 
     assert not changed
     assert diff, "a dry run still reports what it would do"
-    assert path.read_text() == "# My rules\n"
+    assert path.read_text(encoding="utf-8") == "# My rules\n"
     assert not (tmp_path / "AGENTS.md.bak").exists()
 
 

--- a/tests/test_host_sessions.py
+++ b/tests/test_host_sessions.py
@@ -105,10 +105,10 @@ def test_cursor_discovers_only_agent_transcripts(tmp_path: pathlib.Path) -> None
     """The project dirs also hold canvases and terminal logs — those must not be mined."""
     transcript = tmp_path / "Users-a-proj" / "agent-transcripts" / "abc" / "abc.jsonl"
     transcript.parent.mkdir(parents=True)
-    transcript.write_text('{"role":"user","message":{"content":[{"type":"text","text":"hi"}]}}\n')
+    transcript.write_text('{"role":"user","message":{"content":[{"type":"text","text":"hi"}]}}\n', encoding="utf-8")
     stray = tmp_path / "Users-a-proj" / "terminals" / "log.jsonl"
     stray.parent.mkdir(parents=True)
-    stray.write_text("{}\n")
+    stray.write_text("{}\n", encoding="utf-8")
 
     assert CursorTranscriptSource(tmp_path).discover() == [transcript]
 


### PR DESCRIPTION
## 📝 Pull Request Summary

修复 #500 的问题 2：非 UTF-8 locale 的 Windows（GBK/cp936 等）上测试套件挂 5 个用例。纯机械修改——给测试里的 `read_text`/`write_text` 补上 `encoding="utf-8"`，不动任何断言和逻辑。

---

## ✅ What does this PR do?

- `tests/test_host_instruction.py`：8 处 `read_text` + 4 处 `write_text` 补 `encoding="utf-8"`
- `tests/test_host_generic.py` / `tests/test_host_sessions.py`：8 处裸 `write_text` 同样补上（目前内容纯 ASCII 暂未炸，属同一隐患）

**验证**：zh-CN Windows 11（cp936/GBK，CPython 3.13.12）上，修复前 27 passed / 5 failed → 修复后全套 **59 passed**；`ruff check` / `ruff format --check` 全绿。

---

## 🤔 Why is this change needed?

生产代码 `instruction.install()` 明确用 UTF-8 写文件（managed block 里有 U+2014 长破折号），测试却用**裸 `read_text()`** 读回。Python 3.13 的裸调用走 locale 编码（PEP 686 的 UTF-8 默认要 3.15 才生效），于是：

- GBK Windows：`UnicodeDecodeError: 'gbk' codec can't decode byte 0x94`（0x94 正是长破折号 UTF-8 编码的第三个字节）
- cp1252 Windows：读不报错但乱码（`â€"`），`in` 断言失败

`src/` 里所有 IO 都显式传了 `encoding="utf-8"`，只有测试没传。CI 只跑 ubuntu（UTF-8 locale），所以一直没暴露。

详见 NevaMind-AI/memU#500（问题 2）。

---

## 🔍 Type of Change

- [x] Bug fix

---

## ✅ PR Quality Checklist

- [x] PR title follows an allowed format (for example `feat:`, `fix:`, `docs:`, `memory base:`)
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable（无需）
- [x] No breaking changes (or clearly documented)
- [x] Related issues or discussions linked

---

## 📌 Optional

- [x] Follow-up tasks mentioned：可选加 `windows-latest` CI job 或 `-X warn_default_encoding`（PEP 597）兜住这一类问题——维护者觉得值得的话我单独提；#500 的问题 1（max-jobs 静默丢会话）、问题 3（Hermes URI 转义）会分别单独提 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
