### PR TITLE
docs(hosts): correct the Claude Code multi-block claim and pin it with tests

### DIFF
--- a/src/memu/hosts/claude_code/sessions.py
+++ b/src/memu/hosts/claude_code/sessions.py
@@ -23,17 +23,19 @@ SESSION_DIR = "~/.claude/projects"
 
 
 class ClaudeCodeTranscriptSource(TranscriptSource):
-    """Claude Code writes one JSON object per line, one content block per record.
+    """Claude Code writes one JSON object per line, usually one content block per record.
 
     A record whose ``type`` is ``user`` or ``assistant`` wraps an API-shaped
-    ``message``; its single content block says what the record is. ``text`` (or a
-    plain-string user message) is a conversation turn; ``tool_use`` and
-    ``tool_result`` are the tool record and its output — Claude Code logs the
-    result as a *user*-typed record, so the role alone cannot classify. Everything
-    else — ``thinking`` blocks, meta-injected user records (``isMeta``), and the
-    non-message types (``queue-operation``, ``attachment``, ``system``,
-    ``pr-link``, ``last-prompt``, ``summary``) — is noise the mining jobs should
-    never see.
+    ``message``; its content blocks say what the record is. Most records carry a
+    single block, but multi-block records occur in real logs (``text`` alongside
+    the ``tool_use`` calls it narrates, ``thinking`` alongside ``tool_use``) — a
+    ``text`` block wins. ``text`` (or a plain-string user message) is a
+    conversation turn; ``tool_use`` and ``tool_result`` are the tool record and
+    its output — Claude Code logs the result as a *user*-typed record, so the
+    role alone cannot classify. Everything else — ``thinking`` blocks,
+    meta-injected user records (``isMeta``), and the non-message types
+    (``queue-operation``, ``attachment``, ``system``, ``pr-link``,
+    ``last-prompt``, ``summary``) — is noise the mining jobs should never see.
     """
 
     name: ClassVar[str] = "claude-code"

--- a/tests/test_host_sessions.py
+++ b/tests/test_host_sessions.py
@@ -64,6 +64,42 @@ def test_claude_code_classify_tool_records() -> None:
     assert source.classify(_line(tool_result)) is RecordKind.TOOL
 
 
+def test_claude_code_classify_multi_block_records() -> None:
+    """Real logs carry multi-block records; a ``text`` block wins (see the class
+    docstring). Pinned so a refactor that inspects only ``content[0]`` — which
+    would pass every single-block fixture above — fails here instead of silently
+    losing records: ``thinking`` precedes ``tool_use`` inside real records, so
+    first-block logic would bucket them OTHER and the tool call would vanish
+    from the skill transcript. Cursor's narrated_tool test cannot catch this;
+    each host has its own classify.
+    """
+    source = ClaudeCodeTranscriptSource()
+    narrated_tool = {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Running the build."},
+                {"type": "tool_use", "name": "Bash", "input": {"command": "make"}},
+            ],
+        },
+    }
+    thinking_then_tool = {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "hmm"},
+                {"type": "tool_use", "name": "Bash", "input": {}},
+            ],
+        },
+    }
+    # Prose sharing a record with the tool calls it narrates stays conversation.
+    assert source.classify(_line(narrated_tool)) is RecordKind.MESSAGE
+    # No prose: the tool call must survive as TOOL even with thinking in front.
+    assert source.classify(_line(thinking_then_tool)) is RecordKind.TOOL
+
+
 def test_claude_code_drops_noise() -> None:
     source = ClaudeCodeTranscriptSource()
     thinking = {


### PR DESCRIPTION
## 📝 Pull Request Summary

修正 #500 的问题 4，并把修正后的断言钉进测试：`ClaudeCodeTranscriptSource` 的 docstring 说「每条记录一个 content block」，与真实日志不符。本 PR ①修正描述，②新增两条多 block fixture 把「a text block wins」变成测试执法的规则。**classify 本身零改动。**

---

## ✅ What does this PR do?

- `src/memu/hosts/claude_code/sessions.py`：docstring 修正——「one content block per record」→「usually one …」，补充多 block 记录的存在及 classify 的处理方式（有 `text` block 即归 MESSAGE，进两份 transcript）。
- `tests/test_host_sessions.py`：新增 `test_claude_code_classify_multi_block_records`——`text`+`tool_use` → MESSAGE、`thinking`+`tool_use` → TOOL。**没有它**：一个只看 `content[0]` 的"简化"重构能通过现有全部单 block 用例（CI 全绿），却会把 thinking 开头的多 block 记录静默判成 OTHER——工具调用从 skill transcript 消失，无报警。Cursor 的 `narrated_tool` 用例覆盖不到这里（每个宿主是独立的 classify 实现）。

---

## 🤔 Why is this change needed?

用真实 Claude Code 会话数据（453 个会话 / 123,808 条记录）验证时发现，多 block 记录确实存在：

- `text` + `tool_use`（叙述伴随工具调用）
- `thinking` + `tool_use`
- `image` + `text`

`classify()` 的处理本来就是**对的**（text 胜出 → MESSAGE 进两份 transcript，工具信息不丢），错的只有 docstring。而 docstring 是下一个宿主适配器作者的第一手参考（ADR 0010：「下一个宿主就是一个 classify 方法」）——错误的单 block 断言会直接误导第七个适配器的实现。

至于为什么文档修正要带测试：契约只写在文档里、没有测试执法，就会漂移——#499 即前车之鉴（embed 的元组契约写在 base.py，但测试 fake 不遵守，于是全绿地坏掉）。

**验证**：`tests/test_host_sessions.py` 12/12 通过，`ruff check` / `ruff format` 全绿；另附真实 pipeline 端到端复验记录（见下方评论），docstring 的每条断言均有实测背书。

详见 NevaMind-AI/memU#500（问题 4）。

---

## 🔍 Type of Change

- [x] Documentation update
- [x] Other: 为修正后的文档断言补回归测试（行为零变化）

---

## ✅ PR Quality Checklist

- [x] PR title follows an allowed format (for example `feat:`, `fix:`, `docs:`, `memory base:`)
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable
- [x] No breaking changes (or clearly documented)
- [x] Related issues or discussions linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
