### PR TITLE
feat(hosts): install retrieval as a skill on Codex and Claude Code

### DIFF
--- a/src/memu/hosts/claude_code/INSTALL.md
+++ b/src/memu/hosts/claude_code/INSTALL.md
@@ -157,24 +157,35 @@ simply always there — no hook, no wrapper, no per-turn process.
 memu-claude-code install-instruction
 ```
 
-It writes memU's block into `~/.claude/CLAUDE.md`, creating the file if it does
-not exist, and prints the diff. It appends rather than overwrites (existing
-content is backed up to `~/.claude/CLAUDE.md.bak`), and it is idempotent: the
-text sits in a marked block that a re-run — or a later memU release — replaces in
-place. `--dry-run` shows the diff without writing; `--print` prints just the
-block.
+One command, two files, because Claude Code has skills:
+
+- `~/.claude/skills/memu-retrieve/SKILL.md` — the procedure: the `retrieve`
+  command to run and how to read the layers that come back. This directory is
+  memU's own, so a re-run overwrites it whole.
+- `~/.claude/CLAUDE.md` — two sentences telling you to use that skill before
+  answering. The detail stays out of here on purpose: this file is in context on
+  every turn, whether or not the turn touches memory; the skill is loaded only
+  when you act on it.
+
+It creates either file if absent and prints the diff of both. `CLAUDE.md` is the
+*user's*, so it appends rather than overwrites (previous content is backed up to
+`~/.claude/CLAUDE.md.bak`), and memU's text sits in a marked block that a re-run —
+or a later memU release — replaces in place. `--dry-run` shows the diffs without
+writing; `--print` prints what would be installed.
 
 ### ✅ Verify Part 3
 
 ```
 cat ~/.claude/CLAUDE.md
+cat ~/.claude/skills/memu-retrieve/SKILL.md
 memu-claude-code retrieve "smoke test"
 ```
 
-The memU block must appear exactly once, anything the user had there must be
-intact, and `retrieve` must exit cleanly (empty result lists are fine). A *fresh*
-Claude Code session is what picks up the new CLAUDE.md — do not be surprised that
-the instruction is not in your own context yet.
+The memU block must appear exactly once and name the `memu-retrieve` skill, that
+skill must exist, anything the user had in `CLAUDE.md` must be intact, and
+`retrieve` must exit cleanly (empty result lists are fine). A *fresh* Claude Code
+session is what picks up the new CLAUDE.md and skill — do not be surprised that
+neither is in your own context yet.
 
 ---
 
@@ -182,6 +193,5 @@ the instruction is not in your own context yet.
 
 Report back to the user: the store (`MEMU_DB`) and provider in use; the scheduled
 job and its schedule in words; and that the retrieval instruction is now in
-`~/.claude/CLAUDE.md`, taking effect in their next session. Record and inject
-both read `~/.memu/config.env`, so they provably share one store — what the task
-learns tonight is what retrieval finds tomorrow.
+`~/.claude/CLAUDE.md`, pointing at the `memu-retrieve` skill and taking effect in
+their next session. Record and inject both read `~/.memu/config.env`, so they provably share one store — what the task learns tonight is what retrieval finds tomorrow.

--- a/src/memu/hosts/claude_code/cli.py
+++ b/src/memu/hosts/claude_code/cli.py
@@ -29,6 +29,10 @@ CLAUDE_MD = "~/.claude/CLAUDE.md"
 project, so the inject seam lands here. (Project-level CLAUDE.md files exist too,
 but the instruction belongs at the level retrieval works at: the user.)"""
 
+SKILLS_DIR = "~/.claude/skills"
+"""Claude Code's personal skills directory. Because it exists, the CLAUDE.md block
+is a pointer and the retrieval procedure itself is installed here as a skill."""
+
 SPEC = HostSpec(
     host=HOST,
     display="Claude Code",
@@ -37,6 +41,7 @@ SPEC = HostSpec(
     session_dir=SESSION_DIR,
     session_help="Claude Code session log (one project dir per escaped cwd)",
     instruction_path=CLAUDE_MD,
+    skills_dir=SKILLS_DIR,
 )
 
 

--- a/src/memu/hosts/codex/INSTALL.md
+++ b/src/memu/hosts/codex/INSTALL.md
@@ -183,42 +183,55 @@ results into your answer.
 memu-codex install-instruction
 ```
 
-That is the whole step. It writes memU's block into `~/.codex/AGENTS.md`, creating
-the file if it does not exist, and prints the diff of what it changed.
+That is the whole step. It writes two files and prints the diff of each, creating
+either if it does not exist:
+
+- **`~/.codex/skills/memu-retrieve/SKILL.md`** — the procedure: the command to run
+  and how to read what comes back.
+- **`~/.codex/AGENTS.md`** — two sentences telling you to use that skill before
+  answering.
+
+The split is the point. AGENTS.md is in your context on *every* turn, whether or
+not the turn has anything to do with memory, so it carries only what you need in
+order to decide to retrieve; the skill carries the detail and is loaded only once
+you act on it.
 
 Three properties worth knowing, because they are what make it safe to just run:
 
 - **It appends; it never overwrites.** `~/.codex/AGENTS.md` is the *user's* global
   instruction file and may already hold rules that have nothing to do with memU.
   Everything already in there survives, and the previous contents are backed up to
-  `~/.codex/AGENTS.md.bak` before anything is written.
+  `~/.codex/AGENTS.md.bak` before anything is written. (The skill directory is
+  memU's own — nothing of the user's lives there — so it is simply overwritten.)
 - **It is idempotent.** memU's text goes inside a marked block. Re-running replaces
   that block in place rather than appending a second copy, so running it twice is
   harmless — and so a later memU release can *improve* the instruction and have the
   upgrade actually reach users who already installed it. A copy pasted in by hand
-  could never be upgraded.
-- **It shows its work.** `--dry-run` prints the diff and writes nothing; `--print`
-  prints just the block. If the user wants to see what lands in their file before it
-  lands, that is how.
+  could never be upgraded. The same holds for the skill.
+- **It shows its work.** `--dry-run` prints the diffs and writes nothing; `--print`
+  prints what would be installed. If the user wants to see what lands in their file
+  before it lands, that is how.
 
-If you want to read the instruction itself, run `memu-codex install-instruction
---print`. In short: it tells you to run `memu-codex retrieve "<query>"` before
+If you want to read the text itself, run `memu-codex install-instruction --print`.
+In short: the skill tells you to run `memu-codex retrieve "<query>"` before
 answering — the LLM-free single-shot retrieval, not the LLM-routed `memu retrieve`,
 which would cost an LLM call on every turn — and it explains how to read the
 `segments`/`files`/`resources` layers that come back.
 
 ### ✅ Verify Part 3
 
-Read the file back:
+Read both files back:
 
 ```
 cat ~/.codex/AGENTS.md
+cat ~/.codex/skills/memu-retrieve/SKILL.md
 ```
 
-The memU block must appear exactly once, and anything the user had in there
-beforehand must still be intact.
+The memU block must appear in AGENTS.md exactly once and name the `memu-retrieve`
+skill, that skill must exist, and anything the user had in AGENTS.md beforehand
+must still be intact.
 
-Then confirm the command the instruction names actually works against the Part 1
+Then confirm the command the skill names actually works against the Part 1
 store:
 
 ```
@@ -228,9 +241,9 @@ memu-codex retrieve "smoke test"
 Empty result lists are fine — you are testing that the read path works, not that
 the store has content yet.
 
-Finally, note that a *fresh* Codex session is what picks up the new AGENTS.md. The
-session you are installing from already loaded the old one, so do not be surprised
-that the instruction is not in your own context yet.
+Finally, note that a *fresh* Codex session is what picks up the new AGENTS.md and
+the new skill. The session you are installing from already loaded the old one, so
+do not be surprised that the instruction is not in your own context yet.
 
 ---
 
@@ -239,9 +252,9 @@ that the instruction is not in your own context yet.
 Report back to the user:
 
 - the store (`MEMU_DB`) and provider now in use;
-- the scheduled task's name and cron, in words (e.g. "hourly at :00 local");
-- that the retrieval instruction is now in `~/.codex/AGENTS.md`, and that it takes
-  effect in their next Codex session.
+- the scheduled task's name and cron, in words (e.g. "daily at 00:00 local");
+- that the retrieval instruction is now in `~/.codex/AGENTS.md`, pointing at the
+  `memu-retrieve` skill, and that it takes effect in their next Codex session.
 
 Record (Part 2) and inject (Part 3) both read `~/.memu/config.env`, so they
 provably share the store you configured in Part 1 — what the task learns tonight

--- a/src/memu/hosts/codex/cli.py
+++ b/src/memu/hosts/codex/cli.py
@@ -41,6 +41,10 @@ AGENTS_MD = "~/.codex/AGENTS.md"
 """Codex's global instruction file — loaded into every session, so the inject seam
 lands here. The path is the only part of that seam that is Codex-specific."""
 
+SKILLS_DIR = "~/.codex/skills"
+"""Codex's skills directory. Because it exists, the AGENTS.md block is a pointer
+and the retrieval procedure itself is installed here as a skill."""
+
 SPEC = HostSpec(
     host=HOST,
     display="Codex",
@@ -49,6 +53,7 @@ SPEC = HostSpec(
     session_dir=SESSION_DIR,
     session_help="Codex session log",
     instruction_path=AGENTS_MD,
+    skills_dir=SKILLS_DIR,
     # Codex shipped before per-host working trees; its ~/.memu layout is a
     # compatibility contract with already-scheduled bridging prompts (ADR 0010).
     base_dir="~/.memu",

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -63,6 +63,13 @@ class HostSpec:
     instruction_path: str
     """The host's global instruction file — where the inject seam lands."""
 
+    skills_dir: str = ""
+    """The host's skills directory, for hosts that have skills (``~/.codex/skills``,
+    ``~/.claude/skills``). Given one, ``install-instruction`` puts the retrieval
+    procedure in a skill there and leaves only a pointer in ``instruction_path``.
+    Empty — the default, and every host without a skills mechanism — keeps the full
+    text inline, which is the only place it can live."""
+
     base_dir: str = ""
     """memU working tree. Empty means the per-host default ``~/.memu/hosts/<host>``;
     Codex overrides this with the pre-multi-host ``~/.memu`` it has always used."""
@@ -250,7 +257,7 @@ def build_parser(spec: HostSpec) -> argparse.ArgumentParser:
     # Shared across hosts, so they are registered, not redefined — only the file
     # the instruction lands in and the binary it names are ours to fill in.
     retrieval.register(sub)
-    instruction.register(sub, path=spec.instruction_path, binary=spec.binary)
+    instruction.register(sub, path=spec.instruction_path, binary=spec.binary, skills_dir=spec.skills_dir)
 
     p = with_base(sub.add_parser("prepare", help=f"Slice new {spec.display} sessions into self-evolve job files"))
     # A host with no universal session location (the generic adapter) leaves

--- a/src/memu/hosts/instruction.py
+++ b/src/memu/hosts/instruction.py
@@ -18,6 +18,17 @@ when :data:`INSTRUCTION_TEMPLATE` improves in a later release, the copy already
 sitting in someone's AGENTS.md is inert. Hence :func:`install` writes a *managed
 block* between markers — re-running replaces it in place, so an upgrade is a
 re-run. Everything outside the markers is the user's and is never touched.
+
+Hosts that support **skills** take a second shape. The detail — how to word the
+query, how to read the three result layers — is not needed until the agent is
+actually retrieving, and an instruction file is read on every turn of every
+session, whether or not memory is in play. So on those hosts the detail moves
+into a skill (:data:`SKILL_TEMPLATE`, installed under the host's ``skills/``
+directory) and what lands in the instruction file shrinks to
+:data:`SKILL_INSTRUCTION_TEMPLATE`: two sentences pointing at it. Same seam, same
+markers, same upgrade-by-re-run; only the split differs. A host with no skills
+directory (:attr:`~memu.hosts.host_cli.HostSpec.skills_dir` left empty) gets the
+full text inline and no skill folder, because for it there is nowhere to put one.
 """
 
 from __future__ import annotations
@@ -32,13 +43,14 @@ from typing import Any
 BEGIN_TEMPLATE = "<!-- memu:begin — managed block, do not edit ({binary} install-instruction) -->"
 END = "<!-- memu:end -->"
 
-INSTRUCTION_TEMPLATE = """\
-## memU — retrieve before answering
+SKILL_NAME = "memu-retrieve"
+"""Directory and frontmatter name of the installed skill — ``<skills>/memu-retrieve/SKILL.md``."""
 
-Before answering, run `{binary} retrieve "<query>"` — where <query> is the
-user's request, reworded into a clearer query or focused keywords when that
-retrieves better (you need not pass their raw words verbatim). Use any relevant
-results as context. If it returns nothing, proceed normally.
+RETRIEVAL_BODY = """\
+Run `{binary} retrieve "<query>"` — where <query> is the user's request, reworded
+into a clearer query or focused keywords when that retrieves better (you need not
+pass their raw words verbatim). Use any relevant results as context. If it returns
+nothing, proceed normally.
 
 The result unfolds progressively, in three layers. `segments` are the narrowest
 and usually the most on-point: the individual slices of memory that matched the
@@ -48,18 +60,32 @@ act on. `resources` are files on the user's own machine that look related. Files
 and resources come back as a location plus a summary rather than full text; work
 from the summary, and open the raw file only when you need what it leaves out.
 """
-"""What the agent is told, every turn, before it answers.
 
-It names ``<binary> retrieve`` — a ``PATH`` command, never a script path, and
-the LLM-free single-shot retrieval. It fails open, hence "proceed normally" — an
-empty store returns empty lists and the turn goes on.
+INSTRUCTION_TEMPLATE = f"""\
+## memU — retrieve before answering
 
-The second paragraph is a legend for the JSON. ``retrieve`` prints raw
-``segments``/``files``/``resources`` with nothing to explain them, and the layers
-are not interchangeable: a segment is a matched slice, a file is the synthesized
-document that slice came from, a resource is a file on disk. Without the legend
-the reader has to guess which layer to trust, and opens raw files it did not need.
+Before answering:
+
+{RETRIEVAL_BODY}"""
+
+SKILL_INSTRUCTION_TEMPLATE = """\
+## memU — retrieve before answering
+
+Before answering, use the `{skill}` skill to pull any relevant memory into
+context. It fails open: if nothing comes back, answer normally.
 """
+
+SKILL_TEMPLATE = f"""\
+---
+name: {SKILL_NAME}
+description: Retrieve the user's durable memory from memU before answering — past
+  decisions, preferences, projects, and related files on this machine. Use at the
+  start of any turn where what the user has said or done before could matter.
+---
+
+# Retrieve from memU before answering
+
+{RETRIEVAL_BODY}"""
 
 
 def begin(binary: str) -> str:
@@ -67,14 +93,25 @@ def begin(binary: str) -> str:
     return BEGIN_TEMPLATE.format(binary=binary)
 
 
-def instruction(binary: str) -> str:
-    """The instruction text, telling the agent to run this host's ``retrieve``."""
+def skill_document(binary: str) -> str:
+    """The ``SKILL.md`` as written to disk, telling the agent how to retrieve."""
+    return SKILL_TEMPLATE.format(binary=binary)
+
+
+def instruction(binary: str, *, skill: bool = False) -> str:
+    """The instruction text, telling the agent to run this host's ``retrieve``.
+
+    ``skill=True`` returns the short pointer for hosts where :func:`install_skill`
+    has put the detail in a skill; otherwise the full inline text.
+    """
+    if skill:
+        return SKILL_INSTRUCTION_TEMPLATE.format(skill=SKILL_NAME, binary=binary)
     return INSTRUCTION_TEMPLATE.format(binary=binary)
 
 
-def block(binary: str) -> str:
+def block(binary: str, *, skill: bool = False) -> str:
     """The managed block exactly as it is written to disk, markers included."""
-    return f"{begin(binary)}\n{instruction(binary)}{END}\n"
+    return f"{begin(binary)}\n{instruction(binary, skill=skill)}{END}\n"
 
 
 def _block_re(binary: str) -> re.Pattern[str]:
@@ -84,7 +121,7 @@ def _block_re(binary: str) -> re.Pattern[str]:
     )
 
 
-def patch(current: str, binary: str) -> str:
+def patch(current: str, binary: str, *, skill: bool = False) -> str:
     """Return ``current`` with the managed block installed — replaced, or appended.
 
     Pure, so the interesting half of :func:`install` is testable without a
@@ -94,11 +131,11 @@ def patch(current: str, binary: str) -> str:
     """
     pattern = _block_re(binary)
     if pattern.search(current):
-        return pattern.sub(lambda _: block(binary), current, count=1)
+        return pattern.sub(lambda _: block(binary, skill=skill), current, count=1)
     if current and not current.endswith("\n"):
         current += "\n"
     separator = "\n" if current else ""
-    return f"{current}{separator}{block(binary)}"
+    return f"{current}{separator}{block(binary, skill=skill)}"
 
 
 def strip(current: str, binary: str) -> str:
@@ -120,16 +157,9 @@ def strip(current: str, binary: str) -> str:
     return stripped.rstrip("\n") + "\n"
 
 
-def install(path: Path, binary: str, *, dry_run: bool = False) -> tuple[bool, str]:
-    """Install the managed block into ``path``. Returns ``(changed, diff)``.
-
-    Creates the file (and its parent) if absent, and backs up any existing content
-    to ``<path>.bak`` before rewriting it — the target belongs to the *host*, not
-    to memU, and may hold instructions that have nothing to do with us.
-    """
-    path = path.expanduser()
+def _write(path: Path, updated: str, *, backup: bool, dry_run: bool) -> tuple[bool, str]:
+    """Rewrite ``path`` to ``updated``, diffing first. Returns ``(changed, diff)``."""
     current = path.read_text(encoding="utf-8") if path.is_file() else ""
-    updated = patch(current, binary)
     diff = "".join(
         difflib.unified_diff(
             current.splitlines(keepends=True),
@@ -142,10 +172,26 @@ def install(path: Path, binary: str, *, dry_run: bool = False) -> tuple[bool, st
         return False, diff
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    if current:
+    if backup and current:
         shutil.copyfile(path, path.with_suffix(path.suffix + ".bak"))
     path.write_text(updated, encoding="utf-8")
     return True, diff
+
+
+def install(path: Path, binary: str, *, skill: bool = False, dry_run: bool = False) -> tuple[bool, str]:
+    """Install the managed block into ``path``. Returns ``(changed, diff)``.
+
+    Creates the file (and its parent) if absent, and backs up any existing content
+    to ``<path>.bak`` before rewriting it — the target belongs to the *host*, not
+    to memU, and may hold instructions that have nothing to do with us.
+
+    ``skill`` installs the short block that points at :func:`install_skill`'s skill
+    instead of the full inline text; pass it only when that skill is being
+    installed too, or the block points at nothing.
+    """
+    path = path.expanduser()
+    current = path.read_text(encoding="utf-8") if path.is_file() else ""
+    return _write(path, patch(current, binary, skill=skill), backup=True, dry_run=dry_run)
 
 
 def remove(path: Path, binary: str, *, dry_run: bool = False) -> tuple[bool, str]:
@@ -161,37 +207,52 @@ def remove(path: Path, binary: str, *, dry_run: bool = False) -> tuple[bool, str
     if not path.is_file():
         return False, ""
     current = path.read_text(encoding="utf-8")
-    updated = strip(current, binary)
-    diff = "".join(
-        difflib.unified_diff(
-            current.splitlines(keepends=True),
-            updated.splitlines(keepends=True),
-            fromfile=str(path),
-            tofile=str(path),
-        )
-    )
-    if updated == current or dry_run:
-        return False, diff
+    return _write(path, strip(current, binary), backup=True, dry_run=dry_run)
 
-    shutil.copyfile(path, path.with_suffix(path.suffix + ".bak"))
-    path.write_text(updated, encoding="utf-8")
-    return True, diff
+
+def skill_path(skills_dir: Path) -> Path:
+    """Where the skill lands inside a host's ``skills/`` directory."""
+    return skills_dir.expanduser() / SKILL_NAME / "SKILL.md"
+
+
+def install_skill(skills_dir: Path, binary: str, *, dry_run: bool = False) -> tuple[bool, str]:
+    """Install the retrieval skill under ``skills_dir``. Returns ``(changed, diff)``.
+
+    Unlike the instruction file, ``<skills_dir>/memu-retrieve/`` is memU's own —
+    nothing of the user's lives there — so it is overwritten whole rather than
+    marker-fenced and backed up. Same upgrade story either way: re-run and the
+    release's text replaces the installed one.
+    """
+    return _write(skill_path(skills_dir), skill_document(binary), backup=False, dry_run=dry_run)
+
+
+def _report(path: Path, changed: bool, diff: str, *, dry_run: bool) -> None:
+    if not diff:
+        print(f"{path}: already up to date")
+    elif dry_run:
+        print(f"{path}: would change\n\n{diff}", end="")
+    else:
+        print(f"{path}: {'updated' if changed else 'unchanged'}\n\n{diff}", end="")
 
 
 def _cmd_install_instruction(args: argparse.Namespace) -> int:
-    path = Path(args.path)
+    skills_dir = Path(args.skills_dir) if args.skills_dir else None
+    skill = skills_dir is not None
     if args.print_only:
-        print(block(args.binary), end="")
+        if skills_dir is not None:
+            print(f"# {skill_path(skills_dir)}\n\n{skill_document(args.binary)}")
+        print(block(args.binary, skill=skill), end="")
         return 0
 
-    changed, diff = install(path, args.binary, dry_run=args.dry_run)
-    if not diff:
-        print(f"{path}: already up to date")
-        return 0
-    if args.dry_run:
-        print(f"{path}: would change\n\n{diff}", end="")
-        return 0
-    print(f"{path}: {'updated' if changed else 'unchanged'}\n\n{diff}", end="")
+    # The skill goes in first: between the two writes, an instruction block naming
+    # a skill that is not there yet is the only order that can mislead an agent.
+    if skills_dir is not None:
+        changed, diff = install_skill(skills_dir, args.binary, dry_run=args.dry_run)
+        _report(skill_path(skills_dir), changed, diff, dry_run=args.dry_run)
+
+    path = Path(args.path)
+    changed, diff = install(path, args.binary, skill=skill, dry_run=args.dry_run)
+    _report(path.expanduser(), changed, diff, dry_run=args.dry_run)
     return 0
 
 
@@ -218,19 +279,35 @@ async def _cmd_remove_instruction_async(args: argparse.Namespace) -> int:
     return _cmd_remove_instruction(args)
 
 
-def register(sub: Any, *, path: str, binary: str) -> None:
+def register(sub: Any, *, path: str, binary: str, skills_dir: str = "") -> None:
     """Add ``install-instruction`` to a host CLI, bound to that host's ``path``.
 
     ``binary`` is the host adapter's own command name (``memu-codex``, …) — it is
     what the installed instruction tells the agent to run.
+
+    ``skills_dir`` is the host's skills directory (``~/.claude/skills``, …), if it
+    has one. Given it, the command installs the retrieval skill there and patches
+    ``path`` with a two-sentence pointer to it; left empty, it patches ``path``
+    with the full text and writes no skill.
     """
     parser = sub.add_parser(
         "install-instruction",
         help="Patch the host's global instruction file so the agent retrieves before answering",
     )
     parser.add_argument("--path", default=path, help=f"Instruction file to patch (default: {path})")
+    parser.add_argument(
+        "--skills-dir",
+        default=skills_dir,
+        help=(
+            f"Skills directory to install the {SKILL_NAME} skill into (default: {skills_dir})"
+            if skills_dir
+            else argparse.SUPPRESS
+        ),
+    )
     parser.add_argument("--dry-run", action="store_true", help="Show the diff without writing")
-    parser.add_argument("--print", dest="print_only", action="store_true", help="Print the managed block and exit")
+    parser.add_argument(
+        "--print", dest="print_only", action="store_true", help="Print what would be installed and exit"
+    )
     parser.set_defaults(handler=_cmd_install_instruction_async, binary=binary)
 
     remover = sub.add_parser(

--- a/tests/test_host_instruction.py
+++ b/tests/test_host_instruction.py
@@ -4,6 +4,10 @@ The target file belongs to the *host*, not to memU, and may already hold a user'
 own global instructions. These pin the three properties that protect it: existing
 content survives, a re-run does not stack a second copy, and a changed
 :data:`INSTRUCTION_TEMPLATE` upgrades in place rather than appending a stale twin.
+
+The second half pins the split: on a host with skills the procedure lives in a
+skill and the instruction file gets a pointer; on a host without one, nothing
+about today's behaviour moves.
 """
 
 from __future__ import annotations
@@ -11,7 +15,7 @@ from __future__ import annotations
 import pathlib
 
 from memu.hosts import instruction
-from memu.hosts.codex.cli import AGENTS_MD, build_parser
+from memu.hosts.codex.cli import AGENTS_MD, SKILLS_DIR, build_parser
 
 BINARY = "memu-codex"
 
@@ -97,6 +101,7 @@ def test_dry_run_writes_nothing(tmp_path: pathlib.Path) -> None:
 def test_cli_defaults_to_the_codex_instruction_file() -> None:
     args = build_parser().parse_args(["install-instruction"])
     assert args.path == AGENTS_MD
+    assert args.skills_dir == SKILLS_DIR
     assert args.binary == BINARY
     assert callable(args.handler)
 
@@ -183,3 +188,91 @@ def test_cli_registers_remove_instruction() -> None:
     assert args.path == AGENTS_MD
     assert args.binary == BINARY
     assert callable(args.handler)
+
+
+def test_skill_carries_the_procedure_and_names_the_host_binary() -> None:
+    document = instruction.skill_document(BINARY)
+    assert document.startswith(f"---\nname: {instruction.SKILL_NAME}\n")
+    assert "description:" in document, "the host reads the frontmatter to decide whether to open it"
+    assert "memu-codex retrieve" in document, "the skill is where the runnable command now lives"
+    assert "`memu retrieve" not in document
+
+
+def test_skill_block_points_at_the_skill_instead_of_carrying_the_procedure() -> None:
+    """The whole point of the split: what sits in every turn's context stays small."""
+    pointer = instruction.instruction(BINARY, skill=True)
+    assert instruction.SKILL_NAME in pointer
+    assert "retrieve" in pointer
+    assert "segments" not in pointer, "the result legend belongs in the skill, not in every turn"
+    assert len(pointer.splitlines()) < len(instruction.instruction(BINARY).splitlines())
+
+
+def test_install_skill_writes_the_skill_where_the_host_looks(tmp_path: pathlib.Path) -> None:
+    changed, diff = instruction.install_skill(tmp_path / "skills", BINARY)
+
+    path = tmp_path / "skills" / instruction.SKILL_NAME / "SKILL.md"
+    assert changed and diff
+    assert path.read_text(encoding="utf-8") == instruction.skill_document(BINARY)
+
+
+def test_install_skill_is_idempotent_then_upgrades_in_place(tmp_path: pathlib.Path, monkeypatch) -> None:
+    skills = tmp_path / "skills"
+    instruction.install_skill(skills, BINARY)
+
+    changed, diff = instruction.install_skill(skills, BINARY)
+    assert not changed and not diff, "a re-run must be a no-op"
+
+    monkeypatch.setattr(instruction, "SKILL_TEMPLATE", "---\nname: memu-retrieve\n---\n\nNew and improved.\n")
+    changed, _ = instruction.install_skill(skills, BINARY)
+    text = (skills / instruction.SKILL_NAME / "SKILL.md").read_text(encoding="utf-8")
+    assert changed
+    assert text == "---\nname: memu-retrieve\n---\n\nNew and improved.\n", "an upgrade replaces it whole"
+
+
+def test_install_skill_dry_run_writes_nothing(tmp_path: pathlib.Path) -> None:
+    changed, diff = instruction.install_skill(tmp_path / "skills", BINARY, dry_run=True)
+
+    assert not changed
+    assert diff, "a dry run still reports what it would do"
+    assert not (tmp_path / "skills").exists()
+
+
+def test_a_skill_host_upgrades_from_the_old_inline_block(tmp_path: pathlib.Path) -> None:
+    """Users installed before the split have the full text in their file already."""
+    path = tmp_path / "AGENTS.md"
+    path.write_text("# My rules\n", encoding="utf-8")
+    instruction.install(path, BINARY)
+    assert "segments" in path.read_text(encoding="utf-8")
+
+    changed, _ = instruction.install(path, BINARY, skill=True)
+
+    text = path.read_text(encoding="utf-8")
+    assert changed
+    assert instruction.SKILL_NAME in text
+    assert "segments" not in text, "the superseded inline procedure must be gone, not left beside the pointer"
+    assert text.count(instruction.begin(BINARY)) == 1
+    assert "# My rules" in text
+
+
+def test_cli_installs_skill_and_pointer_together_for_a_skill_host(tmp_path: pathlib.Path) -> None:
+    args = build_parser().parse_args([
+        "install-instruction",
+        "--path",
+        str(tmp_path / "AGENTS.md"),
+        "--skills-dir",
+        str(tmp_path / "skills"),
+    ])
+    assert instruction._cmd_install_instruction(args) == 0
+
+    assert (tmp_path / "skills" / instruction.SKILL_NAME / "SKILL.md").is_file()
+    assert instruction.SKILL_NAME in (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+
+
+def test_cli_without_a_skills_dir_keeps_the_full_text_and_writes_no_skill(tmp_path: pathlib.Path) -> None:
+    """Hosts with no skills mechanism must not regress into pointing at nothing."""
+    args = build_parser().parse_args(["install-instruction", "--path", str(tmp_path / "AGENTS.md"), "--skills-dir", ""])
+    assert instruction._cmd_install_instruction(args) == 0
+
+    text = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert "memu-codex retrieve" in text and "segments" in text
+    assert not (tmp_path / "skills").exists()


### PR DESCRIPTION
The instruction file is in context on every turn, whether or not the turn touches memory, so it should carry only what the agent needs to decide to retrieve. On hosts that have skills, the procedure — the retrieve command and the segments/files/resources legend — now installs to <host>/skills/memu-retrieve/SKILL.md, and the managed block in AGENTS.md / CLAUDE.md shrinks to two sentences pointing at it.

Which shape a host gets is data, not a branch: HostSpec.skills_dir, set for Codex and Claude Code and empty everywhere else. The other four adapters keep the full text inline and write no skill folder, since they have nowhere to put one.

Both files upgrade by re-run. The marker fence means users installed before this get their inline block replaced in place by the pointer, with their own surrounding text untouched; the skill directory is memU's own and is overwritten whole.

## 📝 Pull Request Summary

Please provide a short summary explaining the purpose of this PR.

---

## ✅ What does this PR do?
- Clearly describe the change introduced.
- Mention the motivation or problem it solves.

---

## 🤔 Why is this change needed?
- Explain the context or user impact.
- Link any relevant issue or discussion.

---

## 🔍 Type of Change
Please check what applies:

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (please explain)

---

## ✅ PR Quality Checklist

- [ ] PR title follows an allowed format (for example `feat:`, `fix:`, `docs:`, `memory base:`)
- [ ] Changes are limited in scope and easy to review
- [ ] Documentation updated where applicable
- [ ] No breaking changes (or clearly documented)
- [ ] Related issues or discussions linked

---

## 📌 Optional

- [ ] Screenshots or examples added (if applicable)
- [ ] Edge cases considered
- [ ] Follow-up tasks mentioned
