### PR TITLE
fix(app): unpack the (vectors, raw_response) tuple embed() returns

### DIFF
--- a/src/memu/app/agentic.py
+++ b/src/memu/app/agentic.py
@@ -13,6 +13,18 @@ if TYPE_CHECKING:
     from memu.database.models import RecallFile, Resource
 
 
+async def _embed_one(embed_client: Any, text: str) -> list[float]:
+    """One text in, one vector out.
+
+    ``embed`` returns ``(vectors, raw_response)`` — the raw response carries
+    provider usage metadata (see :class:`memu.embedding.base.EmbeddingClient`).
+    Every call site here wants just the vector; indexing the tuple with ``[0]``
+    would hand back the whole vectors list instead.
+    """
+    vectors, _ = await embed_client.embed([text])
+    return vectors[0]
+
+
 class AgenticMixin:
     if TYPE_CHECKING:
         _get_database: Callable[[], Database]
@@ -64,7 +76,7 @@ class AgenticMixin:
         where_filters = self._normalize_where(where)
         config = self.progressive_retrieve_config
         embed_client = self._get_embedding_client("embedding")
-        query_vector = (await embed_client.embed([query]))[0]
+        query_vector = await _embed_one(embed_client, query)
 
         segment_hits, segment_pool = self._recall_segments(
             store=store, where_filters=where_filters, query_vector=query_vector, enabled=config.file.enabled
@@ -265,7 +277,7 @@ class AgenticMixin:
                 store.recall_file_resource_repo.unlink_resource(res.id)
                 store.resource_repo.delete_resource(res.id)
 
-            caption_embedding = (await embed_client.embed([caption]))[0] if caption else None
+            caption_embedding = await _embed_one(embed_client, caption) if caption else None
             res = store.resource_repo.create_resource(
                 url=url,
                 local_path=url,
@@ -307,7 +319,7 @@ class AgenticMixin:
             file = {f.name: f for f in existing.values()}.get(name)
             if file is None:
                 emb_text = f"{name}: {description}" if description else name
-                embedding = (await embed_client.embed([emb_text]))[0]
+                embedding = await _embed_one(embed_client, emb_text)
                 file = store.recall_file_repo.get_or_create_category(
                     name=name,
                     description=description,
@@ -372,7 +384,7 @@ class AgenticMixin:
         to_add = [text for text in new_texts if text not in existing_texts]
         if not to_add:
             return
-        vecs = await embed_client.embed(to_add)
+        vecs, _ = await embed_client.embed(to_add)
         for text, vec in zip(to_add, vecs, strict=True):
             store.recall_file_segment_repo.create_segment(
                 recall_file_id=file.id, track=file_track, text=text, embedding=vec, user_data=dict(user_scope)

--- a/src/memu/app/agentic.py
+++ b/src/memu/app/agentic.py
@@ -21,6 +21,7 @@ async def _embed_one(embed_client: Any, text: str) -> list[float]:
     Every call site here wants just the vector; indexing the tuple with ``[0]``
     would hand back the whole vectors list instead.
     """
+    vectors: list[list[float]]
     vectors, _ = await embed_client.embed([text])
     return vectors[0]
 

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -15,11 +15,16 @@ from memu.app import MemoryService
 
 
 class FakeEmbeddingClient:
-    """Deterministic embeddings: similar strings share a prefix dimension."""
+    """Deterministic embeddings: similar strings share a prefix dimension.
+
+    Returns ``(vectors, raw_response)`` like every real client
+    (:class:`memu.embedding.base.EmbeddingClient`) — a fake returning a bare
+    list is exactly what let the tuple-consumption bug (#499) through.
+    """
 
     embed_model = "fake"
 
-    async def embed(self, inputs: list[str]) -> list[list[float]]:
+    async def embed(self, inputs: list[str]) -> tuple[list[list[float]], None]:
         vectors = []
         for text in inputs:
             lowered = text.lower()
@@ -29,7 +34,7 @@ class FakeEmbeddingClient:
                 1.0 if "notes" in lowered else 0.0,
                 float(len(lowered) % 5) / 10.0,
             ])
-        return vectors
+        return vectors, None
 
 
 def make_service(database_config: dict[str, Any]) -> MemoryService:


### PR DESCRIPTION
## 📝 Pull Request Summary

Fixes #499：`embed()` 返回 `(vectors, raw_response)` 元组，但 `agentic.py` 按裸列表消费，导致 `memu commit` 必挂、带数据的 `retrieve` 同样不可用（任何真实 provider 都一样）。这是**消费侧的最小修复**：4 个调用点解包元组 + 把测试 fake 改诚实，共 ~20 行。



---

## ✅ What does this PR do?

- `src/memu/app/agentic.py`：新增一个 8 行的 `_embed_one(client, text)` 帮助函数（单文本进、单向量出，内部解包元组），L67 / L268 / L310 三处单文本调用改走它；L375 的批量调用改为 `vecs, _ = await embed_client.embed(to_add)`。
- `tests/test_agentic.py`：`FakeEmbeddingClient.embed` 从返回裸列表改为返回 `(vectors, None)`——与 `EmbeddingClient` 基类契约一致。**fake 返回裸列表正是让这个 bug 穿过 CI 的原因**；改诚实之后，整个 `test_agentic.py` 就是这条契约的回归测试（已验证：不带修复只改 fake，10 个用例挂 8 个）。

---

## 🤔 Why is this change needed?

`(await embed_client.embed([q]))[0]` 的本意是「取第一个向量」，实际取到的是元组第一元——**整个 vectors 列表**。于是 `RecallFile(embedding=[[...]])` 触发 pydantic `float_type` 校验错误；L375 的 `zip(to_add, vecs, strict=True)` 则是对着二元组 zip。

**验证**（本地 Ollama + BGE-M3，1024 维）：

- 修复前：`memu commit` 必挂（报错的 `input_value` 里就是真实向量值，见 #499 的补充评论）
- 修复后：round-trip 全通——

```
$ memu commit -   # {"recall_files":[{"name":"prefs","track":"memory",...}]}
committed 1 recall file(s) and 0 resource(s)
  - memory/prefs

$ memu retrieve "does the user like dark mode"
segments: "- likes dark mode"  score 0.87
          "- ships on Fridays" score 0.39
```

- `tests/test_agentic.py` 10 passed；`ruff check` / `ruff format` 全绿

**与 `cleanup-flow-db-embedding` 分支的关系**：那边的方向是把 client 侧契约收敛成裸 `list[list[float]]`，也成立。本 PR 选择消费侧解包，理由是改动面最小（不动三个 client 与其调用方）、保留 `raw_response` 通道（基类 docstring 写明它承载 usage 元数据）。两者取其一即可；若维护者倾向 client 侧收敛，本 PR 里 **fake 改诚实 + 回归测试**的部分依然值得单独保留（届时 fake 应与新契约同步改为裸列表）。

详见 #499 与 NevaMind-AI/memU#500（问题 0）。

---

## 🔍 Type of Change

- [x] Bug fix

---

## ✅ PR Quality Checklist

- [x] PR title follows an allowed format (for example `feat:`, `fix:`, `docs:`, `memory base:`)
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable（`_embed_one` docstring 说明了元组契约）
- [x] No breaking changes (or clearly documented)
- [x] Related issues or discussions linked

---

## 📌 Optional

- [x] Edge cases considered：批量路径（L375）连同 `strict=True` 的 zip 一并修复；空 caption 的条件分支行为不变
- [x] Follow-up tasks mentioned：若后续合入 client 侧收敛（cleanup 分支方向），只需同步调整 `_embed_one` 与 fake 两处

🤖 Generated with [Claude Code](https://claude.com/claude-code)
