### PR TITLE
feat(hosts): add WorkBuddy host adapter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ memu-claude-code = "memu.hosts.claude_code.cli:main"
 memu-cursor = "memu.hosts.cursor.cli:main"
 memu-openclaw = "memu.hosts.openclaw.cli:main"
 memu-hermes = "memu.hosts.hermes.cli:main"
+memu-workbuddy = "memu.hosts.workbuddy.cli:main"
 # The generic adapter: any agent without a dedicated binary. `memu-agent
 # detect` finds the session log and instruction file, then reports which of
 # the two seams (memorization / retrieval) work for that agent.

--- a/src/memu/hosts/workbuddy/BRIDGING_TASK.md
+++ b/src/memu/hosts/workbuddy/BRIDGING_TASK.md
@@ -1,0 +1,104 @@
+---
+name: create-memu-bridging-task
+description: Register a scheduled automation that bridges the agent's recent WorkBuddy sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
+---
+
+# Create the memU bridging scheduled task (WorkBuddy)
+
+Use this when the user asks to **set up (or change) the recurring memU
+"bridging" task** — the automation that periodically turns what the agent
+recently did in its WorkBuddy sessions into durable memU memory files, skills,
+and resource records.
+
+Your goal is to **register a recurring WorkBuddy automation** whose prompt is
+the three-step pipeline below. You are not running the pipeline now; you are
+registering the schedule that will run it later.
+
+Part of the full setup in `INSTALL.md` (`memu-workbuddy docs install`), but
+usable on its own.
+
+## What the bridging task does (context)
+
+1. **Prepare** — `memu-workbuddy prepare` scans new turns under
+   `~/.workbuddy/projects` (one JSONL file per session, one directory per
+   project), mirrors the current memU recall files to
+   `~/.memu/hosts/workbuddy/memory` and `~/.memu/hosts/workbuddy/skill`,
+   snapshots them by content hash, and writes numbered **job-instruction files**
+   to `~/.memu/hosts/workbuddy/jobs/` (`1.txt`, `2.txt`, …).
+2. **Self-evolve** — the agent opens each job file **in numeric order** and
+   follows it: mine a session into user **memory**, mine a session into a
+   **skill**, and **describe** the files the sessions touched. "Do nothing" is
+   an allowed, common outcome for any job.
+3. **Commit** — `memu-workbuddy commit` diffs the tracked directories against
+   the step-1 snapshot and submits what the agent actually created or changed
+   back to memU.
+
+Only steps 1 and 3 are code. **Step 2 is real agent work**, so the scheduled
+run's prompt must instruct the agent to do it, not shell out to a script.
+
+## Prerequisites
+
+- **memU is installed and `memu-workbuddy` is on `PATH`.** Verify with
+  `memu-workbuddy doctor`; if it fails, do `INSTALL.md` Part 1 first.
+- **WorkBuddy's automation system is available.** The scheduled run uses
+  WorkBuddy's built-in `automation_update` tool with `scheduleType=recurring`.
+
+## Step 1 — settle the schedule
+
+Ask the user for a schedule if the request doesn't include one. **Default: every
+hour** (RRULE: `FREQ=HOURLY;INTERVAL=1`). Confirm before creating.
+
+## Step 2 — register the scheduled automation
+
+Create a WorkBuddy automation that runs the bridging pipeline. The prompt
+describes the three steps; the agent that picks up this automation will execute
+them.
+
+Register the automation with:
+
+- **task** — the pipeline prompt below (verbatim)
+- **scheduleType** — `recurring`
+- **rrule** — the user's chosen rule (default: `FREQ=HOURLY;INTERVAL=1`)
+- **cwd** — the user's home directory or primary working directory
+
+The pipeline prompt:
+
+```
+Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.
+
+1. PREPARE. Run this exact command with bash:
+   memu-workbuddy prepare
+   — it regenerates ~/.memu/hosts/workbuddy/jobs/. If the command exits non-zero, stop and report the error.
+
+2. SELF-EVOLVE. List ~/.memu/hosts/workbuddy/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.
+
+3. COMMIT. Run this exact command with bash:
+   memu-workbuddy commit
+   — it commits whatever the jobs created or changed. If it exits non-zero, report the error.
+
+Finish with a one-line summary: how many jobs ran and what was committed.
+```
+
+The prompt block is fixed; only the RRULE is the user's choice. Nothing in it
+is machine-specific — the pipeline is invoked through `PATH` commands.
+
+## Step 3 — confirm
+
+Report back: the automation was created (its id), and the schedule in words
+(e.g. "every hour"). Mention that the first run only has work to do once there
+are new WorkBuddy sessions since the last run.
+
+## Notes
+
+- **Idempotent and incremental.** `prepare` tracks a per-session line cursor in
+  `~/.memu/hosts/workbuddy/.session_manifest.workbuddy.json`, so each run only
+  processes turns it hasn't seen.
+- **Ordering is load-bearing.** Memory jobs are numbered before skill jobs, and
+  the resource-describe job is last. Always process in ascending numeric order.
+- **The working tree is host-scoped.** Everything under
+  `~/.memu/hosts/workbuddy/` is this adapter's run-scoped working state; other
+  memU host adapters (Codex, Claude Code, …) have their own and never race with
+  this one. The durable store they all share is the `MEMU_DB` in
+  `~/.memu/config.env`.
+- **Failure handling.** Steps 1 and 3 are the only failure points that should
+  abort the run. A single "do nothing" job in step 2 is normal, not an error.

--- a/src/memu/hosts/workbuddy/INSTALL.md
+++ b/src/memu/hosts/workbuddy/INSTALL.md
@@ -1,0 +1,162 @@
+# Install memU for WorkBuddy
+
+> **Audience: the agent.** A user will point you at this file ("follow this guide
+> to install memU"). Work top to bottom. Each part ends with a **verify** gate —
+> do not proceed until the current one passes.
+>
+> Everything on the memU side is a `PATH` command; you should never need to write
+> an absolute path to a script.
+
+Installing memU on WorkBuddy is three parts:
+
+1. **Install memU** — a Python package, and the store + provider it writes to.
+2. **Register the bridging task** — the scheduled job that turns recent WorkBuddy
+   sessions into durable memory (the *record* seam).
+3. **Patch `~/.workbuddy/MEMORY.md`** — a standing instruction that tells you to
+   pull relevant memory before you answer (the *inject* seam).
+
+Parts 2 and 3 must share one store and one embedding space, or a query is
+compared against vectors written elsewhere and retrieval silently returns
+nothing. Part 1 is what makes them agree.
+
+---
+
+## Part 1 — Install memU
+
+memU is distributed as a **pip package**. A Python runtime is required
+regardless, because the bridging task runs Python.
+
+### 1.1 Install
+
+```
+pip install memu-cli
+```
+
+This puts `memu` (the library's own surface) and **`memu-workbuddy`** (the
+WorkBuddy adapter) on `PATH`. Both Part 2 (record) and Part 3 (inject) go
+through `memu-workbuddy`.
+
+Confirm it resolves:
+
+```
+memu-workbuddy --help
+```
+
+If it is not found, the install landed in an environment that isn't on your
+`PATH`. Fix that now — the scheduled task in Part 2 runs from a bare,
+non-interactive environment and needs this command to resolve there.
+
+### 1.2 Configure the store and provider
+
+memU needs a **database** and an **LLM/embedding provider**. Both seams read this
+one config, so decide it once, here. Collect from the user (or reuse values they
+already have — if another memU host adapter such as `memu-codex` or
+`memu-claude-code` is already set up on this machine, `~/.memu/config.env`
+exists and **must be reused as is**; skip to the verify gate):
+
+| Setting | Env var | Example |
+| --- | --- | --- |
+| Database | `MEMU_DB` | `~/.memu/memu.sqlite3`, or a `postgres://…` DSN |
+| Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
+| API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
+
+**No `MEMU_API_KEY`? Say so, then go local.** If the user has no API key to
+give, tell them up front what that means: memory cannot be called across
+devices — everything stays on this machine, in a local database created for
+them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
+`MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local
+OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1`
+with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
+placeholder value — a local server ignores it.
+
+Write them to **`~/.memu/config.env`**, which every memU command loads. Use an
+**absolute** path for `MEMU_DB`, and `chmod 600` the file (the key is plaintext —
+tell the user). Do **not** instead export these in a shell profile: the scheduled
+task does not inherit your interactive shell.
+
+### ✅ Verify Part 1
+
+```
+memu-workbuddy doctor
+```
+
+It prints the store and provider it resolved and runs a smoke-test retrieval. It
+must exit cleanly. **Zero hits is the expected result** on a new store.
+
+---
+
+## Part 2 — Register the bridging (record) task
+
+The *record* seam: a scheduled job that periodically mines recent sessions under
+`~/.workbuddy/projects` into durable memU memory, skills, and resources.
+
+**Do not reinvent this.** Follow the packaged procedure:
+
+```
+memu-workbuddy docs task
+```
+
+It is authoritative. In summary: you will settle a schedule with the user
+(default: every hour) and register a WorkBuddy automation that runs
+`memu-workbuddy prepare`, works through
+`~/.memu/hosts/workbuddy/jobs/*.txt` in order, then runs
+`memu-workbuddy commit`.
+
+Nothing in that prompt is machine-specific. If you find yourself substituting an
+absolute path into it, you are doing it wrong.
+
+### ✅ Verify Part 2
+
+Confirm the automation exists in WorkBuddy's automation list. Then dry-run the
+first step by hand:
+
+```
+memu-workbuddy prepare
+```
+
+It should report how many sessions it prepared (zero, if there is nothing new
+since the cursor — that is fine and correct).
+
+---
+
+## Part 3 — Patch `~/.workbuddy/MEMORY.md` with the retrieval instruction
+
+The *inject* seam: a standing instruction in WorkBuddy's **global memory file**
+telling you to pull relevant memory before you answer. WorkBuddy loads
+`~/.workbuddy/MEMORY.md` into every session, so the instruction is simply always
+there — no hook, no wrapper, no per-turn process.
+
+**Do not hand-write the instruction.** memU owns the text and installs it for you:
+
+```
+memu-workbuddy install-instruction
+```
+
+It writes memU's block into `~/.workbuddy/MEMORY.md`, creating the file if it
+does not exist, and prints the diff. It appends rather than overwrites (existing
+content is backed up to `~/.workbuddy/MEMORY.md.bak`), and it is idempotent: the
+text sits in a marked block that a re-run — or a later memU release — replaces in
+place. `--dry-run` shows the diff without writing; `--print` prints just the
+block.
+
+### ✅ Verify Part 3
+
+```
+cat ~/.workbuddy/MEMORY.md
+memu-workbuddy retrieve "smoke test"
+```
+
+The memU block must appear exactly once, anything the user had there must be
+intact, and `retrieve` must exit cleanly (empty result lists are fine). A *fresh*
+WorkBuddy session is what picks up the new MEMORY.md — do not be surprised that
+the instruction is not in your own context yet.
+
+---
+
+## Done
+
+Report back to the user: the store (`MEMU_DB`) and provider in use; the scheduled
+automation and its schedule in words; and that the retrieval instruction is now in
+`~/.workbuddy/MEMORY.md`, taking effect in their next session. Record and inject
+both read `~/.memu/config.env`, so they provably share one store — what the task
+learns tonight is what retrieval finds tomorrow.

--- a/src/memu/hosts/workbuddy/UNINSTALL.md
+++ b/src/memu/hosts/workbuddy/UNINSTALL.md
@@ -1,0 +1,96 @@
+# Uninstall memU for WorkBuddy
+
+> **Audience: the agent.** A user has pointed you at this file ("follow this
+> guide to uninstall memU"). Work top to bottom. Each part ends with a
+> **verify** gate — do not proceed until the current one passes.
+
+Uninstalling is the install run in reverse, and it is three parts:
+
+1. **Unregister the bridging task** — stop the scheduled automation first, so
+   nothing fires mid-teardown (the *record* seam).
+2. **Unpatch `~/.workbuddy/MEMORY.md`** — remove the standing retrieval
+   instruction (the *inject* seam).
+3. **Apply the data-and-package defaults** — the user's memory is kept, the
+   tooling is removed — and close by reporting both.
+
+**One store, many hosts.** `~/.memu/config.env` and the store it names may be
+shared by other memU host adapters on this machine (`memu-codex`,
+`memu-claude-code`, …). Removing *this* host's seams never requires touching the
+shared store; Part 3 spells out when touching it is safe at all.
+
+---
+
+## Part 1 — Unregister the bridging (record) task
+
+Find the WorkBuddy automation that runs the memU bridging pipeline and delete
+it. You can find it by name or by the prompt content mentioning "memU bridging
+pipeline". Use WorkBuddy's automation management to remove it.
+
+### ✅ Verify Part 1
+
+The automation no longer appears in WorkBuddy's automation list.
+
+---
+
+## Part 2 — Remove the retrieval instruction
+
+**Do not hand-edit the block out.** memU owns the text and removes it for you:
+
+```
+memu-workbuddy remove-instruction
+```
+
+It deletes memU's marked block from `~/.workbuddy/MEMORY.md` and prints the
+diff. Everything outside the markers is the user's and survives; the previous
+contents are backed up to `~/.workbuddy/MEMORY.md.bak` before the rewrite.
+`--dry-run` shows the diff without writing. Re-running is a clean no-op — a
+file with no block left is already the desired end state.
+
+### ✅ Verify Part 2
+
+`cat ~/.workbuddy/MEMORY.md` — no `memu:begin`/`memu:end` markers remain, and
+the user's own content is intact. The session you are working in already loaded
+the old file, so the instruction may still be in your own context; a fresh
+session is what picks the removal up.
+
+---
+
+## Part 3 — The data, the config, and the package (defaults, then report)
+
+No questions to ask here. Apply the defaults below, and make sure the final
+report tells the user plainly what they got: **memory kept, tooling removed.**
+Only one thing overrides a default: the user's own explicit words.
+
+- **Keep the store and `~/.memu/config.env`.** Always. The store *is* the
+  user's accumulated memory, and it survives an uninstall by design —
+  reinstalling later picks it right back up. Delete it only if the user
+  explicitly asked to erase their memory as part of this uninstall, and warn
+  first, in plain words, that it is irreversible.
+- **The session cursor lives and dies with the store.**
+  `~/.memu/hosts/workbuddy/.session_manifest.workbuddy.json` records which
+  session turns have already been mined *into that store*. Store kept (the
+  default)? Keep the cursor — deleting it loses no memory, but the next install
+  re-mines every old session for nothing. Store deleted at the user's request?
+  Delete the cursor with it — a surviving cursor over an empty store marks
+  history as already mined, and it would never be mined again.
+- **Remove this host's residue.** Everything else under
+  `~/.memu/hosts/workbuddy/` — job files and mirrors, sparing the session
+  cursor above; `~/.workbuddy/MEMORY.md` itself **if** Part 2 left it empty
+  (it held only memU's block, so the install created it) — a file with the
+  user's own content stays, of course.
+- **Uninstall the package** — `pip uninstall memu-cli` (or `pipx uninstall
+  memu-cli` — match how it was installed) — **unless** another host adapter is
+  still integrated on this machine (another host's instruction file still
+  carries a memU block, or its bridging task still exists). Then the package
+  stays, and the report says which host is still using it.
+
+### ✅ Done
+
+Close the report with the two things the user needs to hear, in this order:
+
+1. **What was kept:** their memory — the store at `MEMU_DB`,
+   `~/.memu/config.env`, and the session cursor — untouched. A later reinstall
+   picks it up as is and resumes mining right where it left off.
+2. **What was removed:** the bridging automation, the retrieval instruction,
+   this host's working state, and (unless another host still needs it) the
+   `memu-cli` package.

--- a/src/memu/hosts/workbuddy/__init__.py
+++ b/src/memu/hosts/workbuddy/__init__.py
@@ -1,0 +1,11 @@
+"""The WorkBuddy host adapter — ``memu-workbuddy``.
+
+Binds ADR 0008's two seams onto WorkBuddy: *record* as a scheduled bridging
+task over ``~/.workbuddy/projects`` (see :mod:`memu.hosts.bridging`), *inject* as
+a standing instruction in ``~/.workbuddy/MEMORY.md`` that points the agent at
+the ``memu-workbuddy retrieve`` command.
+"""
+
+from memu.hosts.workbuddy.sessions import WorkBuddyTranscriptSource
+
+__all__ = ["WorkBuddyTranscriptSource"]

--- a/src/memu/hosts/workbuddy/cli.py
+++ b/src/memu/hosts/workbuddy/cli.py
@@ -1,0 +1,48 @@
+"""``memu-workbuddy`` — the WorkBuddy host adapter's command-line surface.
+
+The verbs are the shared host-adapter surface (:mod:`memu.hosts.host_cli`); this
+module is the WorkBuddy declaration: where its sessions live, and which file its
+standing instruction lands in.
+
+Usage:
+    memu-workbuddy retrieve "<query>"    # the inject seam — what the agent runs each turn
+    memu-workbuddy install-instruction   # the inject seam — patch ~/.workbuddy/MEMORY.md
+    memu-workbuddy prepare               # slice new sessions into job files
+    memu-workbuddy verify-resources      # filter the touched-file log (run by a job)
+    memu-workbuddy commit                # submit what the agent produced back to memU
+    memu-workbuddy doctor                # check config + store before relying on them
+    memu-workbuddy docs install          # print the agent-facing install guide
+    memu-workbuddy docs uninstall        # print the agent-facing removal guide
+"""
+
+from __future__ import annotations
+
+import sys
+
+from memu.hosts.workbuddy.sessions import SESSION_DIR, WorkBuddyTranscriptSource
+from memu.hosts.host_cli import HostSpec, run
+
+HOST = "workbuddy"
+
+MEMORY_MD = "~/.workbuddy/MEMORY.md"
+"""WorkBuddy's global memory file — loaded into every session, so the inject
+seam lands here.  (User-level: ``~/.workbuddy/MEMORY.md``; per-project memory
+files also exist but the instruction belongs at the level retrieval works at.)"""
+
+SPEC = HostSpec(
+    host=HOST,
+    display="WorkBuddy",
+    package="memu.hosts.workbuddy",
+    source_factory=WorkBuddyTranscriptSource,
+    session_dir=SESSION_DIR,
+    session_help="WorkBuddy session log (one project dir per escaped cwd)",
+    instruction_path=MEMORY_MD,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run(SPEC, argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/memu/hosts/workbuddy/sessions.py
+++ b/src/memu/hosts/workbuddy/sessions.py
@@ -1,0 +1,86 @@
+"""WorkBuddy's session log: ``~/.workbuddy/projects/<escaped-cwd>/*.jsonl``.
+
+The whole of what makes this host WorkBuddy. Everything the bridging task does
+with these records is host-agnostic and lives in :mod:`memu.hosts.bridging`.
+
+WorkBuddy keeps one directory per project — the project's absolute path with
+``/`` and ``\\`` flattened to ``-`` (``/Users/a/proj`` -> ``-Users-a-proj``) —
+and one JSONL file per session inside it, named by the session UUID.  The
+``sessions.json`` index sitting next to the project directories is not JSONL and
+is naturally skipped by discovery.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+from pathlib import Path
+from typing import ClassVar
+
+from memu.hosts.base import RecordKind, TranscriptSource
+
+SESSION_DIR = "~/.workbuddy/projects"
+
+_MESSAGE_ROLES = ("user", "assistant")
+_TOOL_TYPES = ("function_call", "function_call_result")
+
+
+class WorkBuddyTranscriptSource(TranscriptSource):
+    """WorkBuddy writes one JSON object per line, each a typed record.
+
+    A record is a conversation turn when its ``type`` is ``message`` and its
+    ``role`` is user or assistant — the content blocks use ``input_text``
+    (user) and ``output_text`` (assistant) instead of the ``text``/``tool_use``
+    convention other hosts share.  A record is a tool call or its result when
+    its ``type`` is ``function_call`` or ``function_call_result`` — these are
+    standalone records, not nested inside a message's content blocks (the same
+    pattern Codex uses).  Everything else — ``reasoning`` traces,
+    ``file-history-snapshot`` metadata, ``ai-title`` auto-titles — is noise the
+    mining jobs should never see.
+    """
+
+    name: ClassVar[str] = "workbuddy"
+
+    def __init__(self, session_dir: str | Path = SESSION_DIR) -> None:
+        self._root = Path(os.path.expanduser(str(session_dir)))
+
+    def root(self) -> Path:
+        return self._root
+
+    def classify(self, record: str) -> RecordKind:
+        try:
+            entry = json.loads(record)
+        except json.JSONDecodeError:
+            return RecordKind.OTHER
+        if not isinstance(entry, dict):
+            return RecordKind.OTHER
+
+        typ = entry.get("type")
+
+        # MESSAGE: user or assistant turns with text content.
+        if typ == "message" and entry.get("role") in _MESSAGE_ROLES:
+            content = entry.get("content")
+            if isinstance(content, list):
+                block_types = {b.get("type") for b in content if isinstance(b, dict)}
+                if block_types & {"input_text", "output_text"}:
+                    return RecordKind.MESSAGE
+            if isinstance(content, str) and content:
+                return RecordKind.MESSAGE
+
+        # TOOL: function calls and their results (standalone records).
+        if typ in _TOOL_TYPES:
+            return RecordKind.TOOL
+
+        return RecordKind.OTHER
+
+    def timestamp(self, record: str) -> str | None:
+        """WorkBuddy stamps records with epoch milliseconds."""
+        try:
+            value = json.loads(record).get("timestamp")
+        except (json.JSONDecodeError, AttributeError):
+            return None
+        if isinstance(value, (int, float)):
+            seconds = value / 1000 if value > 1e11 else value
+            return datetime.datetime.fromtimestamp(seconds, tz=datetime.UTC).isoformat()
+        return value if isinstance(value, str) else None

--- a/tests/test_host_sessions.py
+++ b/tests/test_host_sessions.py
@@ -18,6 +18,7 @@ from memu.hosts.codex.sessions import CodexTranscriptSource
 from memu.hosts.cursor.sessions import CursorTranscriptSource
 from memu.hosts.hermes.sessions import HermesTranscriptSource
 from memu.hosts.openclaw.sessions import OpenClawTranscriptSource
+from memu.hosts.workbuddy.sessions import WorkBuddyTranscriptSource
 
 
 def _line(entry: dict) -> str:
@@ -298,3 +299,86 @@ def test_hermes_opens_paths_with_uri_special_characters(tmp_path: pathlib.Path) 
     assert [source.key(path) for path in source.discover()] == ["new", "old"]
     with pytest.raises(sqlite3.OperationalError, match="readonly"):
         source._connect().execute("INSERT INTO messages (session_id, role, timestamp) VALUES ('x', 'user', 1)")
+
+
+# ── WorkBuddy ────────────────────────────────────────────────────────────────
+
+
+def test_workbuddy_classify_conversation_turns() -> None:
+    source = WorkBuddyTranscriptSource()
+    user = {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": "fix the bug"}],
+    }
+    assistant = {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "On it."}],
+    }
+    assert source.classify(_line(user)) is RecordKind.MESSAGE
+    assert source.classify(_line(assistant)) is RecordKind.MESSAGE
+
+
+def test_workbuddy_classify_tool_records() -> None:
+    """WorkBuddy logs tool calls and results as standalone records — the same
+    pattern Codex uses, unlike Claude Code / Cursor which nest them in message
+    content blocks."""
+    source = WorkBuddyTranscriptSource()
+    function_call = {
+        "type": "function_call",
+        "name": "Bash",
+        "callId": "chatcmpl-tool-abc123",
+        "arguments": '{"command": "ls"}',
+    }
+    function_call_result = {
+        "type": "function_call_result",
+        "name": "Bash",
+        "callId": "chatcmpl-tool-abc123",
+        "status": "completed",
+        "output": {"type": "text", "text": "file1.txt\nfile2.txt"},
+    }
+    assert source.classify(_line(function_call)) is RecordKind.TOOL
+    assert source.classify(_line(function_call_result)) is RecordKind.TOOL
+
+
+def test_workbuddy_drops_noise() -> None:
+    source = WorkBuddyTranscriptSource()
+    reasoning = {
+        "type": "reasoning",
+        "rawContent": [{"type": "reasoning_text", "text": "thinking..."}],
+    }
+    snapshot = {"type": "file-history-snapshot", "snapshot": {}}
+    title = {"type": "ai-title", "aiTitle": "test session"}
+    assert source.classify(_line(reasoning)) is RecordKind.OTHER
+    assert source.classify(_line(snapshot)) is RecordKind.OTHER
+    assert source.classify(_line(title)) is RecordKind.OTHER
+    assert source.classify("not json") is RecordKind.OTHER
+
+
+def test_workbuddy_timestamp_accepts_epoch_millis() -> None:
+    source = WorkBuddyTranscriptSource()
+    millis = {"type": "message", "role": "user", "timestamp": 1784435392565}
+    iso = {"type": "message", "role": "user", "timestamp": "2026-07-19T04:29:52.565000+00:00"}
+    assert source.timestamp(_line(millis)) == "2026-07-19T04:29:52.565000+00:00"
+    assert source.timestamp(_line(iso)) == "2026-07-19T04:29:52.565000+00:00"
+    assert source.timestamp(_line({"type": "reasoning"})) is None
+
+
+def test_workbuddy_discover(tmp_path: pathlib.Path) -> None:
+    """WorkBuddy keeps one directory per escaped cwd, one JSONL per session."""
+    project = tmp_path / "d-Users-proj"
+    project.mkdir()
+    session = project / "abc-123.jsonl"
+    session.write_text(
+        '{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}\n',
+        encoding="utf-8",
+    )
+    stray = tmp_path / "app" / "sessions.json"
+    stray.parent.mkdir()
+    stray.write_text("{}\n", encoding="utf-8")
+
+    source = WorkBuddyTranscriptSource(tmp_path)
+    assert source.exists()
+    assert source.discover() == [session]
+    assert source.key(session) == "d-Users-proj/abc-123.jsonl"


### PR DESCRIPTION
##  Pull Request Summary
Add a dedicated host adapter for WorkBuddy (Tencent's AI office agent), enabling memU to bridge WorkBuddy session logs into durable memory.

##  What does this PR do?
- New `WorkBuddyTranscriptSource` - classifies WorkBuddy's JSONL record types (message / function_call / function_call_result / reasoning / ...)
- New `memu-workbuddy` CLI binary with the standard host-adapter verbs
- Agent-facing docs: INSTALL.md, BRIDGING_TASK.md, UNINSTALL.md
- Test suite covering classify, timestamp, and discover

##  Why is this change needed?
WorkBuddy is a major desktop AI agent with no existing memU host adapter. This lets WorkBuddy users bridge their session logs into memU's durable memory system, the same way Codex, Claude Code, Cursor, and other hosts do.

##  Type of Change
- [x] New feature

##  PR Quality Checklist
- [x] PR title follows `feat(scope): description`
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated (INSTALL/BRIDGING_TASK/UNINSTALL)
- [x] No breaking changes