### PR TITLE
feat(doctor): diagnose proxy hijacking instead of printing a bare 502

### DIFF
--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -127,6 +127,35 @@ async def _cmd_verify_resources(spec: HostSpec, args: argparse.Namespace) -> int
     return 0
 
 
+_TRANSPORT_SMELLS = ("502", "503", "504", "timeout", "timed out", "connect", "unreachable", "proxy")
+
+
+def _smells_like_transport(exc: BaseException) -> bool:
+    """Gate the proxy hint on transport-shaped failures only.
+
+    A missing ``MEMU_DB`` or a 401 from a placeholder key has nothing to do
+    with proxies — a hint there would be exactly the misdirection it exists to
+    prevent, and on a machine with a VPN-managed system proxy (where proxies
+    are *always* detected) it would fire on every failure. Walks the cause
+    chain because the interesting error (``ConnectError``, a 502 status) is
+    usually wrapped by the SDK before doctor sees it.
+    """
+    from memu.env import ConfigError
+
+    seen: list[BaseException] = []
+    current: BaseException | None = exc
+    while current is not None and current not in seen:
+        seen.append(current)
+        current = current.__cause__ or current.__context__
+    if any(isinstance(e, ConfigError) for e in seen):
+        return False
+    for e in seen:
+        text = f"{type(e).__name__} {e}".lower()
+        if any(smell in text for smell in _TRANSPORT_SMELLS):
+            return True
+    return False
+
+
 def _proxy_hint(base_url: str) -> str | None:
     """One diagnostic line for a failed doctor that smells like proxy trouble.
 
@@ -178,9 +207,10 @@ async def _cmd_doctor(spec: HostSpec, args: argparse.Namespace) -> int:
         if os.environ.get("MEMU_DEBUG") == "1":
             raise
         print(f"error: {exc} (set MEMU_DEBUG=1 for a traceback)", file=sys.stderr)
-        hint = _proxy_hint(env("MEMU_BASE_URL", "") or "")
-        if hint:
-            print(hint, file=sys.stderr)
+        if _smells_like_transport(exc):
+            hint = _proxy_hint(env("MEMU_BASE_URL", "") or "")
+            if hint:
+                print(hint, file=sys.stderr)
         return 1
     found = sum(len(result.get(layer, [])) for layer in ("segments", "files", "resources"))
     print(f"config    {os.path.expanduser(CONFIG_ENV)}")

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -23,6 +23,7 @@ import argparse
 import asyncio
 import os
 import sys
+import urllib.request
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from importlib.resources import files
@@ -126,6 +127,43 @@ async def _cmd_verify_resources(spec: HostSpec, args: argparse.Namespace) -> int
     return 0
 
 
+def _proxy_hint(base_url: str) -> str | None:
+    """One diagnostic line for a failed doctor that smells like proxy trouble.
+
+    The facts that took a live install minutes of tool calls to assemble — the
+    target is loopback, the call failed, a proxy is configured (possibly only
+    in the OS's system-wide settings, invisible to ``env``) — are all free to
+    check right here. So check them and say what they imply, instead of
+    leaving the next agent to re-derive the same conclusion from a bare 502.
+    """
+    proxies = urllib.request.getproxies()
+    if not proxies:
+        return None
+    from memu.embedding.http_client import is_loopback_url
+
+    listing = ", ".join(sorted(set(proxies.values())))
+    env_configured = any(k.lower().endswith("_proxy") for k in os.environ)
+    source = "the shell environment" if env_configured else "the OS's system-wide settings (invisible to `env`)"
+
+    if not is_loopback_url(base_url):
+        return (
+            f"hint: requests to this target go through a proxy ({listing}, from {source}). If the target "
+            "is actually this machine reached through a non-loopback address (host.docker.internal, a LAN "
+            "IP, a WSL/VM host address), the proxy cannot reach it — add that address to NO_PROXY."
+        )
+    if os.environ.get("MEMU_HTTP_PROXY"):
+        return (
+            "hint: the embedding target is this machine, and your explicit MEMU_HTTP_PROXY routes memU's "
+            "traffic through a proxy anyway. If that proxy cannot reach your localhost, unset MEMU_HTTP_PROXY."
+        )
+    return (
+        f"hint: the embedding target is this machine and a proxy is configured ({listing}, from {source}). "
+        "This memU bypasses proxies for loopback targets, so the proxy is likely not the cause — check the "
+        f"embedding server itself (is it running? does `curl {base_url}` answer?). On older memU releases "
+        "the proxy *would* hijack this call; there, set NO_PROXY=localhost,127.0.0.1."
+    )
+
+
 async def _cmd_doctor(spec: HostSpec, args: argparse.Namespace) -> int:
     """Prove config resolves and the store answers — the install guide's verify gate.
 
@@ -134,7 +172,16 @@ async def _cmd_doctor(spec: HostSpec, args: argparse.Namespace) -> int:
     """
     from memu.env import CONFIG_ENV, embedding_provider, env
 
-    result = await retrieval.retrieve("smoke test")
+    try:
+        result = await retrieval.retrieve("smoke test")
+    except Exception as exc:
+        if os.environ.get("MEMU_DEBUG") == "1":
+            raise
+        print(f"error: {exc} (set MEMU_DEBUG=1 for a traceback)", file=sys.stderr)
+        hint = _proxy_hint(env("MEMU_BASE_URL", "") or "")
+        if hint:
+            print(hint, file=sys.stderr)
+        return 1
     found = sum(len(result.get(layer, [])) for layer in ("segments", "files", "resources"))
     print(f"config    {os.path.expanduser(CONFIG_ENV)}")
     print(f"store     {env('MEMU_DB')}")

--- a/tests/test_doctor_proxy_hint.py
+++ b/tests/test_doctor_proxy_hint.py
@@ -110,3 +110,60 @@ async def test_doctor_failure_without_proxies_has_no_hint(
     err = capsys.readouterr().err
     assert "error: 502" in err
     assert "hint:" not in err
+
+
+async def test_config_error_gets_no_proxy_hint_even_with_proxies(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A missing MEMU_DB has nothing to do with proxies — on a VPN machine
+    (proxies always detected) the hint must not fire on every failure."""
+    from memu.env import ConfigError
+
+    monkeypatch.setenv("MEMU_BASE_URL", LOOPBACK)
+    monkeypatch.setenv("HTTP_PROXY", PROXY)
+    monkeypatch.delenv("MEMU_DEBUG", raising=False)
+
+    async def boom(query: str) -> dict:
+        raise ConfigError("MEMU_DB")
+
+    monkeypatch.setattr(retrieval, "retrieve", boom)
+
+    assert await _cmd_doctor(SPEC, argparse.Namespace()) == 1
+    assert "hint:" not in capsys.readouterr().err
+
+
+async def test_auth_error_gets_no_proxy_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("MEMU_BASE_URL", LOOPBACK)
+    monkeypatch.setenv("HTTP_PROXY", PROXY)
+    monkeypatch.delenv("MEMU_DEBUG", raising=False)
+
+    async def boom(query: str) -> dict:
+        raise RuntimeError("401")
+
+    monkeypatch.setattr(retrieval, "retrieve", boom)
+
+    assert await _cmd_doctor(SPEC, argparse.Namespace()) == 1
+    assert "hint:" not in capsys.readouterr().err
+
+
+async def test_wrapped_transport_error_still_hints(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The interesting error is usually wrapped by the SDK — the gate must
+    walk the cause chain, not just look at the outermost message."""
+    monkeypatch.setenv("MEMU_BASE_URL", LOOPBACK)
+    monkeypatch.setenv("HTTP_PROXY", PROXY)
+    monkeypatch.delenv("MEMU_DEBUG", raising=False)
+
+    class ConnectError(Exception):
+        pass
+
+    async def boom(query: str) -> dict:
+        raise RuntimeError("failed") from ConnectError()
+
+    monkeypatch.setattr(retrieval, "retrieve", boom)
+
+    assert await _cmd_doctor(SPEC, argparse.Namespace()) == 1
+    assert "hint:" in capsys.readouterr().err

--- a/tests/test_doctor_proxy_hint.py
+++ b/tests/test_doctor_proxy_hint.py
@@ -1,0 +1,112 @@
+"""A failed doctor should diagnose proxy trouble, not just print a bare 502.
+
+Field origin: a live install against local Ollama spent minutes of agent tool
+calls ruling out cold-start, IPv6, and header theories before finding a proxy
+configured only in macOS's system-wide settings — invisible to ``env``. Every
+fact in that conclusion was free to check at failure time; these pin that the
+doctor now checks them and says what they imply.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import urllib.request
+
+import pytest
+
+from memu.hosts import retrieval
+from memu.hosts.codex.cli import SPEC
+from memu.hosts.host_cli import _cmd_doctor, _proxy_hint
+
+PROXY = "http://proxy.corp:8080"
+LOOPBACK = "http://localhost:11434/v1"
+
+
+@pytest.fixture(autouse=True)
+def _clean_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in list(os.environ):
+        if key.lower().endswith("_proxy") or key.lower() == "no_proxy":
+            monkeypatch.delenv(key, raising=False)
+    # macOS reads system-wide proxies through getproxies(); pin to env-only so
+    # these tests behave the same on a developer machine with a system proxy.
+    monkeypatch.setattr(urllib.request, "getproxies", urllib.request.getproxies_environment)
+
+
+def test_no_proxies_no_hint() -> None:
+    assert _proxy_hint(LOOPBACK) is None
+
+
+def test_loopback_with_ambient_proxy_points_at_the_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With the automatic bypass in this build, the proxy is likely NOT the
+    cause — the hint should steer the agent away from the proxy rabbit hole."""
+    monkeypatch.setenv("HTTP_PROXY", PROXY)
+    hint = _proxy_hint(LOOPBACK)
+    assert hint is not None
+    assert "bypasses proxies for loopback" in hint
+    assert "the shell environment" in hint
+    assert "NO_PROXY" in hint, "older releases still need the exemption"
+
+
+def test_os_level_proxy_is_named_as_the_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The field case: getproxies() reports a proxy while env shows nothing —
+    macOS system settings. The hint must name that source explicitly."""
+    monkeypatch.setattr(urllib.request, "getproxies", lambda: {"http": PROXY})
+    hint = _proxy_hint(LOOPBACK)
+    assert hint is not None
+    assert "system-wide settings" in hint
+    assert "invisible to `env`" in hint
+
+
+def test_explicit_memu_proxy_is_called_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MEMU_HTTP_PROXY", PROXY)
+    hint = _proxy_hint(LOOPBACK)
+    assert hint is not None
+    assert "MEMU_HTTP_PROXY" in hint
+
+
+def test_non_loopback_local_address_suggests_no_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HTTP_PROXY", PROXY)
+    hint = _proxy_hint("http://host.docker.internal:11434/v1")
+    assert hint is not None
+    assert "host.docker.internal" in hint
+    assert "NO_PROXY" in hint
+
+
+async def test_doctor_prints_hint_on_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("MEMU_BASE_URL", LOOPBACK)
+    monkeypatch.setenv("HTTP_PROXY", PROXY)
+    monkeypatch.delenv("MEMU_DEBUG", raising=False)
+
+    async def boom(query: str) -> dict:
+        raise RuntimeError("502")
+
+    monkeypatch.setattr(retrieval, "retrieve", boom)
+
+    rc = await _cmd_doctor(SPEC, argparse.Namespace())
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "error: 502" in err
+    assert "hint:" in err
+
+
+async def test_doctor_failure_without_proxies_has_no_hint(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("MEMU_BASE_URL", LOOPBACK)
+    monkeypatch.delenv("MEMU_DEBUG", raising=False)
+
+    async def boom(query: str) -> dict:
+        raise RuntimeError("502")
+
+    monkeypatch.setattr(retrieval, "retrieve", boom)
+
+    rc = await _cmd_doctor(SPEC, argparse.Namespace())
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "error: 502" in err
+    assert "hint:" not in err


### PR DESCRIPTION
## What

When `doctor`'s test call fails, it now adds **one `hint:` line** if a proxy is configured.

Before:

```
error: Error code: 502 (set MEMU_DEBUG=1 for a traceback)
```

After:

```
error: Error code: 502 (set MEMU_DEBUG=1 for a traceback)
hint: the embedding target is this machine and a proxy is configured
      (http://127.0.0.1:7899, from the OS's system-wide settings, invisible
      to `env`) — ...what this means and what to do...
```

The hint covers three cases:

- **Loopback target + normal proxy** → "this memU already bypasses proxies for loopback (#519), so check the server itself; older releases need `NO_PROXY`"
- **Loopback target + explicit `MEMU_HTTP_PROXY`** → "you opted into the proxy yourself; unset it if it can't reach localhost"
- **Non-loopback target** (`host.docker.internal`, LAN IP) → "the bypass doesn't apply here; add the address to `NO_PROXY`"

Proxy detection uses `urllib.request.getproxies()`, so it sees shell env vars **and** OS system settings — and the hint says which one it found.

## Why

A real install burned ~4 minutes and ~15 tool calls debugging a bare 502 (see #523 for the story). Everything the agent eventually figured out, `doctor` could have printed in the first second — all three facts are free to check at failure time.

## Safety

- Zero change to how requests are sent — this only adds a print on the failure path
- Exit code and `MEMU_DEBUG` re-raise behavior unchanged
- 7 tests cover every branch, including "no proxy → no hint"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
