### PR TITLE
fix(cli): force UTF-8 stdio so piped output survives non-UTF-8 Windows code pages

### DIFF
--- a/src/memu/cli.py
+++ b/src/memu/cli.py
@@ -167,6 +167,14 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # Piped stdio on Windows falls back to the ANSI code page (gbk, cp1252, …),
+    # which cannot encode retrieved memory content printed raw (ensure_ascii=False)
+    # — and agents read every command through a pipe. Force UTF-8; on UTF-8 stdio
+    # it's a no-op.
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8", errors="replace")
     args = build_parser().parse_args(argv)
     handler: Callable[[argparse.Namespace], Coroutine[Any, Any, int]] = args.handler
     try:

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -213,6 +213,13 @@ def build_parser(spec: HostSpec) -> argparse.ArgumentParser:
 
 
 def run(spec: HostSpec, argv: list[str] | None = None) -> int:
+    # Piped stdio on Windows falls back to the ANSI code page (gbk, cp1252, …),
+    # which cannot encode the guides' ✅ or stored memory content — and agents
+    # read every command through a pipe. Force UTF-8; on UTF-8 stdio it's a no-op.
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8", errors="replace")
     args = build_parser(spec).parse_args(argv)
     handler: Callable[[argparse.Namespace], Coroutine[Any, Any, int]] = args.handler
     try:

--- a/tests/test_cli_stdio.py
+++ b/tests/test_cli_stdio.py
@@ -1,0 +1,47 @@
+"""Both CLI entries force UTF-8 stdio before anything prints.
+
+Piped stdio on Windows falls back to the ANSI code page (gbk on zh-CN, cp1252
+on en-US), which cannot encode the packaged guides' ✅ or stored memory content
+— and agents read every command through a pipe. These tests hand each entry the
+exact stream a Chinese-locale Windows pipe provides and expect UTF-8 bytes out;
+like the rest of the CLI tests, they never construct a MemoryService.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from memu.cli import main
+from memu.hosts.claude_code.cli import SPEC
+from memu.hosts.host_cli import run
+
+
+def _gbk_pipe() -> tuple[io.TextIOWrapper, io.BytesIO]:
+    buffer = io.BytesIO()
+    return io.TextIOWrapper(buffer, encoding="gbk"), buffer
+
+
+def test_host_docs_install_survives_gbk_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Without the entry-point reconfigure this is the field failure: the guide's
+    # first ✅ raises UnicodeEncodeError and the agent gets zero lines of it.
+    stdout, buffer = _gbk_pipe()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    assert run(SPEC, ["docs", "install"]) == 0
+    stdout.flush()
+    assert "✅" in buffer.getvalue().decode("utf-8")
+
+
+def test_memu_entry_reconfigures_both_streams(monkeypatch: pytest.MonkeyPatch) -> None:
+    stdout, _ = _gbk_pipe()
+    stderr, err_buffer = _gbk_pipe()
+    monkeypatch.setattr(sys, "stdout", stdout)
+    monkeypatch.setattr(sys, "stderr", stderr)
+    # The no-service error path: parses argv, prints the error, exits 2.
+    assert main(["commit", "/definitely/not/a/payload.json"]) == 2
+    assert stdout.encoding == "utf-8"
+    assert stderr.encoding == "utf-8"
+    stderr.flush()
+    assert "no such file" in err_buffer.getvalue().decode("utf-8")


### PR DESCRIPTION
## 📝 Pull Request Summary

修复 #512：非 UTF-8 代码页的 Windows 上（zh-CN cp936 实测），stdout 走管道时全部 6 个宿主适配器的 `docs install` 因指南里的 `✅` 触发 gbk `UnicodeEncodeError`，exit 1、零输出——agent 连安装指南都读不到。本 PR 在两个 CLI 入口强制 UTF-8 输出，并把 gbk 管道场景钉进回归测试。

---

## ✅ What does this PR do?

- `src/memu/hosts/host_cli.py` `run()`（6 个宿主二进制的共用入口）与 `src/memu/cli.py` `main()`（顶层 `memu`）：入口处 `sys.stdout/stderr.reconfigure(encoding="utf-8", errors="replace")`。已是 UTF-8 的终端上为 no-op，字节级行为不变；`retrieve` 的 `ensure_ascii=False` 保留——缺陷在传输编码，不在 JSON。
- `tests/test_cli_stdio.py`：两条新测试，给两个入口各喂一条 gbk 编码流（zh-CN Windows 管道给出的正是这种流），断言 exit 0 且 `✅` 以 UTF-8 完整到达。**已确认在未修复代码上变红**（错误与线上一致）。

---

## 🤔 Why is this change needed?

- 管道/重定向下，Windows Python 用系统 ANSI 代码页编码 stdout；交互终端走 UTF-8（PEP 528）不炸——**而 agent 全部走管道**，所以「agent 驱动安装」的主流程在第 3 步 100% 死。
- 不是 claude_code 特例：6 个适配器的 INSTALL.md 全带 `✅`（#512 逐文件实测）；#509 的 UNINSTALL.md 也带，一发布 `docs uninstall` 同炸；存储内容含 emoji 时 `retrieve` 输出同机制崩。所以修入口，而不是逐文件删 emoji。

**验证**：

| 项 | 结果 |
| --- | --- |
| 新测试对旧代码 | 2/2 变红（正是线上错误） |
| 新测试对本 PR | 2/2 通过 |
| 全套测试 / mypy | 70/70 通过；mypy 全绿（103 files） |
| 真机 E2E（zh-CN cp936） | `memu-claude-code docs install \| head` → exit 0、指南完整、3/3 `✅`；同机 0.3.0 wheel exit 1 零输出 |

Fixes #512。

---

## 🔍 Type of Change
Please check what applies:

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (please explain)

---

## ✅ PR Quality Checklist

- [x] PR title follows an allowed format (for example `feat:`, `fix:`, `docs:`, `memory base:`)
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable（无文档需更新：修复后的行为即文档描述的行为）
- [x] No breaking changes (or clearly documented)
- [x] Related issues or discussions linked

---

## 📌 Optional

- [x] Screenshots or examples added (if applicable)——见验证表与 #512 的最小复现
- [x] Edge cases considered——非 TextIOWrapper 的 stdio（pytest capture、嵌入场景）由 getattr 守卫安全跳过；cp1252 同机制（#512 边界）；交互终端不受影响
- [x] Follow-up tasks mentioned——合并后需发新版，PyPI 0.3.0 wheel 在此之前仍带此 bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)
