### PR TITLE
docs(hosts): the scheduler's PATH is not your shell's — fix and honest verify for the bridging guides

### DIFF
--- a/src/memu/hosts/claude_code/BRIDGING_TASK.md
+++ b/src/memu/hosts/claude_code/BRIDGING_TASK.md
@@ -53,6 +53,19 @@ hour**, cron `0 * * * *` (local time). Confirm before creating.
 
 ## Step 2 — register the scheduled run
 
+**The crontab's first line is a `PATH`.** cron runs with a bare
+`/usr/bin:/bin`; the binaries this entry needs (pipx and npm installs land in
+`~/.local/bin` and `/opt/homebrew/bin`) are not there, and the entry dies on
+`command not found` before the pipeline starts. Derive it at registration time
+and write it **above** the entry:
+
+```
+PATH=$(dirname "$(command -v memu-claude-code)"):$(dirname "$(command -v claude)"):/usr/local/bin:/usr/bin:/bin
+```
+
+The machine-specific fact lives in the crontab, where machine facts belong —
+the pipeline prompt itself stays verbatim.
+
 Create a system cron entry — the default, macOS included (use launchd only if
 the user explicitly asks for it) — that runs Claude Code headless with the
 pipeline prompt:
@@ -65,6 +78,19 @@ The prompt block is fixed; only the cron expression is the user's choice. Nothin
 in it is machine-specific — the pipeline is invoked through `PATH` commands.
 
 ## Step 3 — confirm
+
+**Your shell's `PATH` proves nothing about the scheduler's.** Two checks that
+count:
+
+- `env -i PATH=/usr/bin:/bin /bin/sh -c 'command -v memu-claude-code'` — this
+  *failing* is exactly why the entry needs its `PATH` line; with that line in
+  place the command must resolve from the directories it names.
+- The hard check: trigger one run through cron itself (temporarily set the
+  schedule a minute ahead, or run the entry's command line by hand with
+  `env -i PATH=... /bin/sh -c`), then verify **filesystem traces** — the session
+  cursor and `jobs/` timestamps moved — rather than trusting the run's own
+  summary. Field data, twice over: scheduled runs in bare environments have
+  reported "completed successfully" on a command-not-found.
 
 Report back: where the schedule was registered (crontab/launchd), and the cron in
 words (e.g. "hourly at :00 local time"). Mention that the first run only has

--- a/src/memu/hosts/cursor/BRIDGING_TASK.md
+++ b/src/memu/hosts/cursor/BRIDGING_TASK.md
@@ -50,6 +50,19 @@ hour**, cron `0 * * * *` (local time). Confirm before creating.
 
 ## Step 2 — register the scheduled run
 
+**The crontab's first line is a `PATH`.** cron runs with a bare
+`/usr/bin:/bin`; the binaries this entry needs (pipx and npm installs land in
+`~/.local/bin` and `/opt/homebrew/bin`) are not there, and the entry dies on
+`command not found` before the pipeline starts. Derive it at registration time
+and write it **above** the entry:
+
+```
+PATH=$(dirname "$(command -v memu-cursor)"):$(dirname "$(command -v cursor-agent)"):/usr/local/bin:/usr/bin:/bin
+```
+
+The machine-specific fact lives in the crontab, where machine facts belong —
+the pipeline prompt itself stays verbatim.
+
 Create a system cron entry — the default, macOS included (use launchd only if
 the user explicitly asks for it) — running:
 
@@ -61,6 +74,19 @@ The prompt block is fixed; only the cron expression is the user's choice. Nothin
 in it is machine-specific — the pipeline is invoked through `PATH` commands.
 
 ## Step 3 — confirm
+
+**Your shell's `PATH` proves nothing about the scheduler's.** Two checks that
+count:
+
+- `env -i PATH=/usr/bin:/bin /bin/sh -c 'command -v memu-cursor'` — this
+  *failing* is exactly why the entry needs its `PATH` line; with that line in
+  place the command must resolve from the directories it names.
+- The hard check: trigger one run through cron itself (temporarily set the
+  schedule a minute ahead, or run the entry's command line by hand with
+  `env -i PATH=... /bin/sh -c`), then verify **filesystem traces** — the session
+  cursor and `jobs/` timestamps moved — rather than trusting the run's own
+  summary. Field data, twice over: scheduled runs in bare environments have
+  reported "completed successfully" on a command-not-found.
 
 Report back: where the schedule was registered, and the cron in words. Mention
 that the first run only has work to do once there are new Cursor agent sessions

--- a/src/memu/hosts/generic/BRIDGING_TASK.md
+++ b/src/memu/hosts/generic/BRIDGING_TASK.md
@@ -51,6 +51,19 @@ creating.
 
 ## Step 2 — register the scheduled run
 
+**The crontab's first line is a `PATH`.** cron runs with a bare
+`/usr/bin:/bin`; the binaries this entry needs (pipx and npm installs land in
+`~/.local/bin` and `/opt/homebrew/bin`) are not there, and the entry dies on
+`command not found` before the pipeline starts. Derive it at registration time
+and write it **above** the entry:
+
+```
+PATH=$(dirname "$(command -v memu-agent)"):/usr/local/bin:/usr/bin:/bin
+```
+
+The machine-specific fact lives in the crontab, where machine facts belong —
+the pipeline prompt itself stays verbatim.
+
 Default to a system cron entry invoking the agent headless; use the agent's
 own scheduler instead only if the user prefers it. The recurring prompt, with `<SESSION_DIR>` filled
 in, **verbatim**:
@@ -89,6 +102,19 @@ that there was nothing to commit).
 ```
 
 ## Step 3 — confirm
+
+**Your shell's `PATH` proves nothing about the scheduler's.** Two checks that
+count:
+
+- `env -i PATH=/usr/bin:/bin /bin/sh -c 'command -v memu-agent'` — this
+  *failing* is exactly why the entry needs its `PATH` line; with that line in
+  place the command must resolve from the directories it names.
+- The hard check: trigger one run through cron itself (temporarily set the
+  schedule a minute ahead, or run the entry's command line by hand with
+  `env -i PATH=... /bin/sh -c`), then verify **filesystem traces** — the session
+  cursor and `jobs/` timestamps moved — rather than trusting the run's own
+  summary. Field data, twice over: scheduled runs in bare environments have
+  reported "completed successfully" on a command-not-found.
 
 Report back: where the schedule was registered, and the cron in words. Mention
 that the first run only has work to do once there are new sessions since the

--- a/src/memu/hosts/hermes/BRIDGING_TASK.md
+++ b/src/memu/hosts/hermes/BRIDGING_TASK.md
@@ -51,6 +51,19 @@ hour**, cron `0 * * * *` (local time). Confirm before creating.
 
 ## Step 2 — register the scheduled run
 
+**The crontab's first line is a `PATH`.** cron runs with a bare
+`/usr/bin:/bin`; the binaries this entry needs (pipx and npm installs land in
+`~/.local/bin` and `/opt/homebrew/bin`) are not there, and the entry dies on
+`command not found` before the pipeline starts. Derive it at registration time
+and write it **above** the entry:
+
+```
+PATH=$(dirname "$(command -v memu-hermes)"):$(dirname "$(command -v hermes)"):/usr/local/bin:/usr/bin:/bin
+```
+
+The machine-specific fact lives in the crontab, where machine facts belong —
+the pipeline prompt itself stays verbatim.
+
 Create a system cron entry that runs Hermes headless with the pipeline prompt:
 
 ```
@@ -62,6 +75,19 @@ prompt block verbatim.) Nothing in it is machine-specific — the pipeline is
 invoked through `PATH` commands.
 
 ## Step 3 — confirm
+
+**Your shell's `PATH` proves nothing about the scheduler's.** Two checks that
+count:
+
+- `env -i PATH=/usr/bin:/bin /bin/sh -c 'command -v memu-hermes'` — this
+  *failing* is exactly why the entry needs its `PATH` line; with that line in
+  place the command must resolve from the directories it names.
+- The hard check: trigger one run through cron itself (temporarily set the
+  schedule a minute ahead, or run the entry's command line by hand with
+  `env -i PATH=... /bin/sh -c`), then verify **filesystem traces** — the session
+  cursor and `jobs/` timestamps moved — rather than trusting the run's own
+  summary. Field data, twice over: scheduled runs in bare environments have
+  reported "completed successfully" on a command-not-found.
 
 Report back: where the schedule was registered, and the cron in words. Mention
 that the first run only has work to do once there are new Hermes sessions since

--- a/src/memu/hosts/openclaw/BRIDGING_TASK.md
+++ b/src/memu/hosts/openclaw/BRIDGING_TASK.md
@@ -53,6 +53,14 @@ hour**, cron `0 * * * *` (local time). Confirm before creating.
 Create an OpenClaw cron job (e.g. named `memu-bridging`) with the chosen
 schedule, and set its recurring prompt to this block **verbatim**:
 
+**The scheduled turn runs in the gateway's environment, not your shell.** The
+gateway is a system service (launchd/systemd) with a bare `PATH` —
+`memu-openclaw` (pipx installs land in `~/.local/bin`) may not resolve there
+even though it resolves for you. Make it resolvable to the *gateway* before
+trusting the schedule: add a `PATH` entry under `env` in `openclaw.json`
+(include the directory `command -v memu-openclaw` prints), then restart the
+gateway.
+
 ```
 Run the memU bridging pipeline. Do the three steps strictly in order; do not
 skip a step even if the previous one looks like it produced nothing.
@@ -89,6 +97,18 @@ The prompt block is fixed; only the schedule is the user's choice. Nothing in it
 is machine-specific — the pipeline is invoked through `PATH` commands.
 
 ## Step 3 — confirm
+
+**Your shell's `PATH` proves nothing about the scheduler's.** Two checks that
+count:
+
+- `env -i PATH=/usr/bin:/bin /bin/sh -c 'command -v memu-openclaw'` — this
+  *failing* is exactly why the entry needs its `PATH` line; with that line in
+  place the command must resolve from the directories it names.
+- The hard check: trigger one run now with `openclaw cron run <job>`, then
+  verify **filesystem traces** — the session
+  cursor and `jobs/` timestamps moved — rather than trusting the run's own
+  summary. Field data, twice over: scheduled runs in bare environments have
+  reported "completed successfully" on a command-not-found.
 
 Report back: the cron job's name and the schedule in words (e.g. "hourly at :00
 local time"). Mention that the first run only has work to do once there are new


### PR DESCRIPTION
## The bug, in one picture

```
Your shell:      PATH = ~/.local/bin : /opt/homebrew/bin : /usr/bin : /bin ...
                        └── memu-<host> lives here ✅ install verifies green

Cron at night:   PATH = /usr/bin : /bin
                        └── memu-<host>? command not found ❌ pipeline dead
```

The install guides told the agent to verify the binary resolves — but the agent naturally checks **in its own shell**, the one environment where the check cannot fail. Then the scheduled run executes in cron's bare environment and dies before the pipeline starts.

This happened twice in one day, on two different hosts:

1. **OpenClaw**: the gateway-scheduled run hit command-not-found — and its fallback model summarized it as *"completed successfully, no errors encountered"*. Nothing on disk had changed.
2. **Hermes**: verified happily in its own shell, wrote a crontab that could not work at midnight.

## The fix (docs only, 5 guides)

**For the four cron-based guides** (claude-code, cursor, hermes, generic), two additions:

1. **The crontab now starts with a PATH line**, generated at install time:
   ```
   PATH=$(dirname "$(command -v memu-<host>)"):...:/usr/bin:/bin
   ```
   The machine-specific part goes in the crontab (which is per-machine anyway). The pipeline prompt stays verbatim — the existing "nothing machine-specific in the prompt" rule is untouched.

2. **A verify step that can actually fail.** Check resolution under cron's environment, not yours:
   ```
   env -i PATH=/usr/bin:/bin /bin/sh -c 'command -v memu-<host>'
   ```
   And the hard check: trigger one run through the scheduler itself, then look at **file timestamps** (session cursor, `jobs/`) instead of the run's own summary — because we have field proof that summaries can say "success" over a command-not-found.

**For OpenClaw** (scheduled turns run inside the gateway daemon, not user cron): make the binary resolvable to the *gateway* — `env.PATH` in `openclaw.json`, restart — and verify with `openclaw cron run <job>` + timestamps.

**Codex untouched**: its scheduled tasks run in Codex's own managed environment, no machine crontab involved.

## Why all four cron guides, not just the two that failed

The failure mechanism has no host-specific step in it: pipx puts binaries in `~/.local/bin` → cron doesn't look there → self-verification in one's own shell can't catch it. Two hosts proved the mechanism; the same registration recipe is copy-pasted in all four guides, so all four get the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
