### PR TITLE
fix(bridging): advance the cursor and snapshot at commit, not prepare

### DIFF
--- a/src/memu/hosts/bridging/layout.py
+++ b/src/memu/hosts/bridging/layout.py
@@ -48,14 +48,27 @@ class Layout:
 
     @property
     def session_manifest(self) -> Path:
-        """Per-session line cursor. Scoped by host: two hosts' session keys are
+        """Per-session line cursor — the *promoted* one, advanced only by a
+        successful ``commit``. Scoped by host: two hosts' session keys are
         unrelated, and sharing one cursor file would let each hide the other's
         new turns."""
         return self.base / f".session_manifest.{self.host}.json"
 
     @property
+    def session_manifest_pending(self) -> Path:
+        """The cursor as ``prepare`` staged it, promoted by ``commit``.
+
+        Two files because the two moments differ: prepare knows what it *saw*,
+        only commit knows what survived into the store. Promoting on commit is
+        what makes a bare ``prepare`` harmless and a run that dies mid-pipeline
+        recoverable instead of silently lossy (#518)."""
+        return self.session_manifest.with_name(self.session_manifest.name + ".pending")
+
+    @property
     def memory_manifest(self) -> Path:
-        """Content hashes of the mirrored recall files, as of prepare."""
+        """Content hashes of the tracked files as of the last successful
+        ``commit`` (bootstrapped by the first ``prepare`` from the
+        store-derived mirror)."""
         return self.base / ".memory_manifest.json"
 
     @property

--- a/src/memu/hosts/bridging/manifest.py
+++ b/src/memu/hosts/bridging/manifest.py
@@ -1,9 +1,13 @@
 """Snapshot the mirrored recall files by content hash, diff them later.
 
-Prepare records a sha256 of every mirrored file; commit re-hashes and diffs
-against that snapshot to learn which files the agent actually created or
-modified. Hashing content (not mtime, and not the agent's own account of what it
-did) means a rewrite with identical bytes is correctly seen as unchanged.
+The snapshot means "state as of the last successful commit": the first
+``prepare`` bootstraps it from the store-derived mirror (committed content by
+construction), and thereafter only a successful ``commit`` re-takes it — so
+files a crashed run wrote but never committed keep diffing until they land
+(#518). ``commit`` re-hashes and diffs against the snapshot to learn which
+files the agent actually created or modified; hashing content (not mtime, and
+not the agent's own account of what it did) means a rewrite with identical
+bytes is correctly seen as unchanged.
 """
 
 from __future__ import annotations

--- a/src/memu/hosts/bridging/pipeline.py
+++ b/src/memu/hosts/bridging/pipeline.py
@@ -11,6 +11,7 @@ Nothing here knows what a Codex is. The host arrives as a
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from memu.env import build_service_from_env
@@ -42,10 +43,15 @@ async def prepare(
         out_dir=layout.sessions,
         manifest_path=layout.session_manifest,
         max_jobs=max_jobs,
+        pending_path=layout.session_manifest_pending,
     )
 
-    # Mirror the store's current recall files to disk, then snapshot them by
-    # content hash so commit can tell which ones the agent went on to touch.
+    # Mirror the store's current recall files to disk. The snapshot is only
+    # *bootstrapped* here (first contact, from store-derived — i.e. committed —
+    # content); afterwards it is re-taken by a successful commit and means
+    # "state as of the last commit". Re-snapshotting on every prepare would
+    # absorb files a crashed run wrote but never committed, making them
+    # undiffable — and therefore uncommittable — forever.
     service = build_service_from_env()
     result = await service.list_all_recall_files()
     for recall_file in result["categories"]:
@@ -53,7 +59,8 @@ async def prepare(
         if subdir is None:
             continue
         write_recall_file(layout.base, subdir, recall_file)
-    snapshot_tracked(layout.base, layout.track_dirs, layout.memory_manifest)
+    if not layout.memory_manifest.exists():
+        snapshot_tracked(layout.base, layout.track_dirs, layout.memory_manifest)
 
     # The touched-file log is per-run. Left in place it accumulates across runs,
     # and since the verify pass caps at the first N paths, stale entries would
@@ -78,7 +85,15 @@ async def prepare(
 
 
 async def commit(layout: Layout) -> dict[str, Any]:
-    """Submit whatever the agent created or changed back into memU."""
+    """Submit whatever the agent created or changed, then make the run durable.
+
+    State advances on durable success, not on intent (#518): the session
+    cursor staged by ``prepare`` is promoted here, and the memory snapshot is
+    re-taken here — both strictly after the store accepted the submission. A
+    run that dies anywhere earlier leaves the previous cursor and snapshot in
+    force, so everything unfinished is re-offered next time: bounded re-work,
+    never silent loss.
+    """
     subdir_track = {subdir: track for track, subdir in TRACK_DIRS.items()}
 
     changed = diff_tracked(layout.base, layout.track_dirs, layout.memory_manifest)
@@ -87,4 +102,9 @@ async def commit(layout: Layout) -> dict[str, Any]:
 
     service = build_service_from_env()
     result: dict[str, Any] = await service.commit_results(recall_files=recall_files, resource=resources)
+
+    snapshot_tracked(layout.base, layout.track_dirs, layout.memory_manifest)
+    pending = layout.session_manifest_pending
+    if pending.exists():
+        os.replace(pending, layout.session_manifest)
     return result

--- a/src/memu/hosts/bridging/transcripts.py
+++ b/src/memu/hosts/bridging/transcripts.py
@@ -38,14 +38,21 @@ def prepare_transcripts(
     out_dir: Path,
     manifest_path: Path,
     max_jobs: int,
+    pending_path: Path,
 ) -> int:
-    """Extract new session turns into numbered transcripts and advance the cursor.
+    """Extract new session turns into numbered transcripts and *stage* the cursor.
 
     Scans the host's sessions newest-first, comparing each file's line count
-    against the cursor. The first already-seen file with no new lines ends the
-    scan — older files cannot hold newer content. The latest ``max_jobs`` files
-    with new lines are written oldest-first as ``<idx>.jsonl`` (conversation) and
-    ``<idx>_full.jsonl`` (conversation plus tool calls), with ``idx`` from 1.
+    against the promoted cursor at ``manifest_path``. The first already-seen
+    file with no new lines ends the scan — older files cannot hold newer
+    content. The latest ``max_jobs`` files with new lines are written
+    oldest-first as ``<idx>.jsonl`` (conversation) and ``<idx>_full.jsonl``
+    (conversation plus tool calls), with ``idx`` from 1.
+
+    The promoted cursor is read here but never written: the advanced cursor
+    goes to ``pending_path``, and only a successful ``commit`` promotes it. So
+    a bare ``prepare`` — or a run that dies before commit — leaves the durable
+    cursor untouched, and every unmined turn stays selectable next time.
 
     Returns the number of sessions written. Zero is the correct, common outcome
     on a quiet day.
@@ -81,7 +88,7 @@ def prepare_transcripts(
 
         manifest[key] = {"lines": len(records), "last_timestamp": _last_timestamp(source, records)}
 
-    manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    pending_path.parent.mkdir(parents=True, exist_ok=True)
+    pending_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
 
     return len(selected)

--- a/tests/test_bridging_promotion.py
+++ b/tests/test_bridging_promotion.py
@@ -1,0 +1,125 @@
+"""State advances on durable success, not on intent (#518).
+
+The session cursor is staged by ``prepare`` and promoted only by a successful
+``commit``; the memory snapshot is bootstrapped once and re-taken only by a
+successful ``commit``. These pin the four behaviors that make the pipeline
+at-least-once instead of at-most-once: a bare prepare is harmless, a repeated
+prepare re-offers the same sessions, a completed cycle advances exactly once,
+and files written by a run that died before commit stay committable.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from typing import Any
+
+import pytest
+
+from memu.hosts.base import RecordKind, TranscriptSource
+from memu.hosts.bridging import Layout, commit, prepare
+
+
+class FakeSource(TranscriptSource):
+    name = "fake"
+
+    def __init__(self, root: pathlib.Path) -> None:
+        self._root = root
+
+    def root(self) -> pathlib.Path:
+        return self._root
+
+    def classify(self, record: str) -> RecordKind:
+        return RecordKind.MESSAGE
+
+
+class FakeService:
+    """Stands in for the store: records commits, serves an empty mirror."""
+
+    def __init__(self) -> None:
+        self.committed: list[dict[str, Any]] = []
+
+    async def list_all_recall_files(self) -> dict[str, Any]:
+        return {"categories": []}
+
+    async def commit_results(self, recall_files: Any, resource: Any) -> dict[str, Any]:
+        self.committed.append({"recall_files": recall_files, "resource": resource})
+        return {"recall_files": recall_files, "resources": resource}
+
+
+@pytest.fixture()
+def rig(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> tuple[FakeSource, Layout, FakeService]:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "s1.jsonl").write_text('{"role":"user","content":"hi"}\n{"role":"assistant","content":"yo"}\n')
+
+    layout = Layout.default(host="fake", base=tmp_path / "memu")
+    service = FakeService()
+    import memu.hosts.bridging.pipeline as pipeline
+
+    monkeypatch.setattr(pipeline, "build_service_from_env", lambda: service)
+    return FakeSource(logs), layout, service
+
+
+async def test_bare_prepare_leaves_the_promoted_cursor_untouched(rig) -> None:
+    source, layout, _ = rig
+
+    n = await prepare(source, layout, verify_command="x verify-resources")
+
+    assert n == 1
+    assert not layout.session_manifest.exists(), "prepare must not advance the durable cursor"
+    assert layout.session_manifest_pending.exists(), "the advanced cursor is staged, not promoted"
+
+
+async def test_repeated_prepare_reoffers_the_same_sessions(rig) -> None:
+    source, layout, _ = rig
+
+    first = await prepare(source, layout, verify_command="x verify-resources")
+    second = await prepare(source, layout, verify_command="x verify-resources")
+
+    assert (first, second) == (1, 1), "an uncommitted batch must stay selectable"
+
+
+async def test_commit_promotes_the_cursor_exactly_once(rig) -> None:
+    source, layout, _ = rig
+
+    await prepare(source, layout, verify_command="x verify-resources")
+    await commit(layout)
+
+    assert layout.session_manifest.exists()
+    assert not layout.session_manifest_pending.exists()
+    assert json.loads(layout.session_manifest.read_text())["s1.jsonl"]["lines"] == 2
+
+    assert await prepare(source, layout, verify_command="x verify-resources") == 0, "after promotion the batch is spent"
+
+
+async def test_files_from_a_died_run_stay_committable(rig) -> None:
+    """The crash scenario: run 1 prepares and writes a memory file but never
+    commits; run 2's prepare must not absorb that file into the baseline, and
+    run 2's commit must submit it."""
+    source, layout, service = rig
+
+    await prepare(source, layout, verify_command="x verify-resources")
+    layout.memory.mkdir(parents=True, exist_ok=True)
+    (layout.memory / "orphan.md").write_text("---\nname: orphan\n---\nmined but never committed\n")
+    # run 1 dies here — no commit
+
+    await prepare(source, layout, verify_command="x verify-resources")  # run 2
+    await commit(layout)
+
+    submitted = [f["name"] for f in service.committed[0]["recall_files"]]
+    assert "orphan" in submitted
+
+
+async def test_snapshot_is_retaken_at_commit_so_reruns_are_clean(rig) -> None:
+    source, layout, service = rig
+
+    await prepare(source, layout, verify_command="x verify-resources")
+    layout.memory.mkdir(parents=True, exist_ok=True)
+    (layout.memory / "note.md").write_text("---\nname: note\n---\nv1\n")
+    await commit(layout)
+
+    await commit(layout)  # nothing changed since the last commit
+
+    assert [f["name"] for f in service.committed[0]["recall_files"]] == ["note"]
+    assert service.committed[1]["recall_files"] == [], "the post-commit snapshot must absorb committed work"


### PR DESCRIPTION
Implements the direction proposed in #518, with field evidence attached there. Closes #518 if the direction is accepted — happy to rework toward one of the other candidates instead.

## The invariant this PR installs

> **State advances only on durable success.**

Before: `prepare` wrote the advanced session cursor and re-took the memory snapshot — i.e. the pipeline marked work as done at the moment it was *staged*, while the store only saw results at `commit`. Everything between those two moments burned the batch silently: the next `prepare` deleted the staged jobs, and the cursor already said "seen".

Four ways to land in that gap, all observed on live installs (see #518):

1. a fresh install's verify `prepare` (guaranteed, on every machine with history)
2. a scheduled run dying between `prepare` and `commit` (sleep, quota, crash)
3. a fallback model "processing" every job as do-nothing
4. anyone running a bare `prepare`

## How

- **Cursor**: `prepare` writes the advanced cursor to `.session_manifest.<host>.json.pending` and never touches the promoted file. A successful `commit` promotes it (atomic `os.replace`). Until then, the same sessions stay selectable — bounded re-work, never loss.
- **Snapshot**: now means "state as of the last successful commit". The first `prepare` bootstraps it from the store-derived mirror (committed content by construction); afterwards only `commit` re-takes it. Files written by a run that died before commit keep diffing until they land, instead of being absorbed into the next `prepare`'s baseline (the second flaw documented in #518).

## What doesn't change

- `max_jobs`-capped sessions were never cursor-advanced and still are not.
- Existing installs read unchanged: the promoted manifest keeps its name and format; `.pending` is new transient state.
- All hosts inherit the fix through the shared pipeline — nothing per-adapter.
- The guides' leftover-first step (#525) becomes defense-in-depth rather than the only line of defense.

## Tests

`tests/test_bridging_promotion.py` — five semantics pins: bare `prepare` leaves the durable cursor untouched; repeated `prepare` re-offers the same batch; `commit` promotes exactly once (and the batch is then spent); **files from a died run stay committable** (the crash scenario end-to-end); the post-commit snapshot absorbs committed work so re-runs are clean. Full suite: 114 passing; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)