### PR TITLE
feat(env): config.env carries NO_PROXY; MEMU_HTTP_PROXY works from the file

### DIFF
--- a/src/memu/embedding/http_client.py
+++ b/src/memu/embedding/http_client.py
@@ -53,7 +53,9 @@ def proxy_bypass_mounts(url: str) -> dict[str, httpx.AsyncBaseTransport | None] 
 
 
 def _load_proxy(base_url: str) -> str | None:
-    explicit = os.getenv("MEMU_HTTP_PROXY") or None
+    from memu.env import env as memu_env
+
+    explicit = memu_env("MEMU_HTTP_PROXY") or None
     if is_loopback_url(base_url):
         # Ambient proxies (HTTP_PROXY, HTTPS_PROXY) are aimed at the network at
         # large, never at the machine itself. An explicit MEMU_HTTP_PROXY is

--- a/src/memu/embedding/openai_sdk.py
+++ b/src/memu/embedding/openai_sdk.py
@@ -1,11 +1,11 @@
 import logging
-import os
 from typing import cast
 
 from openai import AsyncOpenAI, DefaultAsyncHttpxClient
 from openai.types import CreateEmbeddingResponse
 
 from memu.embedding.http_client import proxy_bypass_mounts
+from memu.env import env as memu_env
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ class OpenAIEmbeddingSDKClient:
         # explicit MEMU_HTTP_PROXY states intent about memU's own traffic, so
         # it is wired into the transport for real — the same semantics as
         # HTTPEmbeddingClient — and beats both the bypass and ambient proxies.
-        explicit_proxy = os.getenv("MEMU_HTTP_PROXY") or None
+        explicit_proxy = memu_env("MEMU_HTTP_PROXY") or None
         http_client: DefaultAsyncHttpxClient | None
         if explicit_proxy:
             http_client = DefaultAsyncHttpxClient(proxy=explicit_proxy)

--- a/src/memu/env.py
+++ b/src/memu/env.py
@@ -44,9 +44,25 @@ class ConfigError(RuntimeError):
         )
 
 
+_ENV_PASSTHROUGH = ("NO_PROXY", "no_proxy")
+"""Non-``MEMU_*`` keys that ``config.env`` carries into the process environment.
+
+The guides call the file "the carrier" — a scheduled task has no interactive
+shell to inherit from — and a proxy exemption is exactly the kind of
+machine-local fact that must reach the HTTP stack, which reads ``NO_PROXY``
+from the environment and knows nothing of memU's config. Narrow allowlist on
+purpose; ``setdefault`` only, so a value already in the environment wins."""
+
+
 @cache
 def _file_values() -> dict[str, str]:
-    """Parse the dotenv. Cached: entrypoint processes are short-lived."""
+    """Parse the dotenv. Cached: entrypoint processes are short-lived.
+
+    Side effect, once per process: keys in :data:`_ENV_PASSTHROUGH` found in
+    the file are exported to ``os.environ`` (without overriding existing
+    values), so ``NO_PROXY`` written next to the ``MEMU_*`` settings actually
+    reaches httpx.
+    """
     path = Path(os.path.expanduser(os.environ.get("MEMU_CONFIG_ENV", CONFIG_ENV)))
     if not path.is_file():
         return {}
@@ -59,6 +75,9 @@ def _file_values() -> dict[str, str]:
         key, sep, value = line.partition("=")
         if sep:
             values[key.strip()] = value.strip().strip("\"'")
+    for key in _ENV_PASSTHROUGH:
+        if key in values:
+            os.environ.setdefault(key, values[key])
     return values
 
 

--- a/tests/test_embedding_proxy.py
+++ b/tests/test_embedding_proxy.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import os
 import pathlib
+from collections.abc import Iterator
 
 import httpx
 import pytest
@@ -29,7 +30,7 @@ PROXY = "http://proxy.corp:8080"
 
 
 @pytest.fixture(autouse=True)
-def _clean_proxy_env(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+def _clean_proxy_env(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> Iterator[None]:
     """The developer's own shell may carry proxy settings (corporate machines
     usually do), and their real ``config.env`` may carry passthrough keys;
     these tests must depend on neither."""

--- a/tests/test_embedding_proxy.py
+++ b/tests/test_embedding_proxy.py
@@ -16,10 +16,12 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import pathlib
 
 import httpx
 import pytest
 
+from memu import env as menv
 from memu.embedding.http_client import HTTPEmbeddingClient, _load_proxy, is_loopback_url, proxy_bypass_mounts
 from memu.embedding.openai_sdk import OpenAIEmbeddingSDKClient
 
@@ -27,12 +29,17 @@ PROXY = "http://proxy.corp:8080"
 
 
 @pytest.fixture(autouse=True)
-def _clean_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def _clean_proxy_env(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
     """The developer's own shell may carry proxy settings (corporate machines
-    usually do); these tests must not depend on them."""
+    usually do), and their real ``config.env`` may carry passthrough keys;
+    these tests must depend on neither."""
     for key in list(os.environ):
         if key.lower().endswith("_proxy") or key.lower() == "no_proxy":
             monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("MEMU_CONFIG_ENV", str(tmp_path / "empty.env"))
+    menv.reload()
+    yield
+    menv.reload()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_env_passthrough.py
+++ b/tests/test_env_passthrough.py
@@ -1,0 +1,71 @@
+"""``config.env`` is "the carrier" — for ``NO_PROXY`` too.
+
+Field origin: a live OpenClaw install wrote ``NO_PROXY`` into ``config.env``,
+found it inert (memU only consumed ``MEMU_*`` keys), and had to bake the
+variable into the scheduled prompt's shell commands — which the guides forbid
+(nothing machine-specific in the prompt). These pin the fix: passthrough keys
+in the file reach ``os.environ`` (without overriding it), and the
+``MEMU_HTTP_PROXY`` escape hatch works from the file, not only from the shell.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+
+import pytest
+
+from memu import env as menv
+from memu.embedding.http_client import _load_proxy
+
+PROXY = "http://proxy.corp:8080"
+
+
+@pytest.fixture()
+def config_file(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> pathlib.Path:
+    for key in list(os.environ):
+        if key.lower().endswith("_proxy") or key.lower() == "no_proxy":
+            monkeypatch.delenv(key, raising=False)
+    cfg = tmp_path / "config.env"
+    monkeypatch.setenv("MEMU_CONFIG_ENV", str(cfg))
+    menv.reload()
+    yield cfg
+    # The passthrough writes os.environ outside monkeypatch's bookkeeping —
+    # undo by hand so nothing leaks into other test modules.
+    for key in menv._ENV_PASSTHROUGH:
+        os.environ.pop(key, None)
+    menv.reload()
+
+
+def test_no_proxy_in_config_reaches_the_environment(config_file: pathlib.Path) -> None:
+    config_file.write_text("MEMU_DB=/data/x.sqlite3\nNO_PROXY=localhost,127.0.0.1\n")
+    menv.reload()
+
+    assert menv.env("MEMU_DB") == "/data/x.sqlite3"  # touching the file loads it
+    assert os.environ["NO_PROXY"] == "localhost,127.0.0.1"
+
+
+def test_environment_wins_over_the_file(config_file: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_PROXY", "already-set")
+    config_file.write_text("NO_PROXY=from-file\n")
+    menv.reload()
+
+    menv.env("MEMU_DB")
+    assert os.environ["NO_PROXY"] == "already-set"
+
+
+def test_no_passthrough_keys_no_side_effect(config_file: pathlib.Path) -> None:
+    config_file.write_text("MEMU_DB=/data/x.sqlite3\n")
+    menv.reload()
+
+    menv.env("MEMU_DB")
+    assert "NO_PROXY" not in os.environ
+
+
+def test_memu_http_proxy_works_from_the_file(config_file: pathlib.Path) -> None:
+    """The escape hatch (#519) must not require a shell export — the scheduled
+    task has no shell, the file is all it has."""
+    config_file.write_text(f"MEMU_HTTP_PROXY={PROXY}\n")
+    menv.reload()
+
+    assert _load_proxy("http://localhost:11434/v1") == PROXY

--- a/tests/test_env_passthrough.py
+++ b/tests/test_env_passthrough.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+from collections.abc import Iterator
 
 import pytest
 
@@ -22,7 +23,7 @@ PROXY = "http://proxy.corp:8080"
 
 
 @pytest.fixture()
-def config_file(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> pathlib.Path:
+def config_file(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> Iterator[pathlib.Path]:
     for key in list(os.environ):
         if key.lower().endswith("_proxy") or key.lower() == "no_proxy":
             monkeypatch.delenv(key, raising=False)


### PR DESCRIPTION
## What

One sentence: **`NO_PROXY` written in `config.env` now actually works — before, it was silently ignored.**

Before:

```
# ~/.memu/config.env
MEMU_DB=...            ← read
MEMU_EMBED_PROVIDER=...← read
NO_PROXY=localhost     ← ignored (only MEMU_* keys were consumed)
```

After: `NO_PROXY` (and `no_proxy`) found in the file are exported into the process environment, where httpx — the thing that actually needs them — can see them. `setdefault` only: a value already in the environment always wins over the file.

Bonus: the `MEMU_HTTP_PROXY` escape hatch from #519 now also resolves through the file (both embedding clients read it via `memu.env.env()` instead of `os.getenv`), so it no longer requires a shell export.

## Why

The docs promise that `config.env` is **"the carrier"** — the scheduled bridging task runs with no interactive shell, so the file is the only way to hand it configuration. A live OpenClaw install took that promise at face value:

1. Agent hits the proxy 502 → needs `NO_PROXY`
2. Writes it into `config.env`, as the carrier principle suggests → **inert**
3. Falls back to hard-coding the variable into the scheduled prompt's shell commands → violates the *other* rule ("nothing machine-specific in the prompt")

The agent was trapped between two rules. This PR makes rule 1 true so the conflict disappears. It matters most for local servers behind **non-loopback** addresses (`host.docker.internal`, LAN IPs) — the one case #519's automatic bypass deliberately does not cover.

## Deliberately small

This is a **two-key allowlist**, not "export everything in the file". A config file should not be able to inject `PATH` or arbitrary variables into memU processes. New keys can be added one at a time if ever needed.

## Files

| File | Change |
|---|---|
| `env.py` | the passthrough (allowlist + `setdefault`), documented as an explicit side effect |
| `http_client.py` / `openai_sdk.py` | `MEMU_HTTP_PROXY` read via `env()` — one line each |
| `test_env_passthrough.py` (new) | 4 tests: file→env works; env wins; no keys → no side effect; escape hatch works from file |
| `test_embedding_proxy.py` | isolation hardening: with passthrough in play, the developer's real `config.env` could leak `NO_PROXY` under the tests — the autouse fixture now points `MEMU_CONFIG_ENV` at an empty temp file |

33/33 across the touched suites; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
