### PR TITLE
fix(codex): drop harness-injected user records from the conversation seam

### DIFF
--- a/src/memu/hosts/codex/sessions.py
+++ b/src/memu/hosts/codex/sessions.py
@@ -18,14 +18,42 @@ SESSION_DIR = "~/.codex/sessions"
 _MESSAGE_ROLES = ("user", "assistant")
 _TOOL_TYPES = ("function_call", "function_call_output")
 
+# Harness-injected context is logged as ordinary user messages with no
+# isMeta-style flag; the leading marker is the only thing that distinguishes it
+# from typing. The layout drifts across versions — 0.80.0 writes AGENTS.md and
+# environment_context as standalone records, 0.124.x packs both into one
+# record's items — so the check is per item, not per record.
+_INJECTED_PREFIXES = (
+    "<environment_context>",
+    "<turn_aborted>",
+    "# AGENTS.md instructions for",
+)
+
+
+def _injected(payload: dict) -> bool:
+    """True when every content item is harness-injected context, none typing."""
+    if payload.get("role") != "user":
+        return False
+    content = payload.get("content")
+    if not isinstance(content, list):
+        return False
+    texts = [item.get("text", "") for item in content if isinstance(item, dict)]
+    return bool(texts) and all(text.lstrip().startswith(_INJECTED_PREFIXES) for text in texts)
+
 
 class CodexTranscriptSource(TranscriptSource):
     """Codex writes one JSON object per line, each wrapping a ``payload``.
 
     A payload is a conversation turn when its ``type`` is ``message`` and its
-    ``role`` is user or assistant, and a tool record when its ``type`` is a
-    function call or a function-call output. Everything else — session metadata,
-    reasoning traces — is noise the mining jobs should never see.
+    ``role`` is user or assistant — unless it is harness context wearing the
+    user role: Codex logs ``<environment_context>`` dumps, ``<turn_aborted>``
+    markers, and AGENTS.md instructions as ordinary user messages, so a user
+    record whose every content item opens with a known injection marker is
+    dropped (any item of real prose keeps the record; an unknown future marker
+    leaks rather than costing a real message). A payload is a tool record when
+    its ``type`` is a function call or a function-call output. Everything else —
+    session metadata, reasoning traces — is noise the mining jobs should never
+    see.
     """
 
     name: ClassVar[str] = "codex"
@@ -46,7 +74,7 @@ class CodexTranscriptSource(TranscriptSource):
 
         kind = payload.get("type")
         if kind == "message" and payload.get("role") in _MESSAGE_ROLES:
-            return RecordKind.MESSAGE
+            return RecordKind.OTHER if _injected(payload) else RecordKind.MESSAGE
         if kind in _TOOL_TYPES:
             return RecordKind.TOOL
         return RecordKind.OTHER

--- a/tests/test_host_sessions.py
+++ b/tests/test_host_sessions.py
@@ -34,6 +34,51 @@ def test_codex_classify() -> None:
     assert source.classify(_line({"payload": {"type": "reasoning"}})) is RecordKind.OTHER
 
 
+def _codex_user(*texts: str) -> str:
+    content = [{"type": "input_text", "text": text} for text in texts]
+    return _line({"type": "response_item", "payload": {"type": "message", "role": "user", "content": content}})
+
+
+def test_codex_classify_drops_injected_user_records() -> None:
+    """Codex has no isMeta flag: environment context, abort markers, and
+    AGENTS.md dumps are logged as ordinary user messages, distinguishable from
+    typing only by their leading marker. The layout drifts across versions —
+    0.80.0 writes standalone records, 0.124.x packs AGENTS.md and
+    environment_context into one record's items — so all four shapes observed
+    in real logs are pinned here (#510). Role-only classify would feed every
+    one of them to the mining jobs as something the user said.
+    """
+    source = CodexTranscriptSource()
+    env = _codex_user("<environment_context>\n  <cwd>D:\\proj</cwd>\n</environment_context>")
+    agents_md = _codex_user("# AGENTS.md instructions for D:\\proj\n\n<INSTRUCTIONS>reply in haiku</INSTRUCTIONS>")
+    aborted = _codex_user("<turn_aborted>\nThe user interrupted the previous turn on purpose.\n</turn_aborted>")
+    packed = _codex_user("# AGENTS.md instructions for D:\\proj", "<environment_context>\n</environment_context>")
+    assert source.classify(env) is RecordKind.OTHER
+    assert source.classify(agents_md) is RecordKind.OTHER
+    assert source.classify(aborted) is RecordKind.OTHER
+    assert source.classify(packed) is RecordKind.OTHER
+
+
+def test_codex_injected_filter_never_costs_a_real_message() -> None:
+    """The filter fails open: one item of real prose keeps the record, markers
+    mid-text don't count, and assistant records are never inspected."""
+    source = CodexTranscriptSource()
+    assistant = {
+        "type": "response_item",
+        "payload": {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "<environment_context> is injected by the harness."}],
+        },
+    }
+    assert source.classify(_codex_user("fix the bug")) is RecordKind.MESSAGE
+    assert (
+        source.classify(_codex_user("fix the bug", "<environment_context></environment_context>")) is RecordKind.MESSAGE
+    )
+    assert source.classify(_codex_user("what does <environment_context> mean?")) is RecordKind.MESSAGE
+    assert source.classify(_line(assistant)) is RecordKind.MESSAGE
+
+
 # ── Claude Code ────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## 📝 Pull Request Summary

修复 #510：codex 的 `classify()` 把宿主注入的 user-role 记录当成对话——`<environment_context>` 转储、`<turn_aborted>` 标记、AGENTS.md 指令都以普通 user message 形态入日志，真实语料里 **71 条 user-role MESSAGE 中 45 条（58%）是这类噪声**，全部流入挖掘 transcript。本 PR 加一层按内容前缀的保守过滤，并把四种真实形态钉进测试。

---

## ✅ What does this PR do?

- `src/memu/hosts/codex/sessions.py`：新增 `_INJECTED_PREFIXES` 与 `_injected()`——user-role message 的**所有** content item 都以已知注入前缀（`<environment_context>` / `<turn_aborted>` / `# AGENTS.md instructions for`）开头时归 OTHER。**宁漏勿杀（fail-open）**：任一 item 是真实文本（或图像等无 text 的 item）则维持 MESSAGE，未知的未来标记按现状泄入，绝不引入丢失方向的风险；assistant 记录完全不做检查。docstring 同步描述注入形态——#502 的教训：这段文档是下一个宿主适配器作者的第一手参考。
- `tests/test_host_sessions.py`：两条新测试。`test_codex_classify_drops_injected_user_records` 钉住四种真实形态（**已确认在未修复的 classify 上变红**）；`test_codex_injected_filter_never_costs_a_real_message` 钉住 fail-open 边界——真实文本与注入 item 共存、标记只出现在正文中间、assistant 带标记文本，三种情况都必须保持 MESSAGE。

---

## 🤔 Why is this change needed?

#510 的实测（25 个真实会话 / 255 条记录，横跨 codex-cli 0.80.0 / 0.124.0 / 0.124.0-alpha.2 / 0.144.4）：

- 对账干净：71 条 user-role MESSAGE = 真实输入 26 + 注入噪声 45，零未归因；
- codex 日志**没有 `isMeta` 类标记**（对照：Claude Code 适配器靠 `isMeta` 过滤同类注入），只能按内容识别；
- 注入排布已随版本漂移过一次——0.80.0 把 AGENTS.md 和 environment_context 写成独立记录，0.124.x 合并进同一条记录的两个 item——所以 fixture 覆盖全部四种形态，防漂移回归；
- 失败会话（turn 全部 error/abort）照样产出 transcript，其"对话"几乎 100% 是噪声，挖掘 LLM 会把 AGENTS.md、环境 XML 当成用户发言来提炼记忆。

**验证**：

| 项 | 结果 |
| --- | --- |
| 全套测试 | 63/63 通过；`ruff check` / `ruff format` 全绿 |
| 真实语料复验（同一批 25 会话） | MESSAGE 77 → 32，恰为 26 条真实输入 + 6 条 assistant 回复 |
| 噪声残留 / 真实记录误杀 | 0 / 0；26 条真实输入逐条确认仍在对话 transcript；TOOL 不变 |
| 新测试对旧代码 | drop 用例在未修复的 classify 上确认失败 |

已知边界（与 #510 一致，交维护者判断）：前缀清单会随 codex 版本演化，未知新标记 fail-open 泄入（等于现状）；用户手打以完整注入标签开头的消息会被过滤，概率可忽略。

Fixes #510。

---

## 🔍 Type of Change

- [x] Bug fix

---

## ✅ PR Quality Checklist

- [x] PR title follows an allowed format (for example `feat:`, `fix:`, `docs:`, `memory base:`)
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable
- [x] No breaking changes (or clearly documented)
- [x] Related issues or discussions linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
