### PR TITLE
docs(hosts): bind the session cursor's lifecycle to the store's

### DIFF
--- a/src/memu/hosts/claude_code/UNINSTALL.md
+++ b/src/memu/hosts/claude_code/UNINSTALL.md
@@ -76,8 +76,16 @@ Only one thing overrides a default: the user's own explicit words.
   reinstalling later picks it right back up. Delete it only if the user
   explicitly asked to erase their memory as part of this uninstall, and warn
   first, in plain words, that it is irreversible.
-- **Remove this host's residue.** `~/.memu/hosts/claude-code/` (job files,
-  session cursors, mirrors); `~/.claude/CLAUDE.md` itself **if** Part 2 left it
+- **The session cursor lives and dies with the store.**
+  `~/.memu/hosts/claude-code/.session_manifest.claude-code.json` records
+  which session turns have already been mined *into that store*. Store
+  kept (the default)? Keep the cursor — deleting it loses no memory, but the
+  next install re-mines every old session for nothing. Store deleted at the
+  user's request? Delete the cursor with it — a surviving cursor over an empty
+  store marks history as already mined, and it would never be mined again.
+- **Remove this host's residue.** Everything else under
+  `~/.memu/hosts/claude-code/` — job files and mirrors, sparing the session
+  cursor above; `~/.claude/CLAUDE.md` itself **if** Part 2 left it
   empty (it held only memU's block, so the install created it) — a file with
   the user's own content stays, of course; and any allow rules for
   `memu-claude-code` or `~/.memu/` that `~/.claude/settings.json` gained at
@@ -92,8 +100,9 @@ Only one thing overrides a default: the user's own explicit words.
 
 Close the report with the two things the user needs to hear, in this order:
 
-1. **What was kept:** their memory — the store at `MEMU_DB` and
-   `~/.memu/config.env` — untouched. A later reinstall picks it up as is.
+1. **What was kept:** their memory — the store at `MEMU_DB`,
+   `~/.memu/config.env`, and the session cursor — untouched. A later reinstall
+   picks it up as is and resumes mining right where it left off.
 2. **What was removed:** the bridging schedule, the retrieval instruction,
    this host's working state, and (unless another host still needs it) the
    `memu-cli` package.

--- a/src/memu/hosts/codex/UNINSTALL.md
+++ b/src/memu/hosts/codex/UNINSTALL.md
@@ -68,11 +68,19 @@ Only one thing overrides a default: the user's own explicit words.
   reinstalling later picks it right back up. Delete it only if the user
   explicitly asked to erase their memory as part of this uninstall, and warn
   first, in plain words, that it is irreversible.
+- **The session cursor lives and dies with the store.** The `.session_manifest*` files
+  directly under `~/.memu/`
+  records which session turns have already been mined *into that store*. Store
+  kept (the default)? Keep the cursor — deleting it loses no memory, but the
+  next install re-mines every old session for nothing. Store deleted at the
+  user's request? Delete the cursor with it — a surviving cursor over an empty
+  store marks history as already mined, and it would never be mined again.
 - **Remove this host's residue.** Codex predates the per-host layout, so its
   run-scoped state sits directly under `~/.memu/`: the `jobs/`, `memory/`,
-  `skill/`, and `resources/` directories and the `.session_manifest*` cursor
-  files. **Never** sweep `~/.memu/` wholesale to get them — `config.env` and
-  the store file live there too. Also `~/.codex/AGENTS.md` itself **if** Part 2
+  `skill/`, and `resources/` directories — but **not** the `.session_manifest*`
+  cursor files (see above). **Never** sweep `~/.memu/` wholesale to get them —
+  `config.env`, the store file, and the cursor live there too. Also
+  `~/.codex/AGENTS.md` itself **if** Part 2
   left it empty (it held only memU's block, so the install created it) — a
   file with the user's own content stays, of course.
 - **Uninstall the package** — `pip uninstall memu-cli` (or `pipx uninstall
@@ -85,8 +93,9 @@ Only one thing overrides a default: the user's own explicit words.
 
 Close the report with the two things the user needs to hear, in this order:
 
-1. **What was kept:** their memory — the store at `MEMU_DB` and
-   `~/.memu/config.env` — untouched. A later reinstall picks it up as is.
+1. **What was kept:** their memory — the store at `MEMU_DB`,
+   `~/.memu/config.env`, and the session cursor — untouched. A later reinstall
+   picks it up as is and resumes mining right where it left off.
 2. **What was removed:** the bridging schedule, the retrieval instruction,
    this host's working state, and (unless another host still needs it) the
    `memu-cli` package.

--- a/src/memu/hosts/cursor/UNINSTALL.md
+++ b/src/memu/hosts/cursor/UNINSTALL.md
@@ -75,8 +75,16 @@ Only one thing overrides a default: the user's own explicit words.
   reinstalling later picks it right back up. Delete it only if the user
   explicitly asked to erase their memory as part of this uninstall, and warn
   first, in plain words, that it is irreversible.
-- **Remove this host's residue.** `~/.memu/hosts/cursor/` (job files, session
-  cursors, mirrors); and any per-project `AGENTS.md` **if** Part 2 left it
+- **The session cursor lives and dies with the store.**
+  `~/.memu/hosts/cursor/.session_manifest.cursor.json` records which
+  session turns have already been mined *into that store*. Store
+  kept (the default)? Keep the cursor — deleting it loses no memory, but the
+  next install re-mines every old session for nothing. Store deleted at the
+  user's request? Delete the cursor with it — a surviving cursor over an empty
+  store marks history as already mined, and it would never be mined again.
+- **Remove this host's residue.** Everything else under `~/.memu/hosts/cursor/`
+  — job files and mirrors, sparing the session cursor above; and any
+  per-project `AGENTS.md` **if** Part 2 left it
   empty (it held only memU's block, so the install created it) — a file with
   the user's own content stays, of course.
 - **Uninstall the package** — `pip uninstall memu-cli` (or `pipx uninstall
@@ -89,8 +97,9 @@ Only one thing overrides a default: the user's own explicit words.
 
 Close the report with the two things the user needs to hear, in this order:
 
-1. **What was kept:** their memory — the store at `MEMU_DB` and
-   `~/.memu/config.env` — untouched. A later reinstall picks it up as is.
+1. **What was kept:** their memory — the store at `MEMU_DB`,
+   `~/.memu/config.env`, and the session cursor — untouched. A later reinstall
+   picks it up as is and resumes mining right where it left off.
 2. **What was removed:** the bridging schedule, the retrieval instruction,
    this host's working state, and (unless another host still needs it) the
    `memu-cli` package.

--- a/src/memu/hosts/generic/UNINSTALL.md
+++ b/src/memu/hosts/generic/UNINSTALL.md
@@ -76,8 +76,16 @@ Only one thing overrides a default: the user's own explicit words.
   reinstalling later picks it right back up. Delete it only if the user
   explicitly asked to erase their memory as part of this uninstall, and warn
   first, in plain words, that it is irreversible.
-- **Remove this host's residue.** `~/.memu/hosts/agent/` (or the `--base-dir`
-  chosen at install time, for a named generic agent); and each patched
+- **The session cursor lives and dies with the store.**
+  `.session_manifest.agent.json` in the working tree records which session
+  turns have already been mined *into that store*. Store
+  kept (the default)? Keep the cursor — deleting it loses no memory, but the
+  next install re-mines every old session for nothing. Store deleted at the
+  user's request? Delete the cursor with it — a surviving cursor over an empty
+  store marks history as already mined, and it would never be mined again.
+- **Remove this host's residue.** Everything else under `~/.memu/hosts/agent/`
+  (or the `--base-dir` chosen at install time, for a named generic agent) —
+  job files and mirrors, sparing the session cursor above; and each patched
   instruction file **if** Part 2 left it empty (it held only memU's block, so
   the install created it) — a file with the user's own content stays, of
   course. The agent's own session log belongs to the agent — memU only ever
@@ -92,8 +100,9 @@ Only one thing overrides a default: the user's own explicit words.
 
 Close the report with the two things the user needs to hear, in this order:
 
-1. **What was kept:** their memory — the store at `MEMU_DB` and
-   `~/.memu/config.env` — untouched. A later reinstall picks it up as is.
+1. **What was kept:** their memory — the store at `MEMU_DB`,
+   `~/.memu/config.env`, and the session cursor — untouched. A later reinstall
+   picks it up as is and resumes mining right where it left off.
 2. **What was removed:** the bridging schedule, the retrieval instruction,
    this host's working state, and (unless another host still needs it) the
    `memu-cli` package.

--- a/src/memu/hosts/hermes/UNINSTALL.md
+++ b/src/memu/hosts/hermes/UNINSTALL.md
@@ -72,8 +72,16 @@ Only one thing overrides a default: the user's own explicit words.
   reinstalling later picks it right back up. Delete it only if the user
   explicitly asked to erase their memory as part of this uninstall, and warn
   first, in plain words, that it is irreversible.
-- **Remove this host's residue.** `~/.memu/hosts/hermes/` (job files, session
-  cursors, mirrors); and `~/.hermes/SOUL.md` itself **if** Part 2 left it
+- **The session cursor lives and dies with the store.**
+  `~/.memu/hosts/hermes/.session_manifest.hermes.json` records which
+  session turns have already been mined *into that store*. Store
+  kept (the default)? Keep the cursor — deleting it loses no memory, but the
+  next install re-mines every old session for nothing. Store deleted at the
+  user's request? Delete the cursor with it — a surviving cursor over an empty
+  store marks history as already mined, and it would never be mined again.
+- **Remove this host's residue.** Everything else under `~/.memu/hosts/hermes/`
+  — job files and mirrors, sparing the session cursor above; and
+  `~/.hermes/SOUL.md` itself **if** Part 2 left it
   empty (it held only memU's block, so the install created it) — a file with
   the user's own content stays, of course. Hermes's own `~/.hermes/state.db`
   belongs to Hermes, not memU — the adapter only ever read it; leave it alone.
@@ -87,8 +95,9 @@ Only one thing overrides a default: the user's own explicit words.
 
 Close the report with the two things the user needs to hear, in this order:
 
-1. **What was kept:** their memory — the store at `MEMU_DB` and
-   `~/.memu/config.env` — untouched. A later reinstall picks it up as is.
+1. **What was kept:** their memory — the store at `MEMU_DB`,
+   `~/.memu/config.env`, and the session cursor — untouched. A later reinstall
+   picks it up as is and resumes mining right where it left off.
 2. **What was removed:** the bridging schedule, the retrieval instruction,
    this host's working state, and (unless another host still needs it) the
    `memu-cli` package.

--- a/src/memu/hosts/openclaw/UNINSTALL.md
+++ b/src/memu/hosts/openclaw/UNINSTALL.md
@@ -68,8 +68,16 @@ Only one thing overrides a default: the user's own explicit words.
   reinstalling later picks it right back up. Delete it only if the user
   explicitly asked to erase their memory as part of this uninstall, and warn
   first, in plain words, that it is irreversible.
-- **Remove this host's residue.** `~/.memu/hosts/openclaw/` (job files,
-  session cursors, mirrors); and `~/.openclaw/workspace/AGENTS.md` itself
+- **The session cursor lives and dies with the store.**
+  `~/.memu/hosts/openclaw/.session_manifest.openclaw.json` records which
+  session turns have already been mined *into that store*. Store
+  kept (the default)? Keep the cursor — deleting it loses no memory, but the
+  next install re-mines every old session for nothing. Store deleted at the
+  user's request? Delete the cursor with it — a surviving cursor over an empty
+  store marks history as already mined, and it would never be mined again.
+- **Remove this host's residue.** Everything else under
+  `~/.memu/hosts/openclaw/` — job files and mirrors, sparing the session
+  cursor above; and `~/.openclaw/workspace/AGENTS.md` itself
   **if** Part 2 left it empty (it held only memU's block, so the install
   created it) — a file with the user's own content stays, of course.
 - **Uninstall the package** — `pip uninstall memu-cli` (or `pipx uninstall
@@ -82,8 +90,9 @@ Only one thing overrides a default: the user's own explicit words.
 
 Close the report with the two things the user needs to hear, in this order:
 
-1. **What was kept:** their memory — the store at `MEMU_DB` and
-   `~/.memu/config.env` — untouched. A later reinstall picks it up as is.
+1. **What was kept:** their memory — the store at `MEMU_DB`,
+   `~/.memu/config.env`, and the session cursor — untouched. A later reinstall
+   picks it up as is and resumes mining right where it left off.
 2. **What was removed:** the bridging schedule, the retrieval instruction,
    this host's working state, and (unless another host still needs it) the
    `memu-cli` package.


### PR DESCRIPTION
Follow-up to #509 — this commit was pushed a few minutes after the merge and missed it.

`.session_manifest.<host>.json` (the incremental cursor recording which session turns were already mined into the store) was classified as removable residue in the uninstall guides. It is actually memory *state*. The four lifecycle combinations:

| store | cursor | outcome |
|---|---|---|
| kept | kept | seamless resume ✅ (now the default) |
| deleted | deleted | clean slate ✅ (erase-memory path) |
| kept | deleted | full re-mine of every old session for nothing (was the default) |
| deleted | kept | history marked 'already mined' over an empty store — silently never mined ❌ |

All six guides now keep the cursor whenever the store is kept and delete it only together with the store (codex's sits directly under `~/.memu/`, which also strengthens its never-sweep-wholesale warning). The closing report's *what was kept* line includes it: a reinstall resumes mining right where it left off.

Related but deliberately out of scope: the cursor advances at `prepare` time rather than at `commit` time, so a bridging run that dies mid-pipeline silently skips those sessions. That is core pipeline semantics (at-most-once vs at-least-once) — happy to file it as a separate issue for design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)