### PR TITLE
docs(hosts): no-key local fallback hint; default bridging schedule to cron

### DIFF
--- a/src/memu/hosts/claude_code/BRIDGING_TASK.md
+++ b/src/memu/hosts/claude_code/BRIDGING_TASK.md
@@ -53,8 +53,9 @@ day at midnight**, cron `0 0 * * *` (local time). Confirm before creating.
 
 ## Step 2 — register the scheduled run
 
-Create a system cron entry (or launchd job on macOS, if the user prefers) that
-runs Claude Code headless with the pipeline prompt:
+Create a system cron entry — the default, macOS included (use launchd only if
+the user explicitly asks for it) — that runs Claude Code headless with the
+pipeline prompt:
 
 ```
 0 0 * * * claude -p 'Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. PREPARE. Run this exact command with bash:  memu-claude-code prepare  — it regenerates ~/.memu/hosts/claude-code/jobs/. If the command exits non-zero, stop and report the error.  2. SELF-EVOLVE. List ~/.memu/hosts/claude-code/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  3. COMMIT. Run this exact command with bash:  memu-claude-code commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran and what was committed.'

--- a/src/memu/hosts/claude_code/INSTALL.md
+++ b/src/memu/hosts/claude_code/INSTALL.md
@@ -60,6 +60,15 @@ skip to the verify gate):
 | Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
 | API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
 
+**No `MEMU_API_KEY`? Say so, then go local.** If the user has no API key to
+give, tell them up front what that means: memory cannot be called across
+devices — everything stays on this machine, in a local database created for
+them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
+`MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local
+OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1`
+with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
+placeholder value — a local server ignores it.
+
 Write them to **`~/.memu/config.env`**, which every memU command loads. Use an
 **absolute** path for `MEMU_DB`, and `chmod 600` the file (the key is plaintext —
 tell the user). Do **not** instead export these in a shell profile: the scheduled
@@ -89,8 +98,9 @@ memu-claude-code docs task
 
 It is authoritative. In summary: you will settle a schedule with the user
 (default: daily at midnight) and register a recurring headless Claude Code run —
-via system cron or launchd invoking `claude -p "<the prompt that document gives
-you verbatim>"` — that runs `memu-claude-code prepare`, works through
+via system cron (the default; launchd only if the user prefers it) invoking
+`claude -p "<the prompt that document gives you verbatim>"` — that runs
+`memu-claude-code prepare`, works through
 `~/.memu/hosts/claude-code/jobs/*.txt` in order, then runs
 `memu-claude-code commit`.
 

--- a/src/memu/hosts/codex/INSTALL.md
+++ b/src/memu/hosts/codex/INSTALL.md
@@ -64,6 +64,15 @@ Collect from the user (or reuse values they already have):
 | Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
 | API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
 
+**No `MEMU_API_KEY`? Say so, then go local.** If the user has no API key to
+give, tell them up front what that means: memory cannot be called across
+devices — everything stays on this machine, in a local database created for
+them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
+`MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local
+OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1`
+with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
+placeholder value — a local server ignores it.
+
 Write them to **`~/.memu/config.env`**, which every memU command loads:
 
 ```

--- a/src/memu/hosts/cursor/BRIDGING_TASK.md
+++ b/src/memu/hosts/cursor/BRIDGING_TASK.md
@@ -50,8 +50,8 @@ day at midnight**, cron `0 0 * * *` (local time). Confirm before creating.
 
 ## Step 2 — register the scheduled run
 
-Create a system cron entry (or launchd job on macOS, if the user prefers)
-running:
+Create a system cron entry — the default, macOS included (use launchd only if
+the user explicitly asks for it) — running:
 
 ```
 0 0 * * * cursor-agent -p 'Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. PREPARE. Run this exact command with bash:  memu-cursor prepare  — it regenerates ~/.memu/hosts/cursor/jobs/. If the command exits non-zero, stop and report the error.  2. SELF-EVOLVE. List ~/.memu/hosts/cursor/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  3. COMMIT. Run this exact command with bash:  memu-cursor commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran and what was committed.'

--- a/src/memu/hosts/cursor/INSTALL.md
+++ b/src/memu/hosts/cursor/INSTALL.md
@@ -49,6 +49,15 @@ gate. Otherwise collect from the user:
 | Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
 | API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
 
+**No `MEMU_API_KEY`? Say so, then go local.** If the user has no API key to
+give, tell them up front what that means: memory cannot be called across
+devices — everything stays on this machine, in a local database created for
+them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
+`MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local
+OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1`
+with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
+placeholder value — a local server ignores it.
+
 Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
 never a shell-profile export — the scheduled task does not inherit your shell).
 

--- a/src/memu/hosts/generic/BRIDGING_TASK.md
+++ b/src/memu/hosts/generic/BRIDGING_TASK.md
@@ -51,8 +51,8 @@ creating.
 
 ## Step 2 — register the scheduled run
 
-Use the agent's own scheduler if it has one; otherwise a system cron entry
-invoking the agent headless. The recurring prompt, with `<SESSION_DIR>` filled
+Default to a system cron entry invoking the agent headless; use the agent's
+own scheduler instead only if the user prefers it. The recurring prompt, with `<SESSION_DIR>` filled
 in, **verbatim**:
 
 ```

--- a/src/memu/hosts/generic/INSTALL.md
+++ b/src/memu/hosts/generic/INSTALL.md
@@ -64,6 +64,15 @@ gate. Otherwise collect from the user:
 | Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
 | API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
 
+**No `MEMU_API_KEY`? Say so, then go local.** If the user has no API key to
+give, tell them up front what that means: memory cannot be called across
+devices — everything stays on this machine, in a local database created for
+them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
+`MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local
+OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1`
+with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
+placeholder value — a local server ignores it.
+
 Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
 never a shell-profile export — a scheduled task does not inherit your shell).
 

--- a/src/memu/hosts/hermes/INSTALL.md
+++ b/src/memu/hosts/hermes/INSTALL.md
@@ -50,6 +50,15 @@ gate. Otherwise collect from the user:
 | Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
 | API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
 
+**No `MEMU_API_KEY`? Say so, then go local.** If the user has no API key to
+give, tell them up front what that means: memory cannot be called across
+devices — everything stays on this machine, in a local database created for
+them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
+`MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local
+OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1`
+with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
+placeholder value — a local server ignores it.
+
 Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
 never a shell-profile export — the scheduled task does not inherit your shell).
 

--- a/src/memu/hosts/openclaw/INSTALL.md
+++ b/src/memu/hosts/openclaw/INSTALL.md
@@ -50,6 +50,15 @@ gate. Otherwise collect from the user:
 | Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
 | API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
 
+**No `MEMU_API_KEY`? Say so, then go local.** If the user has no API key to
+give, tell them up front what that means: memory cannot be called across
+devices — everything stays on this machine, in a local database created for
+them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
+`MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local
+OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1`
+with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
+placeholder value — a local server ignores it.
+
 Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
 never a shell-profile export — the scheduled task does not inherit your shell).
 


### PR DESCRIPTION
## What

Two changes to the agent-facing host install guides, both prompted by a real agent-driven install run (Claude Code on macOS, no cloud API key available):

1. **No-key local fallback hint (all six hosts, `INSTALL.md` § 1.2).** The guides previously assumed the user could hand over an embedding API key, and the Part 1 verify gate (`doctor`) is a hard stop without one. Each guide now tells the installing agent what to do when the user has **no `MEMU_API_KEY`**: say up front that memory then **cannot be called across devices** — everything stays on the machine in a **local database** (SQLite) — and then configure exactly that path: keep `MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1` with `MEMU_EMBED_MODEL=nomic-embed-text`), placeholder key. This path was verified end-to-end today: `doctor`, `prepare`, `install-instruction`, and `retrieve` all pass their gates against Ollama.

2. **Default the bridging schedule to cron.** `BRIDGING_TASK.md` for claude-code / cursor previously offered cron *or* launchd on macOS; the generic guide preferred the agent's own scheduler. All now name **system cron as the default** (macOS included), with launchd / agent-native schedulers only on explicit user preference. Codex, OpenClaw, and Hermes guides already had a single scheduler and are untouched.

## Why

An agent following `SKILL.md` on a keyless machine currently dead-ends at the Part 1 verify gate with nothing in the guide telling it (or the user) what the trade-off and escape hatch are. And two scheduler options invite the agent to ask an unnecessary question — cron is available everywhere the guides run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
