### PR TITLE
docs(hosts): document the per-run session cap as intended backlog shedding

### DIFF
--- a/src/memu/hosts/bridging/transcripts.py
+++ b/src/memu/hosts/bridging/transcripts.py
@@ -51,7 +51,9 @@ def prepare_transcripts(
     memU marks the start of memory accumulation, and no run — the first one
     especially — should carry an unbounded backlog. A shed session is mined
     later only if it gains new turns; that lifts it above the early stop, which
-    otherwise ends the scan before reaching it. Intentional; settled in #500.
+    otherwise ends the scan before reaching it — a later run does not return
+    for shed sessions even when it mines fewer than ``max_jobs``. Intentional;
+    settled in #500.
 
     Returns the number of sessions written. Zero is the correct, common outcome
     on a quiet day.

--- a/src/memu/hosts/bridging/transcripts.py
+++ b/src/memu/hosts/bridging/transcripts.py
@@ -47,6 +47,12 @@ def prepare_transcripts(
     with new lines are written oldest-first as ``<idx>.jsonl`` (conversation) and
     ``<idx>_full.jsonl`` (conversation plus tool calls), with ``idx`` from 1.
 
+    Sessions beyond ``max_jobs`` are deliberately shed, not queued: installing
+    memU marks the start of memory accumulation, and no run — the first one
+    especially — should carry an unbounded backlog. A shed session is mined
+    later only if it gains new turns; that lifts it above the early stop, which
+    otherwise ends the scan before reaching it. Intentional; settled in #500.
+
     Returns the number of sessions written. Zero is the correct, common outcome
     on a quiet day.
     """

--- a/src/memu/hosts/claude_code/BRIDGING_TASK.md
+++ b/src/memu/hosts/claude_code/BRIDGING_TASK.md
@@ -74,6 +74,12 @@ work to do once there are new Claude Code sessions since the last run.
 - **Idempotent and incremental.** `prepare` tracks a per-session line cursor in
   `~/.memu/hosts/claude-code/.session_manifest.claude-code.json`, so each run
   only processes turns it hasn't seen.
+- **Bounded per run.** Each run mines at most `--max-jobs` sessions (default
+  10), newest first; sessions beyond the cap are skipped, not queued — memU
+  starts accumulating memory when installed and does not retroactively mine a
+  backlog. A skipped session is only picked up later if it gains new turns, so
+  if more than 10 sessions regularly change between runs, schedule the task
+  more frequently or raise `--max-jobs`.
 - **Ordering is load-bearing.** Memory jobs are numbered before skill jobs, and
   the resource-describe job is last. Always process in ascending numeric order.
 - **The working tree is host-scoped.** Everything under

--- a/src/memu/hosts/claude_code/BRIDGING_TASK.md
+++ b/src/memu/hosts/claude_code/BRIDGING_TASK.md
@@ -77,9 +77,10 @@ work to do once there are new Claude Code sessions since the last run.
 - **Bounded per run.** Each run mines at most `--max-jobs` sessions (default
   10), newest first; sessions beyond the cap are skipped, not queued — memU
   starts accumulating memory when installed and does not retroactively mine a
-  backlog. A skipped session is only picked up later if it gains new turns, so
-  if more than 10 sessions regularly change between runs, schedule the task
-  more frequently or raise `--max-jobs`.
+  backlog. A skipped session is only picked up later if it gains new turns — a
+  later run does not return for it even when it has spare capacity — so if
+  more than 10 sessions regularly change between runs, schedule the task more
+  frequently or raise `--max-jobs`.
 - **Ordering is load-bearing.** Memory jobs are numbered before skill jobs, and
   the resource-describe job is last. Always process in ascending numeric order.
 - **The working tree is host-scoped.** Everything under

--- a/src/memu/hosts/codex/BRIDGING_TASK.md
+++ b/src/memu/hosts/codex/BRIDGING_TASK.md
@@ -109,6 +109,12 @@ are new Codex sessions since the last run.
 - **Idempotent and incremental.** `prepare` tracks a per-session line cursor in
   `~/.memu/.session_manifest.codex.json`, so each run only processes turns it
   hasn't seen. A run with no new session activity correctly does nothing.
+- **Bounded per run.** Each run mines at most `--max-jobs` sessions (default
+  10), newest first; sessions beyond the cap are skipped, not queued — memU
+  starts accumulating memory when installed and does not retroactively mine a
+  backlog. A skipped session is only picked up later if it gains new turns, so
+  if more than 10 sessions regularly change between runs, schedule the task
+  more frequently or raise `--max-jobs`.
 - **Ordering is load-bearing.** Memory jobs are numbered before skill jobs, and
   the resource-describe job is last — later jobs depend on files earlier ones
   write (the skill jobs are what populate the touched-file log the resource job

--- a/src/memu/hosts/codex/BRIDGING_TASK.md
+++ b/src/memu/hosts/codex/BRIDGING_TASK.md
@@ -112,9 +112,10 @@ are new Codex sessions since the last run.
 - **Bounded per run.** Each run mines at most `--max-jobs` sessions (default
   10), newest first; sessions beyond the cap are skipped, not queued — memU
   starts accumulating memory when installed and does not retroactively mine a
-  backlog. A skipped session is only picked up later if it gains new turns, so
-  if more than 10 sessions regularly change between runs, schedule the task
-  more frequently or raise `--max-jobs`.
+  backlog. A skipped session is only picked up later if it gains new turns — a
+  later run does not return for it even when it has spare capacity — so if
+  more than 10 sessions regularly change between runs, schedule the task more
+  frequently or raise `--max-jobs`.
 - **Ordering is load-bearing.** Memory jobs are numbered before skill jobs, and
   the resource-describe job is last — later jobs depend on files earlier ones
   write (the skill jobs are what populate the touched-file log the resource job

--- a/src/memu/hosts/cursor/BRIDGING_TASK.md
+++ b/src/memu/hosts/cursor/BRIDGING_TASK.md
@@ -73,9 +73,10 @@ since the last run.
 - **Bounded per run.** Each run mines at most `--max-jobs` sessions (default
   10), newest first; sessions beyond the cap are skipped, not queued — memU
   starts accumulating memory when installed and does not retroactively mine a
-  backlog. A skipped session is only picked up later if it gains new turns, so
-  if more than 10 sessions regularly change between runs, schedule the task
-  more frequently or raise `--max-jobs`.
+  backlog. A skipped session is only picked up later if it gains new turns — a
+  later run does not return for it even when it has spare capacity — so if
+  more than 10 sessions regularly change between runs, schedule the task more
+  frequently or raise `--max-jobs`.
 - **Ordering is load-bearing.** Memory jobs before skill jobs, the
   resource-describe job last. Always ascending numeric order.
 - **The working tree is host-scoped.** Everything under `~/.memu/hosts/cursor/`

--- a/src/memu/hosts/cursor/BRIDGING_TASK.md
+++ b/src/memu/hosts/cursor/BRIDGING_TASK.md
@@ -70,6 +70,12 @@ since the last run.
 
 - **Idempotent and incremental.** `prepare` tracks a per-session line cursor in
   `~/.memu/hosts/cursor/.session_manifest.cursor.json`.
+- **Bounded per run.** Each run mines at most `--max-jobs` sessions (default
+  10), newest first; sessions beyond the cap are skipped, not queued — memU
+  starts accumulating memory when installed and does not retroactively mine a
+  backlog. A skipped session is only picked up later if it gains new turns, so
+  if more than 10 sessions regularly change between runs, schedule the task
+  more frequently or raise `--max-jobs`.
 - **Ordering is load-bearing.** Memory jobs before skill jobs, the
   resource-describe job last. Always ascending numeric order.
 - **The working tree is host-scoped.** Everything under `~/.memu/hosts/cursor/`

--- a/src/memu/hosts/generic/BRIDGING_TASK.md
+++ b/src/memu/hosts/generic/BRIDGING_TASK.md
@@ -101,9 +101,10 @@ last run.
 - **Bounded per run.** Each run mines at most `--max-jobs` sessions (default
   10), newest first; sessions beyond the cap are skipped, not queued — memU
   starts accumulating memory when installed and does not retroactively mine a
-  backlog. A skipped session is only picked up later if it gains new turns, so
-  if more than 10 sessions regularly change between runs, schedule the task
-  more frequently or raise `--max-jobs`.
+  backlog. A skipped session is only picked up later if it gains new turns — a
+  later run does not return for it even when it has spare capacity — so if
+  more than 10 sessions regularly change between runs, schedule the task more
+  frequently or raise `--max-jobs`.
 - **Several generic agents on one machine** must not share a working tree: add
   `--base-dir ~/.memu/hosts/<name>` to both `prepare` and `commit` in each
   task's prompt.

--- a/src/memu/hosts/generic/BRIDGING_TASK.md
+++ b/src/memu/hosts/generic/BRIDGING_TASK.md
@@ -98,6 +98,12 @@ last run.
 
 - **Idempotent and incremental.** `prepare` tracks a per-session line cursor
   in `~/.memu/hosts/agent/.session_manifest.agent.json`.
+- **Bounded per run.** Each run mines at most `--max-jobs` sessions (default
+  10), newest first; sessions beyond the cap are skipped, not queued — memU
+  starts accumulating memory when installed and does not retroactively mine a
+  backlog. A skipped session is only picked up later if it gains new turns, so
+  if more than 10 sessions regularly change between runs, schedule the task
+  more frequently or raise `--max-jobs`.
 - **Several generic agents on one machine** must not share a working tree: add
   `--base-dir ~/.memu/hosts/<name>` to both `prepare` and `commit` in each
   task's prompt.

--- a/src/memu/hosts/hermes/BRIDGING_TASK.md
+++ b/src/memu/hosts/hermes/BRIDGING_TASK.md
@@ -76,9 +76,10 @@ the last run.
 - **Bounded per run.** Each run mines at most `--max-jobs` sessions (default
   10), newest first; sessions beyond the cap are skipped, not queued — memU
   starts accumulating memory when installed and does not retroactively mine a
-  backlog. A skipped session is only picked up later if it gains new messages,
-  so if more than 10 sessions regularly change between runs, schedule the task
-  more frequently or raise `--max-jobs`.
+  backlog. A skipped session is only picked up later if it gains new messages —
+  a later run does not return for it even when it has spare capacity — so if
+  more than 10 sessions regularly change between runs, schedule the task more
+  frequently or raise `--max-jobs`.
 - **Ordering is load-bearing.** Memory jobs before skill jobs, the
   resource-describe job last. Always ascending numeric order.
 - **The working tree is host-scoped.** Everything under `~/.memu/hosts/hermes/`

--- a/src/memu/hosts/hermes/BRIDGING_TASK.md
+++ b/src/memu/hosts/hermes/BRIDGING_TASK.md
@@ -73,6 +73,12 @@ the last run.
   cursor in `~/.memu/hosts/hermes/.session_manifest.hermes.json`, keyed by
   session id — messages are append-only per session, so the count-cursor is
   exactly the line cursor the other hosts use.
+- **Bounded per run.** Each run mines at most `--max-jobs` sessions (default
+  10), newest first; sessions beyond the cap are skipped, not queued — memU
+  starts accumulating memory when installed and does not retroactively mine a
+  backlog. A skipped session is only picked up later if it gains new messages,
+  so if more than 10 sessions regularly change between runs, schedule the task
+  more frequently or raise `--max-jobs`.
 - **Ordering is load-bearing.** Memory jobs before skill jobs, the
   resource-describe job last. Always ascending numeric order.
 - **The working tree is host-scoped.** Everything under `~/.memu/hosts/hermes/`

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -183,7 +183,12 @@ def build_parser(spec: HostSpec) -> argparse.ArgumentParser:
         required=not spec.session_dir,
         help=f"{spec.session_help}" + (f" (default: {spec.session_dir})" if spec.session_dir else ""),
     )
-    p.add_argument("--max-jobs", type=int, default=MAX_JOBS, help=f"Sessions per run (default: {MAX_JOBS})")
+    p.add_argument(
+        "--max-jobs",
+        type=int,
+        default=MAX_JOBS,
+        help=f"Sessions per run (default: {MAX_JOBS}); sessions beyond the cap are skipped, not queued",
+    )
     p.set_defaults(handler=bind(_cmd_prepare))
 
     p = with_base(sub.add_parser("commit", help="Submit what the self-evolve jobs produced back into memU"))

--- a/src/memu/hosts/openclaw/BRIDGING_TASK.md
+++ b/src/memu/hosts/openclaw/BRIDGING_TASK.md
@@ -101,9 +101,10 @@ OpenClaw sessions since the last run.
 - **Bounded per run.** Each run mines at most `--max-jobs` sessions (default
   10), newest first; sessions beyond the cap are skipped, not queued — memU
   starts accumulating memory when installed and does not retroactively mine a
-  backlog. A skipped session is only picked up later if it gains new turns, so
-  if more than 10 sessions regularly change between runs, schedule the task
-  more frequently or raise `--max-jobs`.
+  backlog. A skipped session is only picked up later if it gains new turns — a
+  later run does not return for it even when it has spare capacity — so if
+  more than 10 sessions regularly change between runs, schedule the task more
+  frequently or raise `--max-jobs`.
 - **Ordering is load-bearing.** Memory jobs before skill jobs, the
   resource-describe job last. Always ascending numeric order.
 - **The working tree is host-scoped.** Everything under

--- a/src/memu/hosts/openclaw/BRIDGING_TASK.md
+++ b/src/memu/hosts/openclaw/BRIDGING_TASK.md
@@ -98,6 +98,12 @@ OpenClaw sessions since the last run.
 
 - **Idempotent and incremental.** `prepare` tracks a per-session line cursor in
   `~/.memu/hosts/openclaw/.session_manifest.openclaw.json`.
+- **Bounded per run.** Each run mines at most `--max-jobs` sessions (default
+  10), newest first; sessions beyond the cap are skipped, not queued — memU
+  starts accumulating memory when installed and does not retroactively mine a
+  backlog. A skipped session is only picked up later if it gains new turns, so
+  if more than 10 sessions regularly change between runs, schedule the task
+  more frequently or raise `--max-jobs`.
 - **Ordering is load-bearing.** Memory jobs before skill jobs, the
   resource-describe job last. Always ascending numeric order.
 - **The working tree is host-scoped.** Everything under


### PR DESCRIPTION
## 📝 Pull Request Summary

按 #500 里维护者的意见落地问题 1 的处理：`--max-jobs` 之外的会话被丢弃（不排队）**是预期设计**——「安装 memU 即记忆积累的起点，不追溯过往」——本 PR 只做文档化，行为零改动。

---

## ✅ What does this PR do?

在三个位置写明这一行为，对应三种读者：

1. **`BRIDGING_TASK.md` × 6**（决定调度频率的人）：Notes 里新增 "**Bounded per run**" 一条——每轮最多挖 `--max-jobs` 个会话（默认 10）、超出的不排队、被略过的会话只有再产生新内容才会被挖；重度用户（两次运行间经常 >10 个会话变动）应提高调度频率或调大 `--max-jobs`。放在这里是因为该文件的 Step 1 就是「settle the schedule」——**做调度决定的那一刻正是需要知道这件事的那一刻**。
2. **`--max-jobs` 的 `--help` 文案**（`host_cli.py`，一处覆盖全部 6 个二进制）：补 "sessions beyond the cap are skipped, not queued"。
3. **`prepare_transcripts` 的 docstring**（未来读代码的人）：明文标注 shed 是有意为之（含设计理由，引 #500）——防止下一个读者把设计当 bug「修掉」（我们自己就是这样发现它的）。

---

## 🤔 Why is this change needed?

#500 问题 1 报告了该行为；维护者确认是预期设计并倾向文档化处理（见 #500 内回复）。未文档化的代价是双向的：用户侧，重度使用下会话被静默略过而无处得知补救手段（调频率 / 调 `--max-jobs`）；开发侧，行为看起来像 bug，会被反复报告或被"修复"。

**验证**：`make check` 全绿（mypy 113 文件、ruff、deptry），61/61 测试通过。文档与 help 文案改动，无行为变化。

---

## 🔍 Type of Change

- [x] Documentation update

---

## ✅ PR Quality Checklist

- [x] PR title follows an allowed format (for example `feat:`, `fix:`, `docs:`, `memory base:`)
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable
- [x] No breaking changes (or clearly documented)
- [x] Related issues or discussions linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
