### PR TITLE
docs(hosts): scheduled runs drain leftover jobs first; config repairs stay at the connection layer

### DIFF
--- a/src/memu/hosts/claude_code/BRIDGING_TASK.md
+++ b/src/memu/hosts/claude_code/BRIDGING_TASK.md
@@ -58,7 +58,7 @@ the user explicitly asks for it) — that runs Claude Code headless with the
 pipeline prompt:
 
 ```
-0 * * * * claude -p 'Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. PREPARE. Run this exact command with bash:  memu-claude-code prepare  — it regenerates ~/.memu/hosts/claude-code/jobs/. If the command exits non-zero, stop and report the error.  2. SELF-EVOLVE. List ~/.memu/hosts/claude-code/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  3. COMMIT. Run this exact command with bash:  memu-claude-code commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran and what was committed.'
+0 * * * * claude -p 'Run the memU bridging pipeline. Do the four steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. LEFTOVERS. If ~/.memu/hosts/claude-code/jobs/ already contains job files, they are unfinished work from an earlier run (a crash, or the install itself) — process them exactly as step 3 describes, then run:  memu-claude-code commit  — and only then continue.  2. PREPARE. Run this exact command with bash:  memu-claude-code prepare  — it regenerates ~/.memu/hosts/claude-code/jobs/. If the command exits non-zero, stop and report the error.  3. SELF-EVOLVE. List ~/.memu/hosts/claude-code/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 4. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  4. COMMIT. Run this exact command with bash:  memu-claude-code commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran (leftovers included) and what was committed.'
 ```
 
 The prompt block is fixed; only the cron expression is the user's choice. Nothing
@@ -72,6 +72,12 @@ work to do once there are new Claude Code sessions since the last run.
 
 ## Notes
 
+- **Leftovers run before prepare.** Job files already on disk when the run
+  starts are unfinished work — a run that died mid-pipeline, or the install's
+  own verify. `prepare` deletes unprocessed job files, and the cursor already
+  marks their sessions as seen, so anything skipped at that moment would never
+  be minable again; draining leftovers first turns a half-done cycle into
+  bounded re-work instead of silent loss.
 - **Idempotent and incremental.** `prepare` tracks a per-session line cursor in
   `~/.memu/hosts/claude-code/.session_manifest.claude-code.json`, so each run
   only processes turns it hasn't seen.

--- a/src/memu/hosts/claude_code/INSTALL.md
+++ b/src/memu/hosts/claude_code/INSTALL.md
@@ -84,6 +84,17 @@ Write them to **`~/.memu/config.env`**, which every memU command loads. Use an
 tell the user). Do **not** instead export these in a shell profile: the scheduled
 task does not inherit your interactive shell.
 
+**The existing config fails doctor? Repair the connection, never the
+identity.** If `~/.memu/config.env` predates this install and `doctor` fails,
+diagnose the transport first — is the embedding server running, is a proxy in
+the way — before touching the file. A minimal connection-level edit (say,
+`localhost` → `127.0.0.1`) is acceptable: back the file up first, and tell the
+user what changed and why. Never change `MEMU_DB`, `MEMU_EMBED_PROVIDER`, or
+`MEMU_EMBED_MODEL` on an existing store — those three bind the embedding
+space, and "fixing" them silently splits the user's memory (old vectors become
+unreachable until everything is re-embedded). If one of them looks wrong, stop
+and ask the user.
+
 ### ✅ Verify Part 1
 
 ```
@@ -119,14 +130,17 @@ absolute path into it, you are doing it wrong.
 
 ### ✅ Verify Part 2
 
-Confirm the cron/launchd entry exists. Then dry-run the first step by hand:
+Confirm the cron/launchd entry exists. Then run the **first bridging cycle to
+completion, now** — you are the very agent the scheduled prompt addresses, so
+follow it yourself: run `memu-claude-code prepare`, work through every job file under
+`~/.memu/hosts/claude-code/jobs/` in ascending numeric order, then run `memu-claude-code commit`. Zero prepared
+sessions is fine and correct (nothing to process; commit reports nothing).
 
-```
-memu-claude-code prepare
-```
-
-It should report how many sessions it prepared (zero, if there is nothing new
-since the cursor — that is fine and correct).
+Do **not** stop after `prepare`: it advances the session cursor before anything
+reaches the store, and the next scheduled run's own `prepare` deletes
+unprocessed job files — a cycle left half-done here silently loses every
+session it covered. Finishing it closes that window, and the user leaves the
+install with their first memories already retrievable.
 
 ---
 

--- a/src/memu/hosts/claude_code/INSTALL.md
+++ b/src/memu/hosts/claude_code/INSTALL.md
@@ -130,17 +130,14 @@ absolute path into it, you are doing it wrong.
 
 ### ✅ Verify Part 2
 
-Confirm the cron/launchd entry exists. Then run the **first bridging cycle to
-completion, now** — you are the very agent the scheduled prompt addresses, so
-follow it yourself: run `memu-claude-code prepare`, work through every job file under
-`~/.memu/hosts/claude-code/jobs/` in ascending numeric order, then run `memu-claude-code commit`. Zero prepared
-sessions is fine and correct (nothing to process; commit reports nothing).
+Confirm the cron/launchd entry exists. Then dry-run the first step by hand:
 
-Do **not** stop after `prepare`: it advances the session cursor before anything
-reaches the store, and the next scheduled run's own `prepare` deletes
-unprocessed job files — a cycle left half-done here silently loses every
-session it covered. Finishing it closes that window, and the user leaves the
-install with their first memories already retrievable.
+```
+memu-claude-code prepare
+```
+
+It should report how many sessions it prepared (zero, if there is nothing new
+since the cursor — that is fine and correct).
 
 ---
 

--- a/src/memu/hosts/codex/BRIDGING_TASK.md
+++ b/src/memu/hosts/codex/BRIDGING_TASK.md
@@ -67,34 +67,39 @@ Create a Codex scheduled task with the chosen cron, named e.g. `memu-bridging`,
 and set its recurring prompt to this block **verbatim**:
 
 ```
-Run the memU bridging pipeline. Do the three steps strictly in order; do not
+Run the memU bridging pipeline. Do the four steps strictly in order; do not
 skip a step even if the previous one looks like it produced nothing.
 
-1. PREPARE. Run this exact command with bash:
+1. LEFTOVERS. If ~/.memu/jobs/ already contains job files, they are unfinished
+   work from an earlier run (a crash, or the install itself). Process them
+   exactly as step 3 describes, then run memu-codex commit — and only then
+   continue.
+
+2. PREPARE. Run this exact command with bash:
 
      memu-codex prepare
 
    It regenerates ~/.memu/jobs/. If the command exits non-zero, stop and report
    the error — do not continue.
 
-2. SELF-EVOLVE. List ~/.memu/jobs/*.txt and process them in ascending numeric
+3. SELF-EVOLVE. List ~/.memu/jobs/*.txt and process them in ascending numeric
    order (1.txt, then 2.txt, …). There may be anywhere from 0 to ~21 files, and
    the count changes every run — always glob and sort; never assume a fixed
-   number. If there are no job files, skip to step 3.
+   number. If there are no job files, skip to step 4.
 
    For each job file: read it with `cat` and follow its instructions to the
    letter. Each job is self-contained and already carries the concrete paths it
    needs. Order matters — finish one job before starting the next. Emitting no
    files for a job is a valid outcome; do not invent content to fill a job.
 
-3. COMMIT. After every job is done, run this exact command with bash:
+4. COMMIT. After every job is done, run this exact command with bash:
 
      memu-codex commit
 
    It commits whatever the jobs created or changed. If it exits non-zero, report
    the error.
 
-Finish with a one-line summary: how many jobs ran and what was committed (or
+Finish with a one-line summary: how many jobs ran (leftovers included) and what was committed (or
 that there was nothing to commit).
 ```
 
@@ -106,6 +111,12 @@ are new Codex sessions since the last run.
 
 ## Notes
 
+- **Leftovers run before prepare.** Job files already on disk when the run
+  starts are unfinished work — a run that died mid-pipeline, or the install's
+  own verify. `prepare` deletes unprocessed job files, and the cursor already
+  marks their sessions as seen, so anything skipped at that moment would never
+  be minable again; draining leftovers first turns a half-done cycle into
+  bounded re-work instead of silent loss.
 - **Idempotent and incremental.** `prepare` tracks a per-session line cursor in
   `~/.memu/.session_manifest.codex.json`, so each run only processes turns it
   hasn't seen. A run with no new session activity correctly does nothing.

--- a/src/memu/hosts/codex/INSTALL.md
+++ b/src/memu/hosts/codex/INSTALL.md
@@ -104,6 +104,17 @@ working directory, and the scheduled task has no reliable working directory.
 The API key sits in plaintext in this file. Tell the user, and set the
 permissions: `chmod 600 ~/.memu/config.env`.
 
+**The existing config fails doctor? Repair the connection, never the
+identity.** If `~/.memu/config.env` predates this install and `doctor` fails,
+diagnose the transport first — is the embedding server running, is a proxy in
+the way — before touching the file. A minimal connection-level edit (say,
+`localhost` → `127.0.0.1`) is acceptable: back the file up first, and tell the
+user what changed and why. Never change `MEMU_DB`, `MEMU_EMBED_PROVIDER`, or
+`MEMU_EMBED_MODEL` on an existing store — those three bind the embedding
+space, and "fixing" them silently splits the user's memory (old vectors become
+unreachable until everything is re-embedded). If one of them looks wrong, stop
+and ask the user.
+
 ### ✅ Verify Part 1
 
 ```
@@ -141,16 +152,18 @@ absolute path into it, you are doing it wrong.
 
 ### ✅ Verify Part 2
 
-Confirm the scheduled task exists with the expected name and cron. Then dry-run
-the first step by hand:
+Confirm the scheduled task exists with the expected name and cron. Then run the **first bridging cycle to
+completion, now** — you are the very agent the scheduled prompt addresses, so
+follow it yourself: run `memu-codex prepare`, work through every job file under
+`~/.memu/jobs/` in ascending numeric order, then run `memu-codex commit`. Zero prepared
+sessions is fine and correct (nothing to process; commit reports nothing).
 
-```
-memu-codex prepare
-```
-
-It should report how many sessions it prepared (zero, if there is nothing new
-since the cursor — that is fine and correct). Report the task name and schedule
-back to the user.
+Do **not** stop after `prepare`: it advances the session cursor before anything
+reaches the store, and the next scheduled run's own `prepare` deletes
+unprocessed job files — a cycle left half-done here silently loses every
+session it covered. Finishing it closes that window, and the user leaves the
+install with their first memories already retrievable.
+Report the task name and schedule back to the user.
 
 ---
 

--- a/src/memu/hosts/codex/INSTALL.md
+++ b/src/memu/hosts/codex/INSTALL.md
@@ -152,18 +152,16 @@ absolute path into it, you are doing it wrong.
 
 ### ✅ Verify Part 2
 
-Confirm the scheduled task exists with the expected name and cron. Then run the **first bridging cycle to
-completion, now** — you are the very agent the scheduled prompt addresses, so
-follow it yourself: run `memu-codex prepare`, work through every job file under
-`~/.memu/jobs/` in ascending numeric order, then run `memu-codex commit`. Zero prepared
-sessions is fine and correct (nothing to process; commit reports nothing).
+Confirm the scheduled task exists with the expected name and cron. Then dry-run
+the first step by hand:
 
-Do **not** stop after `prepare`: it advances the session cursor before anything
-reaches the store, and the next scheduled run's own `prepare` deletes
-unprocessed job files — a cycle left half-done here silently loses every
-session it covered. Finishing it closes that window, and the user leaves the
-install with their first memories already retrievable.
-Report the task name and schedule back to the user.
+```
+memu-codex prepare
+```
+
+It should report how many sessions it prepared (zero, if there is nothing new
+since the cursor — that is fine and correct). Report the task name and schedule
+back to the user.
 
 ---
 

--- a/src/memu/hosts/cursor/BRIDGING_TASK.md
+++ b/src/memu/hosts/cursor/BRIDGING_TASK.md
@@ -54,7 +54,7 @@ Create a system cron entry — the default, macOS included (use launchd only if
 the user explicitly asks for it) — running:
 
 ```
-0 * * * * cursor-agent -p 'Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. PREPARE. Run this exact command with bash:  memu-cursor prepare  — it regenerates ~/.memu/hosts/cursor/jobs/. If the command exits non-zero, stop and report the error.  2. SELF-EVOLVE. List ~/.memu/hosts/cursor/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  3. COMMIT. Run this exact command with bash:  memu-cursor commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran and what was committed.'
+0 * * * * cursor-agent -p 'Run the memU bridging pipeline. Do the four steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. LEFTOVERS. If ~/.memu/hosts/cursor/jobs/ already contains job files, they are unfinished work from an earlier run (a crash, or the install itself) — process them exactly as step 3 describes, then run:  memu-cursor commit  — and only then continue.  2. PREPARE. Run this exact command with bash:  memu-cursor prepare  — it regenerates ~/.memu/hosts/cursor/jobs/. If the command exits non-zero, stop and report the error.  3. SELF-EVOLVE. List ~/.memu/hosts/cursor/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 4. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  4. COMMIT. Run this exact command with bash:  memu-cursor commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran (leftovers included) and what was committed.'
 ```
 
 The prompt block is fixed; only the cron expression is the user's choice. Nothing
@@ -68,6 +68,12 @@ since the last run.
 
 ## Notes
 
+- **Leftovers run before prepare.** Job files already on disk when the run
+  starts are unfinished work — a run that died mid-pipeline, or the install's
+  own verify. `prepare` deletes unprocessed job files, and the cursor already
+  marks their sessions as seen, so anything skipped at that moment would never
+  be minable again; draining leftovers first turns a half-done cycle into
+  bounded re-work instead of silent loss.
 - **Idempotent and incremental.** `prepare` tracks a per-session line cursor in
   `~/.memu/hosts/cursor/.session_manifest.cursor.json`.
 - **Ordering is load-bearing.** Memory jobs before skill jobs, the

--- a/src/memu/hosts/cursor/INSTALL.md
+++ b/src/memu/hosts/cursor/INSTALL.md
@@ -71,6 +71,17 @@ do not ask the user.
 Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
 never a shell-profile export — the scheduled task does not inherit your shell).
 
+**The existing config fails doctor? Repair the connection, never the
+identity.** If `~/.memu/config.env` predates this install and `doctor` fails,
+diagnose the transport first — is the embedding server running, is a proxy in
+the way — before touching the file. A minimal connection-level edit (say,
+`localhost` → `127.0.0.1`) is acceptable: back the file up first, and tell the
+user what changed and why. Never change `MEMU_DB`, `MEMU_EMBED_PROVIDER`, or
+`MEMU_EMBED_MODEL` on an existing store — those three bind the embedding
+space, and "fixing" them silently splits the user's memory (old vectors become
+unreachable until everything is re-embedded). If one of them looks wrong, stop
+and ask the user.
+
 ### ✅ Verify Part 1
 
 ```
@@ -100,8 +111,17 @@ it is machine-specific.
 
 ### ✅ Verify Part 2
 
-Confirm the cron entry exists, then dry-run: `memu-cursor prepare` (zero prepared
-sessions is fine and correct when nothing is new).
+Confirm the cron entry exists. Then run the **first bridging cycle to
+completion, now** — you are the very agent the scheduled prompt addresses, so
+follow it yourself: run `memu-cursor prepare`, work through every job file under
+`~/.memu/hosts/cursor/jobs/` in ascending numeric order, then run `memu-cursor commit`. Zero prepared
+sessions is fine and correct (nothing to process; commit reports nothing).
+
+Do **not** stop after `prepare`: it advances the session cursor before anything
+reaches the store, and the next scheduled run's own `prepare` deletes
+unprocessed job files — a cycle left half-done here silently loses every
+session it covered. Finishing it closes that window, and the user leaves the
+install with their first memories already retrievable.
 
 ---
 

--- a/src/memu/hosts/cursor/INSTALL.md
+++ b/src/memu/hosts/cursor/INSTALL.md
@@ -111,17 +111,8 @@ it is machine-specific.
 
 ### ✅ Verify Part 2
 
-Confirm the cron entry exists. Then run the **first bridging cycle to
-completion, now** — you are the very agent the scheduled prompt addresses, so
-follow it yourself: run `memu-cursor prepare`, work through every job file under
-`~/.memu/hosts/cursor/jobs/` in ascending numeric order, then run `memu-cursor commit`. Zero prepared
-sessions is fine and correct (nothing to process; commit reports nothing).
-
-Do **not** stop after `prepare`: it advances the session cursor before anything
-reaches the store, and the next scheduled run's own `prepare` deletes
-unprocessed job files — a cycle left half-done here silently loses every
-session it covered. Finishing it closes that window, and the user leaves the
-install with their first memories already retrievable.
+Confirm the cron entry exists, then dry-run: `memu-cursor prepare` (zero prepared
+sessions is fine and correct when nothing is new).
 
 ---
 

--- a/src/memu/hosts/generic/BRIDGING_TASK.md
+++ b/src/memu/hosts/generic/BRIDGING_TASK.md
@@ -56,27 +56,32 @@ own scheduler instead only if the user prefers it. The recurring prompt, with `<
 in, **verbatim**:
 
 ```
-Run the memU bridging pipeline. Do the three steps strictly in order; do not
+Run the memU bridging pipeline. Do the four steps strictly in order; do not
 skip a step even if the previous one looks like it produced nothing.
 
-1. PREPARE. Run this exact command with the shell tool:
+1. LEFTOVERS. If ~/.memu/hosts/agent/jobs/ already contains job files, they are unfinished
+   work from an earlier run (a crash, or the install itself). Process them
+   exactly as step 3 describes, then run memu-agent commit — and only then
+   continue.
+
+2. PREPARE. Run this exact command with the shell tool:
 
      memu-agent prepare --session-dir <SESSION_DIR>
 
    It regenerates ~/.memu/hosts/agent/jobs/. If the command exits non-zero,
    stop and report the error — do not continue.
 
-2. SELF-EVOLVE. List ~/.memu/hosts/agent/jobs/*.txt and process them in
+3. SELF-EVOLVE. List ~/.memu/hosts/agent/jobs/*.txt and process them in
    ascending numeric order (1.txt, then 2.txt, …). The count changes every
    run — always glob and sort; never assume a fixed number. If there are no
-   job files, skip to step 3.
+   job files, skip to step 4.
 
    For each job file: read it and follow its instructions to the letter. Each
    job is self-contained and already carries the concrete paths it needs.
    Order matters — finish one job before starting the next. Emitting no files
    for a job is a valid outcome; do not invent content to fill a job.
 
-3. COMMIT. After every job is done, run this exact command with the shell
+4. COMMIT. After every job is done, run this exact command with the shell
    tool:
 
      memu-agent commit
@@ -84,7 +89,7 @@ skip a step even if the previous one looks like it produced nothing.
    It commits whatever the jobs created or changed. If it exits non-zero,
    report the error.
 
-Finish with a one-line summary: how many jobs ran and what was committed (or
+Finish with a one-line summary: how many jobs ran (leftovers included) and what was committed (or
 that there was nothing to commit).
 ```
 
@@ -96,6 +101,12 @@ last run.
 
 ## Notes
 
+- **Leftovers run before prepare.** Job files already on disk when the run
+  starts are unfinished work — a run that died mid-pipeline, or the install's
+  own verify. `prepare` deletes unprocessed job files, and the cursor already
+  marks their sessions as seen, so anything skipped at that moment would never
+  be minable again; draining leftovers first turns a half-done cycle into
+  bounded re-work instead of silent loss.
 - **Idempotent and incremental.** `prepare` tracks a per-session line cursor
   in `~/.memu/hosts/agent/.session_manifest.agent.json`.
 - **Several generic agents on one machine** must not share a working tree: add

--- a/src/memu/hosts/generic/INSTALL.md
+++ b/src/memu/hosts/generic/INSTALL.md
@@ -86,6 +86,17 @@ do not ask the user.
 Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
 never a shell-profile export — a scheduled task does not inherit your shell).
 
+**The existing config fails doctor? Repair the connection, never the
+identity.** If `~/.memu/config.env` predates this install and `doctor` fails,
+diagnose the transport first — is the embedding server running, is a proxy in
+the way — before touching the file. A minimal connection-level edit (say,
+`localhost` → `127.0.0.1`) is acceptable: back the file up first, and tell the
+user what changed and why. Never change `MEMU_DB`, `MEMU_EMBED_PROVIDER`, or
+`MEMU_EMBED_MODEL` on an existing store — those three bind the embedding
+space, and "fixing" them silently splits the user's memory (old vectors become
+unreachable until everything is re-embedded). If one of them looks wrong, stop
+and ask the user.
+
 ### ✅ Verify Part 1
 
 ```
@@ -118,12 +129,17 @@ otherwise — whose prompt runs
 
 ### ✅ Verify Part 2
 
-```
-memu-agent prepare --session-dir <detected dir>
-```
+Confirm the scheduled entry exists. Then run the **first bridging cycle to
+completion, now** — you are the very agent the scheduled prompt addresses, so
+follow it yourself: run `memu-agent prepare --session-dir <detected dir>`, work through every job file under
+`~/.memu/hosts/agent/jobs/` in ascending numeric order, then run `memu-agent commit`. Zero prepared
+sessions is fine and correct (nothing to process; commit reports nothing).
 
-It should report how many sessions it prepared (zero is fine and correct when
-nothing is new).
+Do **not** stop after `prepare`: it advances the session cursor before anything
+reaches the store, and the next scheduled run's own `prepare` deletes
+unprocessed job files — a cycle left half-done here silently loses every
+session it covered. Finishing it closes that window, and the user leaves the
+install with their first memories already retrievable.
 
 ---
 

--- a/src/memu/hosts/generic/INSTALL.md
+++ b/src/memu/hosts/generic/INSTALL.md
@@ -129,17 +129,12 @@ otherwise — whose prompt runs
 
 ### ✅ Verify Part 2
 
-Confirm the scheduled entry exists. Then run the **first bridging cycle to
-completion, now** — you are the very agent the scheduled prompt addresses, so
-follow it yourself: run `memu-agent prepare --session-dir <detected dir>`, work through every job file under
-`~/.memu/hosts/agent/jobs/` in ascending numeric order, then run `memu-agent commit`. Zero prepared
-sessions is fine and correct (nothing to process; commit reports nothing).
+```
+memu-agent prepare --session-dir <detected dir>
+```
 
-Do **not** stop after `prepare`: it advances the session cursor before anything
-reaches the store, and the next scheduled run's own `prepare` deletes
-unprocessed job files — a cycle left half-done here silently loses every
-session it covered. Finishing it closes that window, and the user leaves the
-install with their first memories already retrievable.
+It should report how many sessions it prepared (zero is fine and correct when
+nothing is new).
 
 ---
 

--- a/src/memu/hosts/hermes/BRIDGING_TASK.md
+++ b/src/memu/hosts/hermes/BRIDGING_TASK.md
@@ -54,7 +54,7 @@ hour**, cron `0 * * * *` (local time). Confirm before creating.
 Create a system cron entry that runs Hermes headless with the pipeline prompt:
 
 ```
-0 * * * * hermes -p 'Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. PREPARE. Run this exact command with the shell tool:  memu-hermes prepare  — it regenerates ~/.memu/hosts/hermes/jobs/. If the command exits non-zero, stop and report the error.  2. SELF-EVOLVE. List ~/.memu/hosts/hermes/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  3. COMMIT. Run this exact command with the shell tool:  memu-hermes commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran and what was committed.'
+0 * * * * hermes -p 'Run the memU bridging pipeline. Do the four steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. LEFTOVERS. If ~/.memu/hosts/hermes/jobs/ already contains job files, they are unfinished work from an earlier run (a crash, or the install itself) — process them exactly as step 3 describes, then run:  memu-hermes commit  — and only then continue.  2. PREPARE. Run this exact command with the shell tool:  memu-hermes prepare  — it regenerates ~/.memu/hosts/hermes/jobs/. If the command exits non-zero, stop and report the error.  3. SELF-EVOLVE. List ~/.memu/hosts/hermes/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 4. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  4. COMMIT. Run this exact command with the shell tool:  memu-hermes commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran (leftovers included) and what was committed.'
 ```
 
 (Adjust the headless invocation to the Hermes CLI the user runs, but keep the
@@ -69,6 +69,12 @@ the last run.
 
 ## Notes
 
+- **Leftovers run before prepare.** Job files already on disk when the run
+  starts are unfinished work — a run that died mid-pipeline, or the install's
+  own verify. `prepare` deletes unprocessed job files, and the cursor already
+  marks their sessions as seen, so anything skipped at that moment would never
+  be minable again; draining leftovers first turns a half-done cycle into
+  bounded re-work instead of silent loss.
 - **Idempotent and incremental.** `prepare` tracks a per-session message-count
   cursor in `~/.memu/hosts/hermes/.session_manifest.hermes.json`, keyed by
   session id — messages are append-only per session, so the count-cursor is

--- a/src/memu/hosts/hermes/INSTALL.md
+++ b/src/memu/hosts/hermes/INSTALL.md
@@ -112,17 +112,8 @@ then `memu-hermes commit`. Nothing in it is machine-specific.
 
 ### ✅ Verify Part 2
 
-Confirm the cron entry exists. Then run the **first bridging cycle to
-completion, now** — you are the very agent the scheduled prompt addresses, so
-follow it yourself: run `memu-hermes prepare`, work through every job file under
-`~/.memu/hosts/hermes/jobs/` in ascending numeric order, then run `memu-hermes commit`. Zero prepared
-sessions is fine and correct (nothing to process; commit reports nothing).
-
-Do **not** stop after `prepare`: it advances the session cursor before anything
-reaches the store, and the next scheduled run's own `prepare` deletes
-unprocessed job files — a cycle left half-done here silently loses every
-session it covered. Finishing it closes that window, and the user leaves the
-install with their first memories already retrievable.
+Confirm the cron entry exists, then dry-run: `memu-hermes prepare` (zero prepared
+sessions is fine and correct when nothing is new).
 
 ---
 

--- a/src/memu/hosts/hermes/INSTALL.md
+++ b/src/memu/hosts/hermes/INSTALL.md
@@ -72,6 +72,17 @@ do not ask the user.
 Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
 never a shell-profile export — the scheduled task does not inherit your shell).
 
+**The existing config fails doctor? Repair the connection, never the
+identity.** If `~/.memu/config.env` predates this install and `doctor` fails,
+diagnose the transport first — is the embedding server running, is a proxy in
+the way — before touching the file. A minimal connection-level edit (say,
+`localhost` → `127.0.0.1`) is acceptable: back the file up first, and tell the
+user what changed and why. Never change `MEMU_DB`, `MEMU_EMBED_PROVIDER`, or
+`MEMU_EMBED_MODEL` on an existing store — those three bind the embedding
+space, and "fixing" them silently splits the user's memory (old vectors become
+unreachable until everything is re-embedded). If one of them looks wrong, stop
+and ask the user.
+
 ### ✅ Verify Part 1
 
 ```
@@ -101,8 +112,17 @@ then `memu-hermes commit`. Nothing in it is machine-specific.
 
 ### ✅ Verify Part 2
 
-Confirm the cron entry exists, then dry-run: `memu-hermes prepare` (zero prepared
-sessions is fine and correct when nothing is new).
+Confirm the cron entry exists. Then run the **first bridging cycle to
+completion, now** — you are the very agent the scheduled prompt addresses, so
+follow it yourself: run `memu-hermes prepare`, work through every job file under
+`~/.memu/hosts/hermes/jobs/` in ascending numeric order, then run `memu-hermes commit`. Zero prepared
+sessions is fine and correct (nothing to process; commit reports nothing).
+
+Do **not** stop after `prepare`: it advances the session cursor before anything
+reaches the store, and the next scheduled run's own `prepare` deletes
+unprocessed job files — a cycle left half-done here silently loses every
+session it covered. Finishing it closes that window, and the user leaves the
+install with their first memories already retrievable.
 
 ---
 

--- a/src/memu/hosts/openclaw/BRIDGING_TASK.md
+++ b/src/memu/hosts/openclaw/BRIDGING_TASK.md
@@ -54,34 +54,39 @@ Create an OpenClaw cron job (e.g. named `memu-bridging`) with the chosen
 schedule, and set its recurring prompt to this block **verbatim**:
 
 ```
-Run the memU bridging pipeline. Do the three steps strictly in order; do not
+Run the memU bridging pipeline. Do the four steps strictly in order; do not
 skip a step even if the previous one looks like it produced nothing.
 
-1. PREPARE. Run this exact command with the shell tool:
+1. LEFTOVERS. If ~/.memu/hosts/openclaw/jobs/ already contains job files, they are unfinished
+   work from an earlier run (a crash, or the install itself). Process them
+   exactly as step 3 describes, then run memu-openclaw commit — and only then
+   continue.
+
+2. PREPARE. Run this exact command with the shell tool:
 
      memu-openclaw prepare
 
    It regenerates ~/.memu/hosts/openclaw/jobs/. If the command exits non-zero,
    stop and report the error — do not continue.
 
-2. SELF-EVOLVE. List ~/.memu/hosts/openclaw/jobs/*.txt and process them in
+3. SELF-EVOLVE. List ~/.memu/hosts/openclaw/jobs/*.txt and process them in
    ascending numeric order (1.txt, then 2.txt, …). The count changes every run —
    always glob and sort; never assume a fixed number. If there are no job
-   files, skip to step 3.
+   files, skip to step 4.
 
    For each job file: read it and follow its instructions to the letter. Each
    job is self-contained and already carries the concrete paths it needs. Order
    matters — finish one job before starting the next. Emitting no files for a
    job is a valid outcome; do not invent content to fill a job.
 
-3. COMMIT. After every job is done, run this exact command with the shell tool:
+4. COMMIT. After every job is done, run this exact command with the shell tool:
 
      memu-openclaw commit
 
    It commits whatever the jobs created or changed. If it exits non-zero,
    report the error.
 
-Finish with a one-line summary: how many jobs ran and what was committed (or
+Finish with a one-line summary: how many jobs ran (leftovers included) and what was committed (or
 that there was nothing to commit).
 ```
 
@@ -96,6 +101,12 @@ OpenClaw sessions since the last run.
 
 ## Notes
 
+- **Leftovers run before prepare.** Job files already on disk when the run
+  starts are unfinished work — a run that died mid-pipeline, or the install's
+  own verify. `prepare` deletes unprocessed job files, and the cursor already
+  marks their sessions as seen, so anything skipped at that moment would never
+  be minable again; draining leftovers first turns a half-done cycle into
+  bounded re-work instead of silent loss.
 - **Idempotent and incremental.** `prepare` tracks a per-session line cursor in
   `~/.memu/hosts/openclaw/.session_manifest.openclaw.json`.
 - **Ordering is load-bearing.** Memory jobs before skill jobs, the

--- a/src/memu/hosts/openclaw/INSTALL.md
+++ b/src/memu/hosts/openclaw/INSTALL.md
@@ -112,17 +112,9 @@ order, then `memu-openclaw commit`. Nothing in it is machine-specific.
 
 ### ✅ Verify Part 2
 
-Confirm the cron job exists with the expected schedule. Then run the **first bridging cycle to
-completion, now** — you are the very agent the scheduled prompt addresses, so
-follow it yourself: run `memu-openclaw prepare`, work through every job file under
-`~/.memu/hosts/openclaw/jobs/` in ascending numeric order, then run `memu-openclaw commit`. Zero prepared
-sessions is fine and correct (nothing to process; commit reports nothing).
-
-Do **not** stop after `prepare`: it advances the session cursor before anything
-reaches the store, and the next scheduled run's own `prepare` deletes
-unprocessed job files — a cycle left half-done here silently loses every
-session it covered. Finishing it closes that window, and the user leaves the
-install with their first memories already retrievable.
+Confirm the cron job exists with the expected schedule, then dry-run:
+`memu-openclaw prepare` (zero prepared sessions is fine and correct when nothing
+is new).
 
 ---
 

--- a/src/memu/hosts/openclaw/INSTALL.md
+++ b/src/memu/hosts/openclaw/INSTALL.md
@@ -72,6 +72,17 @@ do not ask the user.
 Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
 never a shell-profile export — the scheduled task does not inherit your shell).
 
+**The existing config fails doctor? Repair the connection, never the
+identity.** If `~/.memu/config.env` predates this install and `doctor` fails,
+diagnose the transport first — is the embedding server running, is a proxy in
+the way — before touching the file. A minimal connection-level edit (say,
+`localhost` → `127.0.0.1`) is acceptable: back the file up first, and tell the
+user what changed and why. Never change `MEMU_DB`, `MEMU_EMBED_PROVIDER`, or
+`MEMU_EMBED_MODEL` on an existing store — those three bind the embedding
+space, and "fixing" them silently splits the user's memory (old vectors become
+unreachable until everything is re-embedded). If one of them looks wrong, stop
+and ask the user.
+
 ### ✅ Verify Part 1
 
 ```
@@ -101,9 +112,17 @@ order, then `memu-openclaw commit`. Nothing in it is machine-specific.
 
 ### ✅ Verify Part 2
 
-Confirm the cron job exists with the expected schedule, then dry-run:
-`memu-openclaw prepare` (zero prepared sessions is fine and correct when nothing
-is new).
+Confirm the cron job exists with the expected schedule. Then run the **first bridging cycle to
+completion, now** — you are the very agent the scheduled prompt addresses, so
+follow it yourself: run `memu-openclaw prepare`, work through every job file under
+`~/.memu/hosts/openclaw/jobs/` in ascending numeric order, then run `memu-openclaw commit`. Zero prepared
+sessions is fine and correct (nothing to process; commit reports nothing).
+
+Do **not** stop after `prepare`: it advances the session cursor before anything
+reaches the store, and the next scheduled run's own `prepare` deletes
+unprocessed job files — a cycle left half-done here silently loses every
+session it covered. Finishing it closes that window, and the user leaves the
+install with their first memories already retrievable.
 
 ---
 

--- a/src/memu/hosts/workbuddy/BRIDGING_TASK.md
+++ b/src/memu/hosts/workbuddy/BRIDGING_TASK.md
@@ -64,19 +64,24 @@ Register the automation with:
 The pipeline prompt:
 
 ```
-Run the memU bridging pipeline. Do the three steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.
+Run the memU bridging pipeline. Do the four steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.
 
-1. PREPARE. Run this exact command with bash:
+1. LEFTOVERS. If ~/.memu/hosts/workbuddy/jobs/ already contains job files, they are unfinished
+   work from an earlier run (a crash, or the install itself). Process them
+   exactly as step 3 describes, then run memu-workbuddy commit — and only then
+   continue.
+
+2. PREPARE. Run this exact command with bash:
    memu-workbuddy prepare
    — it regenerates ~/.memu/hosts/workbuddy/jobs/. If the command exits non-zero, stop and report the error.
 
-2. SELF-EVOLVE. List ~/.memu/hosts/workbuddy/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 3. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.
+3. SELF-EVOLVE. List ~/.memu/hosts/workbuddy/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 4. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.
 
-3. COMMIT. Run this exact command with bash:
+4. COMMIT. Run this exact command with bash:
    memu-workbuddy commit
    — it commits whatever the jobs created or changed. If it exits non-zero, report the error.
 
-Finish with a one-line summary: how many jobs ran and what was committed.
+Finish with a one-line summary: how many jobs ran (leftovers included) and what was committed.
 ```
 
 The prompt block is fixed; only the RRULE is the user's choice. Nothing in it
@@ -90,6 +95,12 @@ are new WorkBuddy sessions since the last run.
 
 ## Notes
 
+- **Leftovers run before prepare.** Job files already on disk when the run
+  starts are unfinished work — a run that died mid-pipeline, or the install's
+  own verify. `prepare` deletes unprocessed job files, and the cursor already
+  marks their sessions as seen, so anything skipped at that moment would never
+  be minable again; draining leftovers first turns a half-done cycle into
+  bounded re-work instead of silent loss.
 - **Idempotent and incremental.** `prepare` tracks a per-session line cursor in
   `~/.memu/hosts/workbuddy/.session_manifest.workbuddy.json`, so each run only
   processes turns it hasn't seen.


### PR DESCRIPTION
## The problem, in one timeline

```
Install day:   verify runs `prepare` → job files staged, cursor marks
               those sessions as "seen" → install ends, jobs sit on disk

First scheduled run:  its own `prepare` runs first →
               ├─ deletes the staged job files 🗑
               └─ cursor says "already seen" → those sessions are
                  never offered for mining again
```

Result: on any machine with pre-install history, the history silently becomes unmineable — no error, next run reports success. The same thing happens to a run that dies between `prepare` and `commit`: its staged jobs get wiped by the next run.

## The fix: drain leftovers first

The scheduled pipeline prompt (all 7 hosts' `BRIDGING_TASK.md`) gains one step at the top:

```
1. LEFTOVERS   jobs/ already has files? That's unfinished work from an
               earlier run (a crash, or the install itself).
               Process them, commit them — only then continue.
2. PREPARE     (the step that wipes jobs/ and advances the cursor —
                now guaranteed to only ever wipe an empty/drained board)
3. SELF-EVOLVE
4. COMMIT
```

- Most nights step 1 is a no-op (previous run finished; nothing there).
- Re-work is bounded: the jobs' own rule is "read what exists first; doing nothing is a valid outcome", so an already-mined job re-checks cheaply instead of duplicating.
- One step closes **both** loss windows: install-day and died-mid-run.

## Also in this PR: repair rules for an inherited config

If `~/.memu/config.env` already exists but `doctor` fails (6 `INSTALL.md`): connection-level fixes are fine (`localhost` → `127.0.0.1`, with a backup, telling the user). **Never** change `MEMU_DB`, the provider, or the embedding model — those three bind the embedding space, and "fixing" them silently cuts the user off from every memory already stored. If one looks wrong, stop and ask.

## History of this PR

The first version made the install run the whole first cycle instead. It closed the install-day window but moved minutes of LLM mining into the interactive install and contradicted the guides' own design ("You are not running the pipeline now"). Leftover-first keeps the install cheap, respects the design, and covers the crash case too — strictly better, so the install-side change was reverted.

(Root cause — the cursor advances at `prepare` rather than at `commit` — is tracked in #518 with field evidence.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
