### PR TITLE
docs(hosts): default bridging schedule to hourly

### DIFF
--- a/src/memu/hosts/claude_code/BRIDGING_TASK.md
+++ b/src/memu/hosts/claude_code/BRIDGING_TASK.md
@@ -1,6 +1,6 @@
 ---
 name: create-memu-bridging-task
-description: Register a scheduled job that bridges the agent's recent Claude Code sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every day at midnight).
+description: Register a scheduled job that bridges the agent's recent Claude Code sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
 ---
 
 # Create the memU bridging scheduled task (Claude Code)
@@ -49,7 +49,7 @@ run's prompt must instruct the agent to do it, not shell out to a script.
 ## Step 1 — settle the schedule
 
 Ask the user for a schedule if the request doesn't include one. **Default: every
-day at midnight**, cron `0 0 * * *` (local time). Confirm before creating.
+hour**, cron `0 * * * *` (local time). Confirm before creating.
 
 ## Step 2 — register the scheduled run
 
@@ -58,7 +58,7 @@ the user explicitly asks for it) — that runs Claude Code headless with the
 pipeline prompt:
 
 ```
-0 0 * * * claude -p 'Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. PREPARE. Run this exact command with bash:  memu-claude-code prepare  — it regenerates ~/.memu/hosts/claude-code/jobs/. If the command exits non-zero, stop and report the error.  2. SELF-EVOLVE. List ~/.memu/hosts/claude-code/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  3. COMMIT. Run this exact command with bash:  memu-claude-code commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran and what was committed.'
+0 * * * * claude -p 'Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. PREPARE. Run this exact command with bash:  memu-claude-code prepare  — it regenerates ~/.memu/hosts/claude-code/jobs/. If the command exits non-zero, stop and report the error.  2. SELF-EVOLVE. List ~/.memu/hosts/claude-code/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  3. COMMIT. Run this exact command with bash:  memu-claude-code commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran and what was committed.'
 ```
 
 The prompt block is fixed; only the cron expression is the user's choice. Nothing
@@ -67,7 +67,7 @@ in it is machine-specific — the pipeline is invoked through `PATH` commands.
 ## Step 3 — confirm
 
 Report back: where the schedule was registered (crontab/launchd), and the cron in
-words (e.g. "daily at 00:00 local time"). Mention that the first run only has
+words (e.g. "hourly at :00 local time"). Mention that the first run only has
 work to do once there are new Claude Code sessions since the last run.
 
 ## Notes

--- a/src/memu/hosts/claude_code/INSTALL.md
+++ b/src/memu/hosts/claude_code/INSTALL.md
@@ -97,7 +97,7 @@ memu-claude-code docs task
 ```
 
 It is authoritative. In summary: you will settle a schedule with the user
-(default: daily at midnight) and register a recurring headless Claude Code run —
+(default: every hour) and register a recurring headless Claude Code run —
 via system cron (the default; launchd only if the user prefers it) invoking
 `claude -p "<the prompt that document gives you verbatim>"` — that runs
 `memu-claude-code prepare`, works through

--- a/src/memu/hosts/codex/BRIDGING_TASK.md
+++ b/src/memu/hosts/codex/BRIDGING_TASK.md
@@ -1,6 +1,6 @@
 ---
 name: create-memu-bridging-task
-description: Create a Codex scheduled task that bridges the agent's recent Codex sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every day at midnight).
+description: Create a Codex scheduled task that bridges the agent's recent Codex sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
 ---
 
 # Create the memU bridging scheduled task
@@ -58,7 +58,7 @@ nothing in the task prompt is specific to this machine's directory layout.
 ## Step 1 — settle the schedule
 
 Ask the user for a schedule if the request doesn't include one. **Default: every
-day at midnight**, cron `0 0 * * *` (local time). Confirm the cron expression
+hour**, cron `0 * * * *` (local time). Confirm the cron expression
 before creating the task.
 
 ## Step 2 — create the scheduled task
@@ -100,8 +100,8 @@ that there was nothing to commit).
 
 ## Step 3 — confirm
 
-Report back to the user: the task name and the cron schedule in words (e.g. "daily
-at 00:00 local time"). Mention that the first run only has work to do once there
+Report back to the user: the task name and the cron schedule in words (e.g. "hourly
+at :00 local time"). Mention that the first run only has work to do once there
 are new Codex sessions since the last run.
 
 ## Notes

--- a/src/memu/hosts/codex/INSTALL.md
+++ b/src/memu/hosts/codex/INSTALL.md
@@ -119,7 +119,7 @@ memu-codex docs task
 ```
 
 It is authoritative. In summary, you will settle a cron schedule with the user
-(default: daily at midnight, `0 0 * * *`) and create a Codex scheduled task whose
+(default: every hour, `0 * * * *`) and create a Codex scheduled task whose
 recurring prompt is the three-step block that document gives you verbatim —
 `memu-codex prepare`, then the agent works through `~/.memu/jobs/*.txt` in order,
 then `memu-codex commit`.
@@ -212,7 +212,7 @@ that the instruction is not in your own context yet.
 Report back to the user:
 
 - the store (`MEMU_DB`) and provider now in use;
-- the scheduled task's name and cron, in words (e.g. "daily at 00:00 local");
+- the scheduled task's name and cron, in words (e.g. "hourly at :00 local");
 - that the retrieval instruction is now in `~/.codex/AGENTS.md`, and that it takes
   effect in their next Codex session.
 

--- a/src/memu/hosts/cursor/BRIDGING_TASK.md
+++ b/src/memu/hosts/cursor/BRIDGING_TASK.md
@@ -1,6 +1,6 @@
 ---
 name: create-memu-bridging-task
-description: Register a scheduled job that bridges the agent's recent Cursor agent sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every day at midnight).
+description: Register a scheduled job that bridges the agent's recent Cursor agent sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
 ---
 
 # Create the memU bridging scheduled task (Cursor)
@@ -46,7 +46,7 @@ run's prompt must instruct the agent to do it, not shell out to a script.
 ## Step 1 — settle the schedule
 
 Ask the user for a schedule if the request doesn't include one. **Default: every
-day at midnight**, cron `0 0 * * *` (local time). Confirm before creating.
+hour**, cron `0 * * * *` (local time). Confirm before creating.
 
 ## Step 2 — register the scheduled run
 
@@ -54,7 +54,7 @@ Create a system cron entry — the default, macOS included (use launchd only if
 the user explicitly asks for it) — running:
 
 ```
-0 0 * * * cursor-agent -p 'Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. PREPARE. Run this exact command with bash:  memu-cursor prepare  — it regenerates ~/.memu/hosts/cursor/jobs/. If the command exits non-zero, stop and report the error.  2. SELF-EVOLVE. List ~/.memu/hosts/cursor/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  3. COMMIT. Run this exact command with bash:  memu-cursor commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran and what was committed.'
+0 * * * * cursor-agent -p 'Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. PREPARE. Run this exact command with bash:  memu-cursor prepare  — it regenerates ~/.memu/hosts/cursor/jobs/. If the command exits non-zero, stop and report the error.  2. SELF-EVOLVE. List ~/.memu/hosts/cursor/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  3. COMMIT. Run this exact command with bash:  memu-cursor commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran and what was committed.'
 ```
 
 The prompt block is fixed; only the cron expression is the user's choice. Nothing

--- a/src/memu/hosts/cursor/INSTALL.md
+++ b/src/memu/hosts/cursor/INSTALL.md
@@ -82,7 +82,7 @@ resources. **Do not reinvent this** — follow the packaged procedure:
 memu-cursor docs task
 ```
 
-In summary: settle a schedule with the user (default: daily at midnight) and
+In summary: settle a schedule with the user (default: every hour) and
 register a cron entry that runs `cursor-agent -p "<the prompt that document gives
 you verbatim>"` — the prompt runs `memu-cursor prepare`, works through
 `~/.memu/hosts/cursor/jobs/*.txt` in order, then `memu-cursor commit`. Nothing in

--- a/src/memu/hosts/generic/BRIDGING_TASK.md
+++ b/src/memu/hosts/generic/BRIDGING_TASK.md
@@ -1,6 +1,6 @@
 ---
 name: create-memu-bridging-task
-description: Register a scheduled job that bridges an agent's recent sessions into durable memU memory, skills, and resources via the generic memu-agent adapter. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every day at midnight).
+description: Register a scheduled job that bridges an agent's recent sessions into durable memU memory, skills, and resources via the generic memu-agent adapter. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
 ---
 
 # Create the memU bridging scheduled task (generic `memu-agent`)
@@ -46,7 +46,7 @@ run's prompt must instruct the agent to do it, not shell out to a script.
 ## Step 1 — settle the schedule
 
 Ask the user for a schedule if the request doesn't include one. **Default:
-every day at midnight**, cron `0 0 * * *` (local time). Confirm before
+every hour**, cron `0 * * * *` (local time). Confirm before
 creating.
 
 ## Step 2 — register the scheduled run

--- a/src/memu/hosts/generic/INSTALL.md
+++ b/src/memu/hosts/generic/INSTALL.md
@@ -96,7 +96,7 @@ the packaged procedure:
 memu-agent docs task
 ```
 
-In summary: settle a schedule with the user (default: daily at midnight) and
+In summary: settle a schedule with the user (default: every hour) and
 register a recurring run — the agent's own scheduler if it has one, system cron
 otherwise — whose prompt runs
 `memu-agent prepare --session-dir <detected dir>`, works through

--- a/src/memu/hosts/hermes/BRIDGING_TASK.md
+++ b/src/memu/hosts/hermes/BRIDGING_TASK.md
@@ -1,6 +1,6 @@
 ---
 name: create-memu-bridging-task
-description: Register a scheduled job that bridges the agent's recent Hermes sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every day at midnight).
+description: Register a scheduled job that bridges the agent's recent Hermes sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
 ---
 
 # Create the memU bridging scheduled task (Hermes)
@@ -47,14 +47,14 @@ run's prompt must instruct the agent to do it, not shell out to a script.
 ## Step 1 — settle the schedule
 
 Ask the user for a schedule if the request doesn't include one. **Default: every
-day at midnight**, cron `0 0 * * *` (local time). Confirm before creating.
+hour**, cron `0 * * * *` (local time). Confirm before creating.
 
 ## Step 2 — register the scheduled run
 
 Create a system cron entry that runs Hermes headless with the pipeline prompt:
 
 ```
-0 0 * * * hermes -p 'Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. PREPARE. Run this exact command with the shell tool:  memu-hermes prepare  — it regenerates ~/.memu/hosts/hermes/jobs/. If the command exits non-zero, stop and report the error.  2. SELF-EVOLVE. List ~/.memu/hosts/hermes/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  3. COMMIT. Run this exact command with the shell tool:  memu-hermes commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran and what was committed.'
+0 * * * * hermes -p 'Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. PREPARE. Run this exact command with the shell tool:  memu-hermes prepare  — it regenerates ~/.memu/hosts/hermes/jobs/. If the command exits non-zero, stop and report the error.  2. SELF-EVOLVE. List ~/.memu/hosts/hermes/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  3. COMMIT. Run this exact command with the shell tool:  memu-hermes commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran and what was committed.'
 ```
 
 (Adjust the headless invocation to the Hermes CLI the user runs, but keep the

--- a/src/memu/hosts/hermes/INSTALL.md
+++ b/src/memu/hosts/hermes/INSTALL.md
@@ -83,7 +83,7 @@ reinvent this** — follow the packaged procedure:
 memu-hermes docs task
 ```
 
-In summary: settle a schedule with the user (default: daily at midnight) and
+In summary: settle a schedule with the user (default: every hour) and
 register a recurring headless Hermes run — via system cron invoking `hermes`
 non-interactively with the prompt that document gives you verbatim — that runs
 `memu-hermes prepare`, works through `~/.memu/hosts/hermes/jobs/*.txt` in order,

--- a/src/memu/hosts/openclaw/BRIDGING_TASK.md
+++ b/src/memu/hosts/openclaw/BRIDGING_TASK.md
@@ -1,6 +1,6 @@
 ---
 name: create-memu-bridging-task
-description: Create an OpenClaw cron job that bridges the agent's recent OpenClaw sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every day at midnight).
+description: Create an OpenClaw cron job that bridges the agent's recent OpenClaw sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
 ---
 
 # Create the memU bridging scheduled task (OpenClaw)
@@ -46,7 +46,7 @@ prompt must instruct the agent to do it, not shell out to a script.
 ## Step 1 — settle the schedule
 
 Ask the user for a schedule if the request doesn't include one. **Default: every
-day at midnight**, cron `0 0 * * *` (local time). Confirm before creating.
+hour**, cron `0 * * * *` (local time). Confirm before creating.
 
 ## Step 2 — create the cron job
 
@@ -90,7 +90,7 @@ is machine-specific — the pipeline is invoked through `PATH` commands.
 
 ## Step 3 — confirm
 
-Report back: the cron job's name and the schedule in words (e.g. "daily at 00:00
+Report back: the cron job's name and the schedule in words (e.g. "hourly at :00
 local time"). Mention that the first run only has work to do once there are new
 OpenClaw sessions since the last run.
 

--- a/src/memu/hosts/openclaw/INSTALL.md
+++ b/src/memu/hosts/openclaw/INSTALL.md
@@ -83,7 +83,7 @@ resources. **Do not reinvent this** — follow the packaged procedure:
 memu-openclaw docs task
 ```
 
-In summary: settle a schedule with the user (default: daily at midnight) and
+In summary: settle a schedule with the user (default: every hour) and
 create an **OpenClaw cron job** — OpenClaw schedules agent runs natively — whose
 recurring prompt is the block that document gives you verbatim: it runs
 `memu-openclaw prepare`, works through `~/.memu/hosts/openclaw/jobs/*.txt` in


### PR DESCRIPTION
## 📝 Pull Request Summary

把 6 个宿主适配器的 bridging task 默认调度从「每天午夜」`0 0 * * *` 改为「每小时」`0 * * * *`。调度是 agent 照指南创建的（docs-only，无产品代码），本 PR 改的就是指南里编码这个默认值的每一处。

---

## ✅ What does this PR do?

- 6 个 adapter（codex / claude_code / cursor / openclaw / hermes / generic）的 `BRIDGING_TASK.md` 与 `INSTALL.md`，把默认值统一从 `0 0 * * *`（daily at midnight）改成 `0 * * * *`（every hour）：frontmatter `description`、Step 1 的默认句、字面 cron 行（claude_code / cursor / hermes 三家内嵌了 `0 0 * * * <binary> -p '…'`）、Step 3 的 report-back 示例、INSTALL.md 的 summary。
- 纯文案改动，逐处保留原有换行；`git grep` 确认改后 `midnight` / `daily` / `0 0 * * *` 零残留。

---

## 🤔 Why is this change needed?
一天触发一次的频率太低了。开发阶段很难观察出效果。

另外，默认午夜跑在个人机器上有一个静默失效：桌面/笔记本 00:00 通常处于睡眠或关机，cron 不补跑错过的任务，指南也没启用 Task Scheduler 的 catch-up——于是 record seam（记忆化）可能永远不触发。改成每小时后，机器醒着的任意一小时都会跑到。

**验证**：

| 项 | 结果 |
| --- | --- |
| straggler 检查 | `midnight` / `daily` / `0 0 * * *` 改后零残留 |
| 3 家内嵌 cron 行 | 均为 `0 * * * *` |
| 全套测试 / ruff | 72/72 通过；`ruff check` 全绿 |
| 测试是否断言过旧调度文案 | 无——纯文档改动，零代码影响 |

---

## 🔍 Type of Change
Please check what applies:

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (please explain)

---

## ✅ PR Quality Checklist

- [x] PR title follows an allowed format (for example `feat:`, `fix:`, `docs:`, `memory base:`)
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable（本 PR 即文档本身）
- [x] No breaking changes (or clearly documented)
- [x] Related issues or discussions linked

---

## 📌 Optional

- [x] Edge cases considered——逐处保留换行；codex 的 report-back 示例换行在 "hourly" 后、openclaw 在 ":00" 后，均与原文一致
- [x] Follow-up tasks mentioned——与 #514（Windows 无 cron/launchd 分支）相关：午夜静默失效在 Windows 上尤其明显，两者可一并考虑
