### PR TITLE
fix(openclaw): scan only main session transcripts, not trajectory/checkpoint sidecars

### DIFF
--- a/src/memu/hosts/openclaw/sessions.py
+++ b/src/memu/hosts/openclaw/sessions.py
@@ -7,7 +7,9 @@ One transcript per session, named by session id (Telegram topic sessions add a
 ``-topic-<threadId>`` suffix), grouped per agent under the OpenClaw state dir
 (``~/.openclaw`` by default; the host honors ``OPENCLAW_STATE_DIR``, in which
 case pass ``--session-dir``). The mutable ``sessions.json`` index sitting next to
-the transcripts is not JSONL and is naturally skipped by discovery. Newer
+the transcripts is not JSONL and is naturally skipped by discovery; the
+``*.trajectory.jsonl`` and ``*.checkpoint.*.jsonl`` sidecars *are* JSONL and are
+skipped by name — trace events and replayed turns, not new conversation. Newer
 OpenClaw builds can keep transcripts in SQLite instead (a ``sqlite:`` session
 target); those are out of this adapter's reach — it reads the JSONL default.
 """
@@ -25,6 +27,13 @@ from memu.hosts.base import RecordKind, TranscriptSource
 SESSION_DIR = "~/.openclaw/agents"
 
 _MESSAGE_ROLES = ("user", "assistant")
+
+# Sidecar files sharing the sessions directory. Trajectory files hold trace
+# events — every record classifies OTHER, so scanning them fills prepare's
+# max_jobs slots with empty transcripts (they touch on every turn, so
+# newest-first keeps them on top). Checkpoint files re-emit turns the main
+# session transcript already has, so the same conversation is mined twice.
+_SIDECAR_MARKERS = (".trajectory.", ".checkpoint.")
 
 
 class OpenClawTranscriptSource(TranscriptSource):
@@ -46,6 +55,13 @@ class OpenClawTranscriptSource(TranscriptSource):
 
     def root(self) -> Path:
         return self._root
+
+    def discover(self) -> list[Path]:
+        """Main session transcripts only — the trajectory and checkpoint sidecars
+        sharing the directory trace or replay what the session file already says.
+        Filtering is by name and fails open: an unknown future sidecar kind keeps
+        being scanned rather than risking a missed session."""
+        return [path for path in super().discover() if not any(marker in path.name for marker in _SIDECAR_MARKERS)]
 
     def classify(self, record: str) -> RecordKind:
         try:

--- a/tests/test_host_sessions.py
+++ b/tests/test_host_sessions.py
@@ -220,6 +220,24 @@ def test_openclaw_timestamp_accepts_iso_and_epoch_millis() -> None:
     assert source.timestamp(_line(millis)) == "2025-07-15T00:00:00+00:00"
 
 
+def test_openclaw_discovers_only_main_session_transcripts(tmp_path: pathlib.Path) -> None:
+    """Trajectory sidecars hold trace events (all-OTHER: an empty transcript
+    that still occupies a prepare slot and still spawns mining jobs); checkpoint
+    sidecars re-emit turns the session file already has (the same conversation
+    mined twice). On the surveyed live host, 51 of 60 discovered files were
+    sidecars and 46 of 69 user-role messages were checkpoint duplicates."""
+    sessions = tmp_path / "main" / "sessions"
+    sessions.mkdir(parents=True)
+    session = sessions / "a83c9e20-072d-4708-902a-47c596b14d55.jsonl"
+    session.write_text('{"type":"message"}\n', encoding="utf-8")
+    trajectory = sessions / "a83c9e20-072d-4708-902a-47c596b14d55.trajectory.jsonl"
+    trajectory.write_text("{}\n", encoding="utf-8")
+    checkpoint = sessions / "c22ca449-d54c-4dd0-89ee-17cbf7af90f0.checkpoint.20d27d05.jsonl"
+    checkpoint.write_text("{}\n", encoding="utf-8")
+
+    assert OpenClawTranscriptSource(tmp_path).discover() == [session]
+
+
 # ── Hermes ─────────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## 📝 概述

OpenClaw 在每个 session transcript 旁边还会写两类**侧文件**：`*.trajectory.jsonl`（trace 事件）和 `*.checkpoint.*.jsonl`（重放的对话轮次）。`discover()` 的 `rglob("*.jsonl")` 把它们一并扫了进来——实测主机上 60 个命中里 51 个是侧文件。checkpoint 会让**同一段对话被 prepare、挖掘两次**；trajectory 会切出**空 transcript，却照样占用 `max_jobs` 槽位、照样触发挖掘 job**。按文件名把两类都过滤掉。

Fixes NevaMind-AI/memU#532

## ✅ 这个 PR 做了什么？

- 在 OpenClaw 适配器里重写 `discover()`，按文件名跳过 `.trajectory.` / `.checkpoint.` 文件。fail-open：未知的新侧文件类型继续被扫，绝不引入漏扫会话的风险方向。
- 加一条用真实落盘命名的测试；在模块 docstring 里记录这两类侧文件。
- 不动 classify、无新抽象、对其他宿主零影响。

## 🤔 为什么需要这个改动？

确定发生的机械浪费：每一次 checkpoint 重放，都会对一段**已经挖过**的对话再跑一遍完整的 memory + skill 挖掘（实测主机 69 条 user 消息里 46 条是 checkpoint 复本——除 token 浪费外，还有产出重复记忆的现实风险）；而 trajectory 文件随会话每轮追加、mtime 与主会话同步，在 newest-first 排序里天然置顶，于是拿着空 transcript 和空转的 LLM job 挤占 prepare 槽位。完整数据见关联 issue。

## 🔍 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 重构 / 清理
- [ ] 其他

## ✅ 质量检查清单

- [x] PR 标题符合允许的格式（如 `feat:`、`fix:`、`docs:`、`memory base:`）
- [x] 改动范围小、易于 review（3 行过滤 + 注释 + 一条测试）
- [x] 相应处已更新文档（模块 docstring）
- [x] 无破坏性改动
- [x] 已关联相关 issue

## 📌 可选

- [x] 已考虑边界情况：按文件名子串过滤且 fail-open——两种模式都不匹配的文件继续被扫；真实语料命名（`<uuid>.trajectory.jsonl`、`<uuid>.checkpoint.<uuid>.jsonl`）已在测试中钉住。
- [x] 已提及后续事项：关联 issue 里记录了两项相关但有意不纳入本 PR 的观察——拼在 user 正文头部的渠道 metadata envelope（可容忍、自带标注；剥离原型已就绪，如维护者需要可另开讨论），以及 OpenClaw 可选的 SQLite session target（适配器既有边界）。
