### PR TITLE
feat(hermes): install retrieval as a skill

### DIFF
--- a/src/memu/hosts/hermes/INSTALL.md
+++ b/src/memu/hosts/hermes/INSTALL.md
@@ -134,22 +134,34 @@ files would miss sessions started elsewhere.)
 memu-hermes install-instruction
 ```
 
-It writes memU's block into `~/.hermes/SOUL.md`, creating the file if absent, and
-prints the diff. It appends rather than overwrites (existing content is backed up
-to `SOUL.md.bak`), and it is idempotent: the text sits in a marked block that a
-re-run — or a later memU release — replaces in place. `--dry-run` shows the diff
-without writing; `--path` targets a non-default home or profile.
+One command, two files, because Hermes has skills:
+
+- `~/.hermes/skills/memu-retrieve/SKILL.md` — the procedure: the `retrieve`
+  command to run and how to read the layers that come back. This directory is
+  memU's own, so a re-run overwrites it whole.
+- `~/.hermes/SOUL.md` — two sentences telling the agent to use that skill before
+  answering. The detail stays out of here on purpose: SOUL.md is in context on
+  every turn, whether or not the turn touches memory; the skill is loaded only
+  when the agent acts on it.
+
+It creates either file if absent and prints the diff of both. `SOUL.md` is the
+*user's*, so it appends rather than overwrites (previous content is backed up to
+`~/.hermes/SOUL.md.bak`), and memU's text sits in a marked block that a re-run —
+or a later memU release — replaces in place. `--dry-run` shows the diffs without
+writing; `--path` and `--skills-dir` target a non-default home or profile.
 
 ### ✅ Verify Part 3
 
 ```
 cat ~/.hermes/SOUL.md
+cat ~/.hermes/skills/memu-retrieve/SKILL.md
 memu-hermes retrieve "smoke test"
 ```
 
-The memU block must appear exactly once, prior content intact, and `retrieve`
-must exit cleanly (empty lists are fine). A fresh Hermes session picks up the new
-SOUL.md.
+The memU block must appear exactly once and name the `memu-retrieve` skill, that
+skill must exist, anything the user had in `SOUL.md` must be intact, and
+`retrieve` must exit cleanly (empty lists are fine). A fresh Hermes session is
+what picks up the new SOUL.md and skill.
 
 ---
 
@@ -157,5 +169,6 @@ SOUL.md.
 
 Report back to the user: the store and provider in use; the scheduled job and its
 schedule in words; and that the retrieval instruction is now in
-`~/.hermes/SOUL.md`, taking effect next session. Record and inject both read
-`~/.memu/config.env`, so they provably share one store.
+`~/.hermes/SOUL.md`, pointing at the `memu-retrieve` skill and taking effect next
+session. Record and inject both read `~/.memu/config.env`, so they provably share
+one store.

--- a/src/memu/hosts/hermes/UNINSTALL.md
+++ b/src/memu/hosts/hermes/UNINSTALL.md
@@ -8,8 +8,8 @@ Uninstalling is the install run in reverse, and it is three parts:
 
 1. **Unregister the bridging task** — stop the scheduled job first, so nothing
    fires mid-teardown (the *record* seam).
-2. **Unpatch `~/.hermes/SOUL.md`** — remove the standing retrieval
-   instruction (the *inject* seam).
+2. **Unpatch `~/.hermes/SOUL.md` and remove the retrieval skill** — the
+   standing instruction and the skill it points at (the *inject* seam).
 3. **Apply the data-and-package defaults** — the user's memory is kept, the
    tooling is removed — and close by reporting both.
 
@@ -37,7 +37,7 @@ there.
 
 ---
 
-## Part 2 — Remove the retrieval instruction
+## Part 2 — Remove the retrieval instruction and skill
 
 **Do not hand-edit the block out.** memU owns the text and removes it for you:
 
@@ -53,11 +53,22 @@ file with no block left is already the desired end state. If this install used
 a non-default home (`HERMES_HOME`, or a profile), pass
 `--path <home>/SOUL.md`.
 
+The block pointed at the `memu-retrieve` skill; remove that too. The directory
+is memU's own — the install wrote it whole, so it goes whole:
+
+```
+rm -r ~/.hermes/skills/memu-retrieve
+```
+
+(For a non-default home, it sits under `<home>/skills/` instead.) Other entries
+in `~/.hermes/skills/` are the user's or Hermes's — leave them alone.
+
 ### ✅ Verify Part 2
 
 `cat ~/.hermes/SOUL.md` — no `memu:begin`/`memu:end` markers remain, and the
-user's own content is intact. A session already running loaded the old file; a
-fresh session is what picks the removal up.
+user's own content is intact. `~/.hermes/skills/memu-retrieve` no longer
+exists. A session already running loaded the old file; a fresh session is what
+picks the removal up.
 
 ---
 
@@ -98,6 +109,6 @@ Close the report with the two things the user needs to hear, in this order:
 1. **What was kept:** their memory — the store at `MEMU_DB`,
    `~/.memu/config.env`, and the session cursor — untouched. A later reinstall
    picks it up as is and resumes mining right where it left off.
-2. **What was removed:** the bridging schedule, the retrieval instruction,
-   this host's working state, and (unless another host still needs it) the
-   `memu-cli` package.
+2. **What was removed:** the bridging schedule, the retrieval instruction and
+   skill, this host's working state, and (unless another host still needs it)
+   the `memu-cli` package.

--- a/src/memu/hosts/hermes/cli.py
+++ b/src/memu/hosts/hermes/cli.py
@@ -7,7 +7,7 @@ lands in.
 
 Usage:
     memu-hermes retrieve "<query>"    # the inject seam — what the agent runs each turn
-    memu-hermes install-instruction   # the inject seam — patch ~/.hermes/SOUL.md to run it
+    memu-hermes install-instruction   # the inject seam — install the skill, point SOUL.md at it
     memu-hermes prepare               # slice new sessions into job files
     memu-hermes verify-resources      # filter the touched-file log (run by a job)
     memu-hermes commit                # submit what the agent produced back to memU
@@ -31,6 +31,11 @@ session regardless of working directory, so the inject seam lands here.
 (Project-level ``.hermes.md``/``AGENTS.md`` files are per-directory and would
 miss sessions started elsewhere.)"""
 
+SKILLS_DIR = "~/.hermes/skills"
+"""Hermes's skills directory (agentskills.io layout, loaded on demand via
+``skills_list``/``skill_view``). Because it exists, the SOUL.md block is a
+pointer and the retrieval procedure itself is installed here as a skill."""
+
 SPEC = HostSpec(
     host=HOST,
     display="Hermes",
@@ -39,6 +44,7 @@ SPEC = HostSpec(
     session_dir=STATE_DB,
     session_help="Hermes SQLite session store (state.db under HERMES_HOME)",
     instruction_path=SOUL_MD,
+    skills_dir=SKILLS_DIR,
 )
 
 

--- a/tests/test_host_instruction.py
+++ b/tests/test_host_instruction.py
@@ -106,6 +106,14 @@ def test_cli_defaults_to_the_codex_instruction_file() -> None:
     assert callable(args.handler)
 
 
+def test_hermes_is_a_skill_host() -> None:
+    """Hermes loads skills on demand from ~/.hermes/skills (agentskills.io
+    layout), so its SOUL.md block must be the pointer, not the full procedure."""
+    from memu.hosts.hermes.cli import SPEC
+
+    assert SPEC.skills_dir == "~/.hermes/skills"
+
+
 def test_instruction_names_the_llm_free_retrieval() -> None:
     """`memu retrieve` is LLM-routed — one LLM call per turn is what this avoids."""
     assert "memu-codex retrieve" in instruction.instruction(BINARY)


### PR DESCRIPTION
Follow-up to #535, extending the same split to Hermes. Hermes loads skills on demand from `~/.hermes/skills` (agentskills.io layout — `SKILL.md` with name/description frontmatter, surfaced via `skills_list` and loaded whole only on `skill_view`), which is exactly the shape #535 was built for: the retrieval procedure installs as `~/.hermes/skills/memu-retrieve/SKILL.md`, and the managed block in `SOUL.md` shrinks to the two-sentence pointer.

As designed there, the change is data, not a branch: `HostSpec.skills_dir`. Everything else — install order (skill before pointer), idempotence, in-place upgrade of a pre-existing inline block on re-run — comes from the shared `instruction` module and is already pinned by the #535 tests; the new test pins the one Hermes-specific fact, that the spec declares the skills directory.

The install guide's Part 3 follows the Claude Code wording (one command, two files, and why the detail stays out of SOUL.md). The uninstall guide now also covers the skill: `remove-instruction` only deletes the managed block, so the guide instructs removing `~/.hermes/skills/memu-retrieve` whole — the directory is memU's own — while leaving the user's other skills alone. (The Claude Code and Codex uninstall guides have the same gap; happy to follow up there separately.)

Verified: full test suite passes (125), plus an end-to-end run against a temp home — install writes both files with user content intact, a legacy inline block upgrades to the pointer in place, and a second run is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)