### PR TITLE
feat(retrieval): shape progressive-retrieve output for the agent

### DIFF
--- a/src/memu/hosts/bridging/recall_files.py
+++ b/src/memu/hosts/bridging/recall_files.py
@@ -11,6 +11,17 @@ from pathlib import Path
 from typing import Any
 
 
+def recall_file_path(base_dir: Path, subdir: str, name: str) -> Path:
+    """The on-disk mirror path for a recall file, by name.
+
+    The one place the filename convention lives, so the writer and any reader
+    that needs to *locate* a mirrored file by name (e.g. retrieval, surfacing a
+    file's path to the agent) agree by construction rather than by comment.
+    """
+    # Escape spaces in the filename with '-'; the frontmatter keeps the raw name.
+    return base_dir / subdir / f"{name.replace(' ', '-')}.md"
+
+
 def write_recall_file(base_dir: Path, subdir: str, recall_file: dict[str, Any]) -> Path:
     """Mirror one recall file into ``base_dir/subdir`` as front-mattered markdown."""
     name = recall_file["name"]
@@ -20,8 +31,7 @@ def write_recall_file(base_dir: Path, subdir: str, recall_file: dict[str, Any]) 
     out_dir = base_dir / subdir
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    # Escape spaces in the filename with '-'; the frontmatter keeps the raw name.
-    out_path = out_dir / f"{name.replace(' ', '-')}.md"
+    out_path = recall_file_path(base_dir, subdir, name)
     out_path.write_text(f"---\nname: {name}\ndescription: {description}\n---\n{content}", encoding="utf-8")
     return out_path
 

--- a/src/memu/hosts/instruction.py
+++ b/src/memu/hosts/instruction.py
@@ -54,13 +54,14 @@ nothing, proceed normally.
 
 The result unfolds progressively, in three layers. `segments` are the narrowest
 and usually the most on-point: the individual slices of memory that matched the
-query, each naming the `source_file` it was cut from. `files` are the synthesized
-documents those segments came from — broader, and worth consulting when a segment
-reads as relevant but is too thin to act on; find one by its `path` (the same
-value a segment's `source_file` points at). `resources` are files on the user's
-own machine that look related, each with a `path`. Files and resources come back
-as a location plus a summary rather than full text; work from the summary, and
-open the file at its `path` only when you need what it leaves out.
+query, each naming in `source_file` the document it was cut from. `files` are
+those synthesized documents — broader, and worth consulting when a segment reads
+as relevant but is too thin to act on; find one by matching a segment's
+`source_file` to it. Each file gives you a summary plus either a `path` to open
+when you need the full text or, if its file is unavailable, the text inline.
+`resources` are files on the user's own machine that look related, each a `path`
+plus a summary. Work from the summaries; open a `path` only when you need what it
+leaves out.
 """
 
 INSTRUCTION_TEMPLATE = f"""\

--- a/src/memu/hosts/instruction.py
+++ b/src/memu/hosts/instruction.py
@@ -54,11 +54,13 @@ nothing, proceed normally.
 
 The result unfolds progressively, in three layers. `segments` are the narrowest
 and usually the most on-point: the individual slices of memory that matched the
-query. `files` are the synthesized documents those segments were cut from —
-broader, and worth consulting when a segment reads as relevant but is too thin to
-act on. `resources` are files on the user's own machine that look related. Files
-and resources come back as a location plus a summary rather than full text; work
-from the summary, and open the raw file only when you need what it leaves out.
+query, each naming the `source_file` it was cut from. `files` are the synthesized
+documents those segments came from — broader, and worth consulting when a segment
+reads as relevant but is too thin to act on; find one by its `path` (the same
+value a segment's `source_file` points at). `resources` are files on the user's
+own machine that look related, each with a `path`. Files and resources come back
+as a location plus a summary rather than full text; work from the summary, and
+open the file at its `path` only when you need what it leaves out.
 """
 
 INSTRUCTION_TEMPLATE = f"""\

--- a/src/memu/hosts/retrieval.py
+++ b/src/memu/hosts/retrieval.py
@@ -18,18 +18,83 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+from pathlib import Path
 from typing import Any
 
 from memu.env import build_service_from_env
+from memu.hosts.bridging.layout import BASE_DIR, TRACK_DIRS
+from memu.hosts.bridging.recall_files import recall_file_path
 
 
 async def retrieve(query: str, where: dict[str, Any] | None = None) -> dict[str, Any]:
     """Retrieve against the configured store. Returns ``segments``/``files``/``resources``.
 
     Embeddings are already stripped from the hits, so the result is safe to print.
+    :func:`_shape_for_agent` then reshapes the raw store records into the
+    progressive form the standing instruction promises (see
+    :mod:`memu.hosts.instruction`).
     """
     service = build_service_from_env()
     result: dict[str, Any] = await service.progressive_retrieve(query, where=where)
+    return _shape_for_agent(result)
+
+
+def _mirror_path(base: Path, track: Any, name: Any) -> Path | None:
+    """The mirror path a recall file *should* live at, or ``None`` if unlocatable.
+
+    Unlocatable means the file's track has no mirror directory (only
+    ``memory``/``skill`` are mirrored) or it has no name — in either case there
+    is no path to hand the agent, so the caller falls back to inline content.
+    """
+    subdir = TRACK_DIRS.get(track or "")
+    if subdir is None or not name:
+        return None
+    return recall_file_path(base, subdir, str(name))
+
+
+def _shape_for_agent(result: dict[str, Any]) -> dict[str, Any]:
+    """Reshape raw retrieval records into the agent-facing progressive form.
+
+    Matching the instruction's contract that files and resources come back as
+    *a location plus a summary* rather than full text:
+
+    * ``files`` shed their ``content`` in favour of a ``path`` to the on-disk
+      mirror (``~/.memu/<track>/<name>.md``). The mirror is written by
+      ``commit`` but is not guaranteed to survive — the user owns that tree — so
+      when it is missing the ``content`` is kept inline and the result stays
+      self-sufficient. The internal ``resource_urls`` link list is dropped: the
+      standing instruction never names it, so it is noise to the agent.
+    * ``segments`` swap the internal ``recall_file_id`` UUID for ``source_file``:
+      the same ``path`` its parent file reports, so provenance is both
+      human-meaningful and directly openable, with no cross-referencing a UUID.
+    * ``resources`` collapse the duplicated ``url``/``local_path`` (``commit`` is
+      the only writer and sets them equal) down to a single ``path``.
+    """
+    base = Path(os.path.expanduser(BASE_DIR))
+
+    file_paths: dict[str, str] = {}
+    for file in result.get("files", []):
+        path = _mirror_path(base, file.get("track"), file.get("name"))
+        content = file.pop("content", None)
+        _ = file.pop("resource_urls", None)
+        if path is not None:
+            file["path"] = str(path)
+            file_paths[file.get("id")] = str(path)
+        if path is None or not path.exists():
+            # Unlocatable, or the mirror is gone: keep the text so the agent
+            # still has it even though there is no file to open.
+            file["content"] = content
+
+    for segment in result.get("segments", []):
+        fid = segment.pop("recall_file_id", None)
+        segment["source_file"] = file_paths.get(fid)
+
+    for resource in result.get("resources", []):
+        resource.pop("local_path", None)
+        if "url" in resource:
+            resource["path"] = resource.pop("url")
+
     return result
 
 

--- a/src/memu/hosts/retrieval.py
+++ b/src/memu/hosts/retrieval.py
@@ -53,42 +53,59 @@ def _mirror_path(base: Path, track: Any, name: Any) -> Path | None:
     return recall_file_path(base, subdir, str(name))
 
 
+def _source_label(track: Any, name: Any) -> str | None:
+    """A stable, human-readable id for a recall file: ``<track>/<name>``.
+
+    What a segment points back to and what the agent matches against the
+    ``files`` layer. The track prefix disambiguates a bare name (which can
+    collide across tracks). It is deliberately *not* a filesystem path — the
+    openable location is the file's ``path`` — so a segment never carries a
+    location that may not exist on disk.
+    """
+    if not name:
+        return None
+    return f"{track}/{name}" if track else str(name)
+
+
 def _shape_for_agent(result: dict[str, Any]) -> dict[str, Any]:
     """Reshape raw retrieval records into the agent-facing progressive form.
 
     Matching the instruction's contract that files and resources come back as
     *a location plus a summary* rather than full text:
 
-    * ``files`` shed their ``content`` in favour of a ``path`` to the on-disk
-      mirror (``~/.memu/<track>/<name>.md``). The mirror is written by
-      ``commit`` but is not guaranteed to survive — the user owns that tree — so
-      when it is missing the ``content`` is kept inline and the result stays
-      self-sufficient. The internal ``resource_urls`` link list is dropped: the
-      standing instruction never names it, so it is noise to the agent.
-    * ``segments`` swap the internal ``recall_file_id`` UUID for ``source_file``:
-      the same ``path`` its parent file reports, so provenance is both
-      human-meaningful and directly openable, with no cross-referencing a UUID.
+    * ``files`` shed their ``content``: when the on-disk mirror
+      (``~/.memu/<track>/<name>.md``) exists, they carry a ``path`` to it; when
+      it does not — the user owns that tree and may delete it — they keep the
+      ``content`` inline and emit *no* ``path``, so the agent never sees a
+      location that isn't there. The internal ``resource_urls`` link list is
+      dropped: the standing instruction never names it, so it is noise.
+    * ``segments`` swap the internal ``recall_file_id`` UUID for ``source_file``,
+      the ``<track>/<name>`` id of their parent file — an identifier for finding
+      the fuller document in ``files``, not a path to open (that is the file's
+      job, which degrades cleanly to inline content).
     * ``resources`` collapse the duplicated ``url``/``local_path`` (``commit`` is
       the only writer and sets them equal) down to a single ``path``.
     """
     base = Path(os.path.expanduser(BASE_DIR))
 
-    file_paths: dict[str, str] = {}
+    file_labels: dict[str, str | None] = {}
     for file in result.get("files", []):
+        file_labels[file.get("id")] = _source_label(file.get("track"), file.get("name"))
+
         path = _mirror_path(base, file.get("track"), file.get("name"))
         content = file.pop("content", None)
-        _ = file.pop("resource_urls", None)
-        if path is not None:
+        file.pop("resource_urls", None)
+        if path is not None and path.exists():
+            # The mirror is on disk: hand over the openable location, not the text.
             file["path"] = str(path)
-            file_paths[file.get("id")] = str(path)
-        if path is None or not path.exists():
-            # Unlocatable, or the mirror is gone: keep the text so the agent
-            # still has it even though there is no file to open.
+        else:
+            # Unlocatable, or the mirror is gone: keep the text inline and emit no
+            # dead path, so the agent never reasons about a file that isn't there.
             file["content"] = content
 
     for segment in result.get("segments", []):
         fid = segment.pop("recall_file_id", None)
-        segment["source_file"] = file_paths.get(fid)
+        segment["source_file"] = file_labels.get(fid)
 
     for resource in result.get("resources", []):
         resource.pop("local_path", None)

--- a/tests/test_host_retrieval.py
+++ b/tests/test_host_retrieval.py
@@ -3,9 +3,10 @@
 ``progressive_retrieve`` returns raw store records; :func:`_shape_for_agent` turns
 them into the progressive form the standing instruction promises — files and
 resources as *a location plus a summary*, segments naming their source. These pin
-that contract: content gives way to a mirror ``path`` when the file is on disk,
-survives inline when it is not, segments swap their UUID for that same path, and
-resources collapse the duplicated url/local_path down to one ``path``.
+that contract: a file gives way to a mirror ``path`` when it is on disk and keeps
+its text inline (with no dead ``path``) when it is not; a segment carries the
+``track/name`` id of its parent file, not a filesystem path; and resources
+collapse the duplicated url/local_path down to one ``path``.
 """
 
 from __future__ import annotations
@@ -52,24 +53,26 @@ def test_present_mirror_replaces_content_with_path(tmp_path: pathlib.Path, monke
     assert file["path"] == str(tmp_path / "memory" / "coffee-preferences.md")
 
 
-def test_missing_mirror_keeps_content_inline(tmp_path: pathlib.Path, monkeypatch) -> None:
+def test_missing_mirror_keeps_content_inline_with_no_path(tmp_path: pathlib.Path, monkeypatch) -> None:
     monkeypatch.setattr(retrieval, "BASE_DIR", str(tmp_path))
-    # No file written: the mirror is gone, so the result must stay self-sufficient.
+    # No file written: the mirror is gone, so the result must stay self-sufficient
+    # and must NOT dangle a path at a file that isn't there.
     shaped = retrieval._shape_for_agent(_result())
 
     file = shaped["files"][0]
     assert file["content"] == "No sugar.", "with no file to open, the text must survive inline"
-    assert file["path"] == str(tmp_path / "memory" / "coffee-preferences.md")
+    assert "path" not in file, "a missing mirror must not leave a dead path for the agent to chase"
 
 
-def test_segment_source_file_points_at_its_files_path(tmp_path: pathlib.Path, monkeypatch) -> None:
+def test_segment_names_its_source_file_by_track_and_name(tmp_path: pathlib.Path, monkeypatch) -> None:
     monkeypatch.setattr(retrieval, "BASE_DIR", str(tmp_path))
     shaped = retrieval._shape_for_agent(_result())
 
     seg = shaped["segments"][0]
     assert "recall_file_id" not in seg, "the internal UUID must not leak to the agent"
-    assert seg["source_file"] == shaped["files"][0]["path"]
-    # A segment whose file fell out of the result gets no fabricated path.
+    # The label identifies the parent file for lookup — an id, not a path.
+    assert seg["source_file"] == "memory/coffee preferences"
+    # A segment whose file fell out of the result gets no fabricated label.
     assert shaped["segments"][1]["source_file"] is None
 
 

--- a/tests/test_host_retrieval.py
+++ b/tests/test_host_retrieval.py
@@ -1,0 +1,82 @@
+"""The inject seam's presentation: does the raw retrieval get reshaped for the agent?
+
+``progressive_retrieve`` returns raw store records; :func:`_shape_for_agent` turns
+them into the progressive form the standing instruction promises — files and
+resources as *a location plus a summary*, segments naming their source. These pin
+that contract: content gives way to a mirror ``path`` when the file is on disk,
+survives inline when it is not, segments swap their UUID for that same path, and
+resources collapse the duplicated url/local_path down to one ``path``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from memu.hosts import retrieval
+from memu.hosts.bridging.recall_files import write_recall_file
+
+
+def _result() -> dict:
+    return {
+        "segments": [
+            {"id": "s1", "recall_file_id": "f1", "track": "memory", "text": "No sugar.", "score": 0.4},
+            {"id": "s2", "recall_file_id": "gone", "track": "memory", "text": "orphan", "score": 0.3},
+        ],
+        "files": [
+            {
+                "id": "f1",
+                "name": "coffee preferences",
+                "track": "memory",
+                "description": "How the user likes their coffee",
+                "content": "No sugar.",
+                "score": 0.4,
+                "resource_urls": [],
+            }
+        ],
+        "resources": [
+            {"id": "r1", "url": "notes/onboarding.md", "local_path": "notes/onboarding.md", "caption": "notes"}
+        ],
+    }
+
+
+def test_present_mirror_replaces_content_with_path(tmp_path: pathlib.Path, monkeypatch) -> None:
+    monkeypatch.setattr(retrieval, "BASE_DIR", str(tmp_path))
+    # The mirror file exists on disk (space in the name becomes a dash).
+    write_recall_file(tmp_path, "memory", {"name": "coffee preferences", "description": "d", "content": "No sugar."})
+
+    shaped = retrieval._shape_for_agent(_result())
+
+    file = shaped["files"][0]
+    assert "content" not in file, "a locatable file hands over a path, not its full text"
+    assert "resource_urls" not in file, "the internal link list the instruction never names is dropped"
+    assert file["path"] == str(tmp_path / "memory" / "coffee-preferences.md")
+
+
+def test_missing_mirror_keeps_content_inline(tmp_path: pathlib.Path, monkeypatch) -> None:
+    monkeypatch.setattr(retrieval, "BASE_DIR", str(tmp_path))
+    # No file written: the mirror is gone, so the result must stay self-sufficient.
+    shaped = retrieval._shape_for_agent(_result())
+
+    file = shaped["files"][0]
+    assert file["content"] == "No sugar.", "with no file to open, the text must survive inline"
+    assert file["path"] == str(tmp_path / "memory" / "coffee-preferences.md")
+
+
+def test_segment_source_file_points_at_its_files_path(tmp_path: pathlib.Path, monkeypatch) -> None:
+    monkeypatch.setattr(retrieval, "BASE_DIR", str(tmp_path))
+    shaped = retrieval._shape_for_agent(_result())
+
+    seg = shaped["segments"][0]
+    assert "recall_file_id" not in seg, "the internal UUID must not leak to the agent"
+    assert seg["source_file"] == shaped["files"][0]["path"]
+    # A segment whose file fell out of the result gets no fabricated path.
+    assert shaped["segments"][1]["source_file"] is None
+
+
+def test_resource_collapses_to_single_path(tmp_path: pathlib.Path, monkeypatch) -> None:
+    monkeypatch.setattr(retrieval, "BASE_DIR", str(tmp_path))
+    shaped = retrieval._shape_for_agent(_result())
+
+    res = shaped["resources"][0]
+    assert res["path"] == "notes/onboarding.md"
+    assert "url" not in res and "local_path" not in res


### PR DESCRIPTION
## Why

The per-turn `retrieve` result is what the [standing instruction](../blob/main/src/memu/hosts/instruction.py) teaches the agent to read — files and resources as *a location plus a summary*, segments as narrow slices with clear provenance. The raw store records had drifted from that contract:

1. `files` carried full `content`, burning the agent's context with text it may not want.
2. `segments` exposed the internal `recall_file_id` UUID — opaque and unactionable.
3. `resources` duplicated `url`/`local_path` (always equal, since `commit` is the only writer).

## What

Reshape the result in the host seam (`hosts/retrieval.py`), leaving the app-layer `progressive_retrieve` returning raw records:

- **files**: drop `content` for a `path` to the on-disk mirror (`~/.memu/<track>/<name>.md`). When the mirror is missing (the user owns that tree), keep `content` inline so the result stays self-sufficient — **no dump-on-read**, which would race bridging's `diff_tracked` change detection. Also drop the undocumented `resource_urls` link list.
- **segments**: swap `recall_file_id` for `source_file`, the same `path` the parent file reports — provenance that is human-meaningful and directly openable.
- **resources**: collapse `url`/`local_path` down to a single `path`.

Supporting: extract `recall_file_path` in bridging so the filename convention (spaces→dashes, `.md`) lives in one place shared by the writer and retrieval's path reconstruction; update the standing instruction to name `source_file` and `path`.

## Testing

New `tests/test_host_retrieval.py` pins present-mirror→path, missing-mirror→inline content, segment→source_file, resource→single path, and the `resource_urls` drop. Full suite green (130 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)