### PR TITLE
docs(hosts): name the OS system-wide proxy as a 502 source

### DIFF
--- a/src/memu/hosts/claude_code/INSTALL.md
+++ b/src/memu/hosts/claude_code/INSTALL.md
@@ -70,8 +70,10 @@ with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
 placeholder value — a local server ignores it.
 
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
-local embedding server, the shell's `HTTP_PROXY` is hijacking localhost
-traffic. Current memU bypasses proxies for loopback URLs automatically; on an
+local embedding server, a proxy is hijacking localhost traffic. The proxy may
+come from the shell's `HTTP_PROXY` — or from the OS's system-wide settings
+(macOS: System Settings → Network → Proxies), which `env | grep -i proxy`
+will not show. Current memU bypasses proxies for loopback URLs automatically; on an
 older release, set `NO_PROXY=localhost,127.0.0.1` for the commands that call
 memU. A local server reached through a **non-loopback** address
 (`host.docker.internal`, a LAN IP, a WSL or VM host address) needs the

--- a/src/memu/hosts/claude_code/INSTALL.md
+++ b/src/memu/hosts/claude_code/INSTALL.md
@@ -72,7 +72,8 @@ placeholder value — a local server ignores it.
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
 local embedding server, a proxy is hijacking localhost traffic. The proxy may
 come from the shell's `HTTP_PROXY` — or from the OS's system-wide settings
-(macOS: System Settings → Network → Proxies), which `env | grep -i proxy`
+(macOS: System Settings → Network → Proxies — a VPN
+client typically turns this on), which `env | grep -i proxy`
 will not show. Current memU bypasses proxies for loopback URLs automatically; on an
 older release, set `NO_PROXY=localhost,127.0.0.1` for the commands that call
 memU. A local server reached through a **non-loopback** address

--- a/src/memu/hosts/codex/INSTALL.md
+++ b/src/memu/hosts/codex/INSTALL.md
@@ -77,7 +77,8 @@ placeholder value — a local server ignores it.
 shell traffic through its proxy, which cannot reach *your* `localhost` — the
 symptom is `doctor` failing with a 502 against a local embedding server. (The
 same 502 can come from the user's own shell `HTTP_PROXY`, or from the OS's
-system-wide proxy — macOS: System Settings → Network → Proxies — which
+system-wide proxy — macOS: System Settings → Network → Proxies, typically turned on by a VPN
+client — which
 `env | grep -i proxy` will not show.)
 Current memU bypasses proxies for loopback URLs automatically; if you see that
 502 on an older release, set `NO_PROXY=localhost,127.0.0.1` for the commands

--- a/src/memu/hosts/codex/INSTALL.md
+++ b/src/memu/hosts/codex/INSTALL.md
@@ -75,7 +75,10 @@ placeholder value — a local server ignores it.
 
 **Going local behind Codex's network proxy: nothing to ask.** Codex routes
 shell traffic through its proxy, which cannot reach *your* `localhost` — the
-symptom is `doctor` failing with a 502 against a local embedding server.
+symptom is `doctor` failing with a 502 against a local embedding server. (The
+same 502 can come from the user's own shell `HTTP_PROXY`, or from the OS's
+system-wide proxy — macOS: System Settings → Network → Proxies — which
+`env | grep -i proxy` will not show.)
 Current memU bypasses proxies for loopback URLs automatically; if you see that
 502 on an older release, set `NO_PROXY=localhost,127.0.0.1` for the commands
 that call memU. The automatic bypass covers **loopback URLs only** — a local

--- a/src/memu/hosts/cursor/INSTALL.md
+++ b/src/memu/hosts/cursor/INSTALL.md
@@ -61,7 +61,8 @@ placeholder value — a local server ignores it.
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
 local embedding server, a proxy is hijacking localhost traffic. The proxy may
 come from the shell's `HTTP_PROXY` — or from the OS's system-wide settings
-(macOS: System Settings → Network → Proxies), which `env | grep -i proxy`
+(macOS: System Settings → Network → Proxies — a VPN
+client typically turns this on), which `env | grep -i proxy`
 will not show. Current memU bypasses proxies for loopback URLs automatically; on an
 older release, set `NO_PROXY=localhost,127.0.0.1` for the commands that call
 memU. A local server reached through a **non-loopback** address

--- a/src/memu/hosts/cursor/INSTALL.md
+++ b/src/memu/hosts/cursor/INSTALL.md
@@ -59,8 +59,10 @@ with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
 placeholder value — a local server ignores it.
 
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
-local embedding server, the shell's `HTTP_PROXY` is hijacking localhost
-traffic. Current memU bypasses proxies for loopback URLs automatically; on an
+local embedding server, a proxy is hijacking localhost traffic. The proxy may
+come from the shell's `HTTP_PROXY` — or from the OS's system-wide settings
+(macOS: System Settings → Network → Proxies), which `env | grep -i proxy`
+will not show. Current memU bypasses proxies for loopback URLs automatically; on an
 older release, set `NO_PROXY=localhost,127.0.0.1` for the commands that call
 memU. A local server reached through a **non-loopback** address
 (`host.docker.internal`, a LAN IP, a WSL or VM host address) needs the

--- a/src/memu/hosts/generic/INSTALL.md
+++ b/src/memu/hosts/generic/INSTALL.md
@@ -76,7 +76,8 @@ placeholder value — a local server ignores it.
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
 local embedding server, a proxy is hijacking localhost traffic. The proxy may
 come from the shell's `HTTP_PROXY` — or from the OS's system-wide settings
-(macOS: System Settings → Network → Proxies), which `env | grep -i proxy`
+(macOS: System Settings → Network → Proxies — a VPN
+client typically turns this on), which `env | grep -i proxy`
 will not show. Current memU bypasses proxies for loopback URLs automatically; on an
 older release, set `NO_PROXY=localhost,127.0.0.1` for the commands that call
 memU. A local server reached through a **non-loopback** address

--- a/src/memu/hosts/generic/INSTALL.md
+++ b/src/memu/hosts/generic/INSTALL.md
@@ -74,8 +74,10 @@ with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
 placeholder value — a local server ignores it.
 
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
-local embedding server, the shell's `HTTP_PROXY` is hijacking localhost
-traffic. Current memU bypasses proxies for loopback URLs automatically; on an
+local embedding server, a proxy is hijacking localhost traffic. The proxy may
+come from the shell's `HTTP_PROXY` — or from the OS's system-wide settings
+(macOS: System Settings → Network → Proxies), which `env | grep -i proxy`
+will not show. Current memU bypasses proxies for loopback URLs automatically; on an
 older release, set `NO_PROXY=localhost,127.0.0.1` for the commands that call
 memU. A local server reached through a **non-loopback** address
 (`host.docker.internal`, a LAN IP, a WSL or VM host address) needs the

--- a/src/memu/hosts/hermes/INSTALL.md
+++ b/src/memu/hosts/hermes/INSTALL.md
@@ -62,7 +62,8 @@ placeholder value — a local server ignores it.
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
 local embedding server, a proxy is hijacking localhost traffic. The proxy may
 come from the shell's `HTTP_PROXY` — or from the OS's system-wide settings
-(macOS: System Settings → Network → Proxies), which `env | grep -i proxy`
+(macOS: System Settings → Network → Proxies — a VPN
+client typically turns this on), which `env | grep -i proxy`
 will not show. Current memU bypasses proxies for loopback URLs automatically; on an
 older release, set `NO_PROXY=localhost,127.0.0.1` for the commands that call
 memU. A local server reached through a **non-loopback** address

--- a/src/memu/hosts/hermes/INSTALL.md
+++ b/src/memu/hosts/hermes/INSTALL.md
@@ -60,8 +60,10 @@ with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
 placeholder value — a local server ignores it.
 
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
-local embedding server, the shell's `HTTP_PROXY` is hijacking localhost
-traffic. Current memU bypasses proxies for loopback URLs automatically; on an
+local embedding server, a proxy is hijacking localhost traffic. The proxy may
+come from the shell's `HTTP_PROXY` — or from the OS's system-wide settings
+(macOS: System Settings → Network → Proxies), which `env | grep -i proxy`
+will not show. Current memU bypasses proxies for loopback URLs automatically; on an
 older release, set `NO_PROXY=localhost,127.0.0.1` for the commands that call
 memU. A local server reached through a **non-loopback** address
 (`host.docker.internal`, a LAN IP, a WSL or VM host address) needs the

--- a/src/memu/hosts/openclaw/INSTALL.md
+++ b/src/memu/hosts/openclaw/INSTALL.md
@@ -62,7 +62,8 @@ placeholder value — a local server ignores it.
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
 local embedding server, a proxy is hijacking localhost traffic. The proxy may
 come from the shell's `HTTP_PROXY` — or from the OS's system-wide settings
-(macOS: System Settings → Network → Proxies), which `env | grep -i proxy`
+(macOS: System Settings → Network → Proxies — a VPN
+client typically turns this on), which `env | grep -i proxy`
 will not show. Current memU bypasses proxies for loopback URLs automatically; on an
 older release, set `NO_PROXY=localhost,127.0.0.1` for the commands that call
 memU. A local server reached through a **non-loopback** address

--- a/src/memu/hosts/openclaw/INSTALL.md
+++ b/src/memu/hosts/openclaw/INSTALL.md
@@ -60,8 +60,10 @@ with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
 placeholder value — a local server ignores it.
 
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
-local embedding server, the shell's `HTTP_PROXY` is hijacking localhost
-traffic. Current memU bypasses proxies for loopback URLs automatically; on an
+local embedding server, a proxy is hijacking localhost traffic. The proxy may
+come from the shell's `HTTP_PROXY` — or from the OS's system-wide settings
+(macOS: System Settings → Network → Proxies), which `env | grep -i proxy`
+will not show. Current memU bypasses proxies for loopback URLs automatically; on an
 older release, set `NO_PROXY=localhost,127.0.0.1` for the commands that call
 memU. A local server reached through a **non-loopback** address
 (`host.docker.internal`, a LAN IP, a WSL or VM host address) needs the


### PR DESCRIPTION
## What

Docs only. All six install guides now mention a **third place a proxy can hide**: the OS's system-wide settings (macOS: System Settings → Network → Proxies) — **typically turned on by the user's VPN client** (Clash, Surge, …), not by hand.

This one is sneaky: `env | grep -i proxy` shows **nothing**, but Python's HTTP stack still uses it.

## Why

It happened in a real install. `doctor` kept returning 502 against local Ollama:

- `curl` worked — curl ignores system proxies
- Python failed — Python honors them

The installing agent spent minutes ruling out cold-start, IPv6, and headers before finding the proxy in System Settings — set there by the user's VPN client (`scutil --proxy` confirms it).

## Note

No code change needed. The automatic loopback bypass from #519 already covers this source — the behavioral tests pass on a machine with exactly this system proxy turned on. This PR just makes sure the next agent recognizes the symptom in seconds instead of minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
