### PR TITLE
fix(hermes): escape the state.db path when building the SQLite URI

### DIFF
--- a/src/memu/hosts/hermes/sessions.py
+++ b/src/memu/hosts/hermes/sessions.py
@@ -66,7 +66,10 @@ class HermesTranscriptSource(TranscriptSource):
     def _connect(self) -> sqlite3.Connection:
         # Read-only: the bridging task must never take Hermes's write lock —
         # the gateway and live CLI sessions share this database in WAL mode.
-        return sqlite3.connect(f"file:{self._db}?mode=ro", uri=True)
+        # The path is percent-encoded into a proper file: URI — pasted in raw,
+        # a '%' in the path would decode and a '#' would truncate it, silently
+        # taking ?mode=ro (and the read-only guarantee) with it.
+        return sqlite3.connect(f"{self._db.resolve().as_uri()}?mode=ro", uri=True)
 
     def discover(self) -> list[Path]:
         """Sessions with messages, most-recently-active first, as virtual paths.

--- a/tests/test_host_sessions.py
+++ b/tests/test_host_sessions.py
@@ -203,3 +203,17 @@ def test_hermes_missing_db_is_empty_not_an_error(tmp_path: pathlib.Path) -> None
     source = HermesTranscriptSource(tmp_path / "state.db")
     assert not source.exists()
     assert source.discover() == []
+
+
+def test_hermes_opens_paths_with_uri_special_characters(tmp_path: pathlib.Path) -> None:
+    """Pasted raw into a file: URI, '%' would percent-decode and '#' would
+    truncate the path — silently taking ?mode=ro with it. So the URI is escaped."""
+    import pytest
+
+    weird = tmp_path / "pct %41 #frag"
+    weird.mkdir()
+    source = HermesTranscriptSource(_hermes_db(weird))
+
+    assert [source.key(path) for path in source.discover()] == ["new", "old"]
+    with pytest.raises(sqlite3.OperationalError, match="readonly"):
+        source._connect().execute("INSERT INTO messages (session_id, role, timestamp) VALUES ('x', 'user', 1)")


### PR DESCRIPTION
## 📝 Pull Request Summary

修复 #500 的问题 3：Hermes 适配器把文件路径**原样**拼进 SQLite 的 `file:` URI，路径带 `%` 或 `#` 时打不开库，`#` 还会静默丢掉 `?mode=ro`（只读保证失效）。

---

## ✅ What does this PR do?

- `src/memu/hosts/hermes/sessions.py` 的 `_connect()`：改用 `Path.resolve().as_uri()` 构造 URI（会把 `%`/`#`/空格等百分号编码，相对路径也顺带绝对化），再拼 `?mode=ro`。
- 新增回归测试 `test_hermes_opens_paths_with_uri_special_characters`：在名字带 `%41` 和 `#` 的目录里建库，验证两件事——能正常 discover，且连接仍然是只读（`INSERT` 报 `readonly`）。已验证该测试在旧代码上确实失败。

---

## 🤔 Why is this change needed?

原代码：

```python
sqlite3.connect(f"file:{self._db}?mode=ro", uri=True)
```

SQLite 按 URI 语法解析这串字符：

- 路径带 `%` → 被百分号解码 → `OperationalError: unable to open database file`
- 路径带 `#` → 后面全部被当 fragment 截掉 → **打开截断后的错误路径**；而且 `?mode=ro` 也在 `#` 后面，一起被吞 → 连接变成**可写**，还会在错误路径创建一个空库。适配器自己承诺的「绝不抢 Hermes 的 WAL 写锁」就此失效
- `%` 和 `#` 在 Windows / POSIX 目录名里都是合法字符

详见 NevaMind-AI/memU#500（问题 3）。

**验证**：`tests/test_host_sessions.py` 12 passed；`ruff check` / `ruff format --check` 全绿。（本机全套还有 5 个失败是 #500 问题 2 的已知 GBK 编码问题，由 #501 修复，与本 PR 无关，ubuntu CI 不受影响。）

---

## 🔍 Type of Change

- [x] Bug fix

---

## ✅ PR Quality Checklist

- [x] PR title follows an allowed format (for example `feat:`, `fix:`, `docs:`, `memory base:`)
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable（`_connect` 内注释已更新说明原因）
- [x] No breaking changes (or clearly documented)
- [x] Related issues or discussions linked

---

## 📌 Optional

- [x] Edge cases considered：空格路径本来就正常（已测）；相对 `--session-dir` 经 `resolve()` 绝对化后行为不变；非 ASCII 路径由 `as_uri()` 按 UTF-8 百分号编码，SQLite 端解码一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)
