### PR TITLE
feat: add cloud-backed memory behind existing CLI

### DIFF
--- a/INSTALL-LATEST.md
+++ b/INSTALL-LATEST.md
@@ -121,7 +121,7 @@ Then print your host's packaged guide and follow it to the letter:
 memu-<your-host> docs install
 ```
 
-It walks you through configuring the store in `~/.memu/config.env`, registering
+It walks you through selecting the local or cloud backend in `~/.memu/config.env`, registering
 the scheduled bridging task, and patching your instruction file, each behind a
 verify gate.
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ memU works with Codex, Claude Code, Cursor, OpenClaw, Hermes, WorkBuddy, and mor
 
 Choose Cloud or Local, then send the corresponding message to your agent.
 
-### Cloud (coming soon)
+### Cloud
 
 **Cross-device · Free · Unlimited · [View online](https://memu.so)**
+
+Cloud setup asks for a memU API key. If you do not have one yet, register at
+[memu.so](https://memu.so) and create one before continuing.
 
 > Read [https://memu.pro/SKILL.md](https://memu.pro/SKILL.md) and follow it to install memU.
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,13 @@ memU runs as a sidecar to a desktop agent (ADR 0008/0009/0010), one binary per h
 
 For agents without a dedicated binary, `memu-agent detect` probes the machine and reports per agent whether **memorization** works (a recognizable session log exists) and whether **retrieval** works (an instruction file exists to patch) — then the same verbs run against what it found.
 
-All hosts share one store and one embedding space via `~/.memu/config.env` — what one host's sessions taught memU, another host retrieves.
+All hosts share one configured memory backend via `~/.memu/config.env` — local
+or MemU Cloud. What one host's sessions taught memU, another host retrieves.
 
-Installation is the one-message setup at the top of this README. [SKILL.md](SKILL.md) is the routing skill it hands your agent: install the package, identify which host you are (falling back to `memu-agent detect` for anything without a dedicated adapter), print that host's packaged install guide (`<binary> docs install`), and follow it — configure the store, register the scheduled bridging task, patch the instruction file, each step behind a verify gate — then report which seams (memorization / retrieval) are now active.
+Installation is the one-message setup at the top of this README. [SKILL.md](SKILL.md) is the routing skill it hands your agent: install the package, identify which host you are (falling back to `memu-agent detect` for anything without a dedicated adapter), print that host's packaged install guide (`<binary> docs install`), and follow it — configure the memory backend, register the scheduled bridging task, patch the instruction file, each step behind a verify gate — then report which seams (memorization / retrieval) are now active.
 
-Afterwards `<binary> doctor` proves the whole loop resolves: config, store, and a live retrieval.
+Afterwards `<binary> doctor` proves the whole loop resolves: config, selected
+mode, and a live retrieval.
 
 Adding another host means implementing one `TranscriptSource` (where its session logs live, how its records are shaped) plus a `HostSpec`-sized CLI — the pipeline, verbs, and instruction text are shared.
 
@@ -107,7 +109,11 @@ uvx --from memu-cli memu     # CLI via uv, no install
 
 ## Configuration
 
-Values resolve in order: process env → `~/.memu/config.env` → default. Every CLI flag has a matching variable:
+Values resolve in order: process env → `~/.memu/config.env` → default. memU
+supports Local and Cloud memory backends, selected by `MEMU_MEMORY_MODE`; an
+unset mode remains Local for backward compatibility.
+
+For Local / self-hosted installations, every CLI flag has a matching variable:
 
 | Setting | Env var | Default |
 |---|---|---|
@@ -116,6 +122,9 @@ Values resolve in order: process env → `~/.memu/config.env` → default. Every
 | API key | `MEMU_API_KEY` | the provider's env var, e.g. `OPENAI_API_KEY` |
 | Embedding model | `MEMU_EMBED_MODEL` | the provider's default |
 | Base URL | `MEMU_BASE_URL` | the provider's default |
+
+Run `<binary> doctor` to display the resolved mode and verify the same retrieval
+path the host uses.
 
 ### Storage backends
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Choose Cloud or Local, then send the corresponding message to your agent.
 Cloud setup asks for a memU API key. If you do not have one yet, register at
 [memu.so](https://memu.so) and create one before continuing.
 
-> Read [https://memu.pro/SKILL.md](https://memu.pro/SKILL.md) and follow it to install memU.
+> Read [https://raw.githubusercontent.com/NevaMind-AI/MemU/main/SKILL.md](https://raw.githubusercontent.com/NevaMind-AI/MemU/main/SKILL.md) and follow it to install memU.
 
 ### Local / self-hosted
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,11 @@ memU works with Codex, Claude Code, Cursor, OpenClaw, Hermes, WorkBuddy, and mor
 
 Choose Cloud or Local, then send the corresponding message to your agent.
 
-### Cloud
+### Cloud (coming soon)
 
 **Cross-device · Free · Unlimited · [View online](https://memu.so)**
 
-Cloud setup asks for a memU API key. If you do not have one yet, register at
-[memu.so](https://memu.so) and create one before continuing.
-
-> Read [https://raw.githubusercontent.com/NevaMind-AI/MemU/main/SKILL.md](https://raw.githubusercontent.com/NevaMind-AI/MemU/main/SKILL.md) and follow it to install memU.
+> Read [https://memu.pro/SKILL.md](https://memu.pro/SKILL.md) and follow it to install memU.
 
 ### Local / self-hosted
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -62,16 +62,15 @@ binary if your host turns out to have one.
 ```
 
 Read what it prints, top to bottom, and follow it exactly. Every guide has the
-same shape — configure the store once in `~/.memu/config.env`, register the
+same shape — select the local or cloud backend once in `~/.memu/config.env`, register the
 scheduled bridging task (record), patch your instruction file (inject) — and
 every part ends with a **verify gate**; do not proceed past a failing one.
 
 Two rules that hold for every host:
 
-- **One store.** If `~/.memu/config.env` already exists (another agent on this
-  machine is already integrated), reuse it as is. A second store would split
-  the embedding space and both installs would silently retrieve nothing from
-  each other.
+- **One backend.** If `~/.memu/config.env` already exists (another agent on this
+  machine is already integrated), reuse it as is. A second mode or local store
+  would split record and retrieval so the two installs no longer share memory.
 - **Report the outcome.** When done, tell the user which seams are now active —
   memorization, retrieval, or both — and where (the session log being mined,
   the instruction file patched). For `memu-agent`, the detect report decides

--- a/docs/adr/0012-cloud-backed-agentic-backend.md
+++ b/docs/adr/0012-cloud-backed-agentic-backend.md
@@ -1,0 +1,107 @@
+ADR 0012: Cloud-Backed Memory Behind the Existing CLI
+
+- Status: Accepted
+- Date: 2026-07-24
+- Builds on: ADR 0008 (two host seams), ADR 0009 (one CLI/config surface)
+- Scope: selecting local or hosted execution for the three agentic memory
+  operations. It does not change `MemoryService`, storage repositories, or the
+  host command surface.
+
+## Context
+
+Every `memu` and `memu-<host>` operation currently constructs a local
+`MemoryService`. That requires a local database plus an embedding provider even
+when the hosted memU service already exposes the same three operations over its
+API-key-authenticated v4 API.
+
+Creating separate cloud binaries would duplicate every host command, retrieval
+instruction, scheduled task, and installation path. Adding HTTP behavior to
+`MemoryService` would instead turn the local composition root into two unrelated
+runtime roles and weaken its embedding-only, storage-pluggable boundary.
+
+## Decision
+
+### One structural capability boundary
+
+`AgenticMemoryBackend` is a structural protocol containing exactly
+`list_all_recall_files`, `progressive_retrieve`, and `commit_results`.
+`MemoryService` already satisfies it and remains the local in-process
+implementation. `CloudMemoryClient` implements it by forwarding requests to:
+
+- `GET /api/v4/memory/`
+- `POST /api/v4/memory/search`
+- `POST /api/v4/memory/`
+
+The cloud client returns successful response dictionaries unchanged. It owns
+Bearer authentication, explicit timeouts, structured cloud errors, and bounded
+retries for transient failures. None of those concerns enter `memu.app`.
+
+### One selector for every caller
+
+`build_agentic_memory_backend_from_env()` is the only backend selector used by
+the main CLI, host retrieval, bridging prepare/commit, and doctor.
+`MEMU_MEMORY_MODE` accepts `local` or `cloud`; absent means `local`, preserving
+existing installs.
+
+Cloud configuration is separate from local embedding configuration:
+
+```env
+MEMU_MEMORY_MODE=cloud
+MEMU_CLOUD_API_KEY=<project-api-key>
+MEMU_CLOUD_BASE_URL=https://api.memu.so/api/v4/memory/
+```
+
+The base URL has the production value above as its default and remains
+overridable for staging or compatible deployments. `MEMU_BASE_URL` and
+`MEMU_API_KEY` keep their existing local-embedding meaning.
+
+The main `memu` CLI retains its local database/embedding flags. They are passed
+as local-mode overrides to the shared selector; cloud mode does not construct a
+local store as a side effect.
+
+### Explicit default owner scope
+
+Cloud requests always send both `user_id` and `agent_id`. Missing, blank, or
+`None` values become the literal `default`. Cloud reads accept only exact
+`user_id` and `agent_id` filters because the public API cannot represent local
+repository operators such as `user_id__in`; unsupported filters fail rather
+than silently widening scope.
+
+### Resource compatibility is visible, not forked
+
+The bridging pipeline remains identical in both modes: it prepares resource
+work and submits `commit_results.resource`. The current cloud API accepts that
+field for wire compatibility but returns an empty `resources` list because it
+does not persist workspace resources yet. Doctor and installation documentation
+state this limitation explicitly; memory and skill recall files are durable.
+
+## Consequences
+
+Positive:
+
+- Existing agent commands, scheduled tasks, and retrieval instructions work in
+  either mode without rewrites.
+- `MemoryService` keeps its three-method public surface and remains free of HTTP
+  and authentication behavior.
+- Cloud credentials cannot be confused with embedding-provider credentials.
+- An old config with no mode keeps its local database and embedding space.
+
+Costs:
+
+- The cloud client has a deliberately narrower `where` vocabulary than a custom
+  local `UserConfig.model`.
+- Resource-description jobs still run in cloud mode even though the service
+  currently does not persist their output. This preserves one bridging
+  pipeline at the cost of temporary redundant work.
+- The project API key may be stored as plaintext in `~/.memu/config.env`; guides
+  require user-only file permissions and process-environment overrides remain
+  available.
+
+## Out of scope
+
+- Dashboard cookie/CSRF APIs
+- OAuth, browser login, or OS keychain integration
+- Local-to-cloud memory migration
+- Cloud resource persistence
+- New CLI binaries
+- Storage protocol, backend, or migration changes

--- a/docs/adr/0012-cloud-backed-agentic-backend.md
+++ b/docs/adr/0012-cloud-backed-agentic-backend.md
@@ -47,13 +47,14 @@ Cloud configuration is separate from local embedding configuration:
 
 ```env
 MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<project-api-key>
+MEMU_CLOUD_API_KEY=<memu-api-key>
 MEMU_CLOUD_BASE_URL=https://api.memu.so/api/v4/memory/
 ```
 
 The base URL has the production value above as its default and remains
-overridable for staging or compatible deployments. `MEMU_BASE_URL` and
-`MEMU_API_KEY` keep their existing local-embedding meaning.
+overridable for compatible deployments. Users obtain a memU API key by
+registering at [memu.so](https://memu.so). `MEMU_BASE_URL` and `MEMU_API_KEY`
+keep their existing local-embedding meaning.
 
 The main `memu` CLI retains its local database/embedding flags. They are passed
 as local-mode overrides to the shared selector; cloud mode does not construct a

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,3 +11,4 @@
 - [0009: Packaging the Codex Integration — pip, a CLI Seam, and One Config Loader](0009-codex-packaging-cli-and-config.md)
 - [0010: Multi-Host Adapters — Claude Code, Cursor, OpenClaw, and Hermes](0010-multi-host-adapters.md)
 - [0011: A Generic Host Adapter — Detect First, Then Bind What Works](0011-generic-host-adapter.md)
+- [0012: Cloud-Backed Memory Behind the Existing CLI](0012-cloud-backed-agentic-backend.md)

--- a/npm/README.md
+++ b/npm/README.md
@@ -28,14 +28,14 @@ npx memu-cli retrieve "deploy checklist"
 
 By default, state persists in a local SQLite database
 (`./data/memu.sqlite3`). Set `MEMU_MEMORY_MODE=cloud` and
-`MEMU_CLOUD_API_KEY=<project-api-key>` to run the same commands through MemU
-Cloud instead; the production API base defaults to
-`https://api.memu.so/api/v4/memory/` and can be overridden with
-`MEMU_CLOUD_BASE_URL` (for example,
-`https://staging-api.memu.so/api/v4/memory/`). Local embedding settings remain
-separate (`MEMU_EMBED_PROVIDER`, `MEMU_EMBED_MODEL`, `MEMU_DB`, ...). Cloud
-currently persists memory and skill recall files but not submitted workspace
-resources. Run `npx memu-cli <command> --help` for the local-mode flags.
+`MEMU_CLOUD_API_KEY=<memu-api-key>` to run the same commands through MemU Cloud
+instead. Register at [memu.so](https://memu.so) to obtain a memU API key. The
+production API base defaults to `https://api.memu.so/api/v4/memory/` and can be
+overridden with `MEMU_CLOUD_BASE_URL` for compatible deployments. Local
+embedding settings remain separate (`MEMU_EMBED_PROVIDER`, `MEMU_EMBED_MODEL`,
+`MEMU_DB`, ...). Cloud currently persists memory and skill recall files but not
+submitted workspace resources. Run `npx memu-cli <command> --help` for the
+local-mode flags.
 
 ## Commands
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -26,7 +26,16 @@ npx memu-cli list-files
 npx memu-cli retrieve "deploy checklist"
 ```
 
-State persists in a local SQLite database (`./data/memu.sqlite3` by default), so commit in one invocation and retrieve in the next. Every flag has a `MEMU_*` environment variable (`--provider`/`MEMU_EMBED_PROVIDER`, `--embed-model`/`MEMU_EMBED_MODEL`, `--db`/`MEMU_DB`, ...) — run `npx memu-cli <command> --help` for the full list.
+By default, state persists in a local SQLite database
+(`./data/memu.sqlite3`). Set `MEMU_MEMORY_MODE=cloud` and
+`MEMU_CLOUD_API_KEY=<project-api-key>` to run the same commands through MemU
+Cloud instead; the production API base defaults to
+`https://api.memu.so/api/v4/memory/` and can be overridden with
+`MEMU_CLOUD_BASE_URL` (for example,
+`https://staging-api.memu.so/api/v4/memory/`). Local embedding settings remain
+separate (`MEMU_EMBED_PROVIDER`, `MEMU_EMBED_MODEL`, `MEMU_DB`, ...). Cloud
+currently persists memory and skill recall files but not submitted workspace
+resources. Run `npx memu-cli <command> --help` for the local-mode flags.
 
 ## Commands
 

--- a/src/memu/agentic_backend.py
+++ b/src/memu/agentic_backend.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class AgenticMemoryBackend(Protocol):
+    """The three memory capabilities consumed by CLIs and host adapters.
+
+    ``MemoryService`` satisfies this protocol structurally for local execution.
+    Remote implementations can provide the same surface without adding transport
+    concerns to the local service composition root.
+    """
+
+    async def list_all_recall_files(
+        self,
+        where: dict[str, Any] | None = None,
+    ) -> dict[str, Any]: ...
+
+    async def progressive_retrieve(
+        self,
+        query: str,
+        where: dict[str, Any] | None = None,
+    ) -> dict[str, Any]: ...
+
+    async def commit_results(
+        self,
+        *,
+        recall_files: list[dict[str, Any]] | None = None,
+        resource: list[dict[str, Any]] | None = None,
+        user: dict[str, Any] | None = None,
+    ) -> dict[str, Any]: ...

--- a/src/memu/cli.py
+++ b/src/memu/cli.py
@@ -1,10 +1,10 @@
 """Command-line interface for memU.
 
-A thin wrapper over :class:`memu.app.MemoryService` exposing the agentic
-surface: ``retrieve`` (progressive, LLM-free), ``list-files``, and ``commit``.
-State persists across invocations through a SQLite database (``--db``, default
-``./data/memu.sqlite3``), so the CLI composes like the library: commit in one
-call, retrieve in the next.
+A thin wrapper over the configured agentic memory backend exposing
+``retrieve`` (progressive, LLM-free), ``list-files``, and ``commit``. Local
+mode persists state through a SQLite database (``--db``, default
+``./data/memu.sqlite3``); cloud mode forwards the same operations to the memU
+v4 API.
 
 Configuration mirrors the library defaults; every flag also reads a ``MEMU_*``
 environment variable so CI/agents can configure once and pass only the command.
@@ -26,7 +26,8 @@ import sys
 from collections.abc import Callable, Coroutine
 from typing import Any
 
-from memu.env import database_config, embedding_provider, env
+from memu.agentic_backend import AgenticMemoryBackend
+from memu.env import build_agentic_memory_backend_from_env, embedding_provider, env
 
 
 def _env(name: str, default: str) -> str:
@@ -36,7 +37,7 @@ def _env(name: str, default: str) -> str:
 
 
 def _add_common_options(parser: argparse.ArgumentParser) -> None:
-    group = parser.add_argument_group("service options (env var in parens)")
+    group = parser.add_argument_group("local service options (env var in parens; ignored in cloud mode)")
     group.add_argument(
         "--provider",
         default=embedding_provider(),
@@ -65,11 +66,7 @@ def _add_common_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--json", action="store_true", help="Print the raw JSON response")
 
 
-def _build_service(args: argparse.Namespace) -> Any:
-    # Imported lazily so `memu --help` stays fast and dependency errors surface
-    # only when a command actually runs.
-    from memu.app import MemoryService
-
+def _build_backend(args: argparse.Namespace) -> AgenticMemoryBackend:
     profile: dict[str, Any] = {"provider": args.provider}
     if args.embed_model:
         profile["embed_model"] = args.embed_model
@@ -77,9 +74,9 @@ def _build_service(args: argparse.Namespace) -> Any:
         profile["base_url"] = args.base_url
     if args.api_key:
         profile["api_key"] = args.api_key
-    return MemoryService(
-        embedding_profiles={"default": profile},
-        database_config=database_config(args.db),
+    return build_agentic_memory_backend_from_env(
+        local_embedding_profile=profile,
+        local_database=args.db,
     )
 
 
@@ -88,15 +85,15 @@ def _print_json(payload: Any) -> None:
 
 
 async def _cmd_retrieve(args: argparse.Namespace) -> int:
-    service = _build_service(args)
-    result = await service.progressive_retrieve(args.query)
+    backend = _build_backend(args)
+    result = await backend.progressive_retrieve(args.query)
     _print_json(result)
     return 0
 
 
 async def _cmd_list_files(args: argparse.Namespace) -> int:
-    service = _build_service(args)
-    result = await service.list_all_recall_files()
+    backend = _build_backend(args)
+    result = await backend.list_all_recall_files()
     if args.json:
         _print_json(result)
         return 0
@@ -116,10 +113,11 @@ async def _cmd_commit(args: argparse.Namespace) -> int:
             print(f"error: no such file: {path}", file=sys.stderr)
             return 2
         payload = json.loads(path.read_text(encoding="utf-8"))
-    service = _build_service(args)
-    result = await service.commit_results(
+    backend = _build_backend(args)
+    result = await backend.commit_results(
         recall_files=payload.get("recall_files"),
         resource=payload.get("resource"),
+        user=payload.get("user"),
     )
     if args.json:
         _print_json(result)

--- a/src/memu/cloud.py
+++ b/src/memu/cloud.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from email.utils import parsedate_to_datetime
+from typing import Any
+
+import httpx
+
+from memu.embedding.http_client import proxy_bypass_mounts
+from memu.env import env
+
+DEFAULT_CLOUD_BASE_URL = "https://api.memu.so/api/v4/memory/"
+DEFAULT_SCOPE = "default"
+
+_RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504}
+_USER_FIELDS = {"user_id", "agent_id", "user_name", "agent_name"}
+_WHERE_FIELDS = {"user_id", "agent_id"}
+
+
+class CloudMemoryError(RuntimeError):
+    """Base error raised by the memU cloud transport."""
+
+    def __init__(self, message: str, *, status_code: int | None = None, code: str | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
+
+
+class CloudClientConfigurationError(ValueError):
+    """Cloud client configuration or argument validation failed."""
+
+    @classmethod
+    def empty_api_key(cls) -> CloudClientConfigurationError:
+        return cls("MEMU_CLOUD_API_KEY must not be empty")
+
+    @classmethod
+    def invalid_attempts(cls) -> CloudClientConfigurationError:
+        return cls("max_attempts must be at least 1")
+
+    @classmethod
+    def unsupported_where(cls, fields: list[str]) -> CloudClientConfigurationError:
+        joined = ", ".join(fields)
+        return cls(
+            f"Cloud memory only supports exact user_id and agent_id filters; unsupported where field(s): {joined}"
+        )
+
+    @classmethod
+    def unsupported_user(cls, fields: list[str]) -> CloudClientConfigurationError:
+        joined = ", ".join(fields)
+        return cls(f"Cloud memory does not support user field(s): {joined}")
+
+
+class CloudAuthenticationError(CloudMemoryError):
+    """The project API key is absent or invalid."""
+
+
+class CloudAuthorizationError(CloudMemoryError):
+    """The project API key cannot perform the requested operation."""
+
+
+class CloudValidationError(CloudMemoryError):
+    """The cloud API rejected the request payload or query."""
+
+
+class CloudRateLimitError(CloudMemoryError):
+    """The cloud API remained rate-limited after safe retries."""
+
+
+class CloudTransportError(CloudMemoryError):
+    """The cloud API could not be reached."""
+
+    @classmethod
+    def from_transport(cls, exc: Exception) -> CloudTransportError:
+        return cls(f"memU cloud transport failed: {exc}")
+
+
+class CloudServiceError(CloudMemoryError):
+    """The cloud API returned an unexpected failure response."""
+
+    @classmethod
+    def invalid_json(cls, status_code: int) -> CloudServiceError:
+        return cls(f"memU cloud returned invalid JSON ({status_code})", status_code=status_code)
+
+    @classmethod
+    def unexpected_shape(cls, status_code: int) -> CloudServiceError:
+        return cls(f"memU cloud returned an unexpected response shape ({status_code})", status_code=status_code)
+
+    @classmethod
+    def unreachable_retry_state(cls) -> CloudServiceError:
+        return cls("cloud request retry loop exited unexpectedly")
+
+
+class CloudMemoryClient:
+    """HTTP implementation of the three agentic memory operations."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str = DEFAULT_CLOUD_BASE_URL,
+        api_key: str,
+        timeout: httpx.Timeout | None = None,
+        max_attempts: int = 3,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        if not api_key.strip():
+            raise CloudClientConfigurationError.empty_api_key()
+        if max_attempts < 1:
+            raise CloudClientConfigurationError.invalid_attempts()
+        self.base_url = base_url.rstrip("/") + "/"
+        self.api_key = api_key
+        self.timeout = timeout or httpx.Timeout(30.0, connect=5.0)
+        self.max_attempts = max_attempts
+        self.transport = transport
+
+    async def list_all_recall_files(
+        self,
+        where: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return await self._request("GET", "", params=self._scope(where))
+
+    async def progressive_retrieve(
+        self,
+        query: str,
+        where: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"query": query, **self._scope(where)}
+        return await self._request("POST", "search", json=payload)
+
+    async def commit_results(
+        self,
+        *,
+        recall_files: list[dict[str, Any]] | None = None,
+        resource: list[dict[str, Any]] | None = None,
+        user: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        payload = {
+            "user": self._user(user),
+            "recall_files": recall_files or [],
+            "resource": resource or [],
+        }
+        return await self._request("POST", "", json=payload)
+
+    @staticmethod
+    def _scope(where: Mapping[str, Any] | None) -> dict[str, str]:
+        values = dict(where or {})
+        unsupported = sorted(set(values) - _WHERE_FIELDS)
+        if unsupported:
+            raise CloudClientConfigurationError.unsupported_where(unsupported)
+        return {
+            "user_id": CloudMemoryClient._scope_value(values.get("user_id")),
+            "agent_id": CloudMemoryClient._scope_value(values.get("agent_id")),
+        }
+
+    @staticmethod
+    def _scope_value(value: Any) -> str:
+        if value is None:
+            return DEFAULT_SCOPE
+        resolved = str(value).strip()
+        return resolved or DEFAULT_SCOPE
+
+    @staticmethod
+    def _user(user: Mapping[str, Any] | None) -> dict[str, Any]:
+        values = dict(user or {})
+        unsupported = sorted(set(values) - _USER_FIELDS)
+        if unsupported:
+            raise CloudClientConfigurationError.unsupported_user(unsupported)
+        payload: dict[str, Any] = {
+            "user_id": CloudMemoryClient._scope_value(values.get("user_id")),
+            "agent_id": CloudMemoryClient._scope_value(values.get("agent_id")),
+        }
+        for field in ("user_name", "agent_name"):
+            if field in values:
+                payload[field] = values[field]
+        return payload
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, str] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        explicit_proxy = env("MEMU_HTTP_PROXY") or None
+        mounts = proxy_bypass_mounts(self.base_url) if explicit_proxy is None else None
+        client_kwargs: dict[str, Any] = {
+            "base_url": self.base_url,
+            "timeout": self.timeout,
+            "headers": headers,
+            "transport": self.transport,
+            "trust_env": self.transport is None,
+            "follow_redirects": True,
+        }
+        if self.transport is None:
+            client_kwargs["proxy"] = explicit_proxy
+            client_kwargs["mounts"] = mounts
+
+        # httpx normalizes ``base_url`` to a trailing slash for relative URL
+        # joining, while the public collection route is slashless. The service
+        # returns 404 (not a redirect) for ``/api/v4/memory/``, so root
+        # operations must use the absolute collection URL without that slash.
+        request_target = endpoint or self.base_url.rstrip("/")
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            for attempt in range(1, self.max_attempts + 1):
+                try:
+                    response = await client.request(method, request_target, params=params, json=json)
+                except (httpx.TimeoutException, httpx.TransportError) as exc:
+                    if attempt < self.max_attempts:
+                        await asyncio.sleep(self._retry_delay(attempt))
+                        continue
+                    raise CloudTransportError.from_transport(exc) from exc
+
+                if response.status_code in _RETRYABLE_STATUS_CODES and attempt < self.max_attempts:
+                    await asyncio.sleep(self._retry_delay(attempt, response))
+                    continue
+                if response.is_error:
+                    raise self._response_error(response)
+                try:
+                    data = response.json()
+                except ValueError as exc:
+                    raise CloudServiceError.invalid_json(response.status_code) from exc
+                if not isinstance(data, dict):
+                    raise CloudServiceError.unexpected_shape(response.status_code)
+                return data
+
+        raise CloudServiceError.unreachable_retry_state()
+
+    @staticmethod
+    def _retry_delay(attempt: int, response: httpx.Response | None = None) -> float:
+        if response is not None:
+            retry_after = response.headers.get("Retry-After")
+            if retry_after:
+                try:
+                    return min(max(float(retry_after), 0.0), 30.0)
+                except ValueError:
+                    try:
+                        retry_at = parsedate_to_datetime(retry_after)
+                        now = parsedate_to_datetime(response.headers.get("Date", ""))
+                        return float(min(max((retry_at - now).total_seconds(), 0.0), 30.0))
+                    except (TypeError, ValueError, OverflowError):
+                        pass
+        return float(min(0.25 * (2 ** (attempt - 1)), 2.0))
+
+    @staticmethod
+    def _response_error(response: httpx.Response) -> CloudMemoryError:
+        message, code = CloudMemoryClient._error_details(response)
+        error_type, label = CloudMemoryClient._error_category(response.status_code)
+        suffix = f" [{code}]" if code else ""
+        return error_type(
+            f"memU cloud {label} ({response.status_code}): {message}{suffix}",
+            status_code=response.status_code,
+            code=code,
+        )
+
+    @staticmethod
+    def _error_details(response: httpx.Response) -> tuple[str, str | None]:
+        message = response.reason_phrase or "request failed"
+        code: str | None = None
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = None
+        if isinstance(payload, dict):
+            if isinstance(payload.get("message"), str) and payload["message"].strip():
+                message = payload["message"].strip()
+            details = payload.get("details")
+            if isinstance(details, list):
+                for detail in details:
+                    if isinstance(detail, dict) and isinstance(detail.get("code"), str):
+                        code = detail["code"]
+                        break
+        return message, code
+
+    @staticmethod
+    def _error_category(status: int) -> tuple[type[CloudMemoryError], str]:
+        if status == 401:
+            return CloudAuthenticationError, "authentication failed"
+        if status == 403:
+            return CloudAuthorizationError, "authorization failed"
+        if status in {400, 409, 422}:
+            return CloudValidationError, "request rejected"
+        if status == 429:
+            return CloudRateLimitError, "rate limit exceeded"
+        return CloudServiceError, "service request failed"

--- a/src/memu/env.py
+++ b/src/memu/env.py
@@ -1,11 +1,12 @@
 """Shared ``MEMU_*`` configuration — one loader, every entrypoint.
 
 The ``memu`` CLI, the ``memu-<host>`` adapters, and the bridging pipeline all
-construct their :class:`~memu.app.MemoryService` here. That sharing is not
-tidiness: the *record* seam (bridging writes) and the *inject* seam (retrieval
-reads) must agree on the DSN **and** the embedding provider, or a query is
-embedded in one space and compared against vectors written in another — the
-comparison is meaningless and retrieval silently returns nothing (ADR 0009).
+select their agentic backend here. That sharing is not tidiness: the *record*
+seam (bridging writes) and the *inject* seam (retrieval reads) must agree on
+local versus cloud execution. In local mode they must also agree on the DSN
+**and** embedding provider, or a query is embedded in one space and compared
+against vectors written in another — the comparison is meaningless and
+retrieval silently returns nothing (ADR 0009/0012).
 
 Values resolve in this order:
 
@@ -28,7 +29,10 @@ from __future__ import annotations
 import os
 from functools import cache
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from memu.agentic_backend import AgenticMemoryBackend
 
 CONFIG_ENV = "~/.memu/config.env"
 """Where install persists the collected values. Override with ``MEMU_CONFIG_ENV``."""
@@ -37,7 +41,10 @@ CONFIG_ENV = "~/.memu/config.env"
 class ConfigError(RuntimeError):
     """Required ``MEMU_*`` configuration is absent or unusable."""
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, detail: str | None = None) -> None:
+        if detail is not None:
+            super().__init__(f"{name}: {detail}")
+            return
         super().__init__(
             f"{name} is not set. Add it to {CONFIG_ENV} (or export it). Refusing to fall back to a "
             f"default: record and retrieval must use the same store, or retrieval finds nothing."
@@ -131,6 +138,66 @@ def embedding_profile() -> dict[str, Any]:
         if value := env(var):
             profile[key] = value
     return profile
+
+
+MemoryMode = Literal["local", "cloud"]
+
+
+def memory_mode() -> MemoryMode:
+    """Resolve the execution backend, defaulting to local for compatibility."""
+    value = (env("MEMU_MEMORY_MODE", "local") or "local").strip().lower()
+    if value == "local":
+        return "local"
+    if value == "cloud":
+        return "cloud"
+    raise ConfigError("MEMU_MEMORY_MODE", "must be either 'local' or 'cloud'")
+
+
+def cloud_base_url() -> str:
+    """The full v4 memory API base URL, including ``/api/v4/memory/``."""
+    from memu.cloud import DEFAULT_CLOUD_BASE_URL
+
+    return env("MEMU_CLOUD_BASE_URL", DEFAULT_CLOUD_BASE_URL) or DEFAULT_CLOUD_BASE_URL
+
+
+def cloud_api_key() -> str:
+    """Resolve the project API key without reusing local embedding credentials."""
+    value = env("MEMU_CLOUD_API_KEY")
+    if not value:
+        raise ConfigError(
+            "MEMU_CLOUD_API_KEY",
+            f"is required in cloud mode. Add it to {CONFIG_ENV} (or export it)",
+        )
+    return value
+
+
+def build_agentic_memory_backend_from_env(
+    *,
+    local_database: str | None = None,
+    local_embedding_profile: dict[str, Any] | None = None,
+) -> AgenticMemoryBackend:
+    """Build the configured local service or cloud client through one selector.
+
+    ``memu`` passes its existing local CLI flag overrides. Host adapters pass no
+    overrides and therefore require the install-time ``MEMU_DB`` configuration
+    in local mode. Cloud mode ignores local-only overrides.
+    """
+    if memory_mode() == "cloud":
+        from memu.cloud import CloudMemoryClient
+
+        return CloudMemoryClient(
+            base_url=cloud_base_url(),
+            api_key=cloud_api_key(),
+        )
+
+    from memu.app import MemoryService
+
+    resolved_database = database_config(local_database if local_database is not None else require("MEMU_DB"))
+    resolved_embedding = local_embedding_profile if local_embedding_profile is not None else embedding_profile()
+    return MemoryService(
+        embedding_profiles={"default": resolved_embedding},
+        database_config=resolved_database,
+    )
 
 
 def build_service_from_env() -> Any:

--- a/src/memu/hosts/bridging/pipeline.py
+++ b/src/memu/hosts/bridging/pipeline.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from memu.env import build_service_from_env
+from memu.env import build_agentic_memory_backend_from_env
 from memu.hosts.base import TranscriptSource
 from memu.hosts.bridging.instructions import prepare_instruction_jobs
 from memu.hosts.bridging.layout import TRACK_DIRS, Layout
@@ -52,8 +52,8 @@ async def prepare(
     # "state as of the last commit". Re-snapshotting on every prepare would
     # absorb files a crashed run wrote but never committed, making them
     # undiffable — and therefore uncommittable — forever.
-    service = build_service_from_env()
-    result = await service.list_all_recall_files()
+    backend = build_agentic_memory_backend_from_env()
+    result = await backend.list_all_recall_files()
     for recall_file in result["categories"]:
         subdir = TRACK_DIRS.get(recall_file.get("track"))
         if subdir is None:
@@ -100,8 +100,8 @@ async def commit(layout: Layout) -> dict[str, Any]:
     recall_files = [read_recall_file(path, subdir_track[path.relative_to(layout.base).parts[0]]) for path in changed]
     resources = read_resources(layout.resources)
 
-    service = build_service_from_env()
-    result: dict[str, Any] = await service.commit_results(recall_files=recall_files, resource=resources)
+    backend = build_agentic_memory_backend_from_env()
+    result: dict[str, Any] = await backend.commit_results(recall_files=recall_files, resource=resources)
 
     snapshot_tracked(layout.base, layout.track_dirs, layout.memory_manifest)
     pending = layout.session_manifest_pending

--- a/src/memu/hosts/claude_code/BRIDGING_TASK.md
+++ b/src/memu/hosts/claude_code/BRIDGING_TASK.md
@@ -1,14 +1,18 @@
 ---
 name: create-memu-bridging-task
-description: Register a scheduled job that bridges the agent's recent Claude Code sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
+description: Register a scheduled job that bridges recent Claude Code sessions into memU memory, skills, and resource submissions. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
 ---
 
 # Create the memU bridging scheduled task (Claude Code)
 
 Use this when the user asks to **set up (or change) the recurring memU
 "bridging" task** — the job that periodically turns what the agent recently did
-in its Claude Code sessions into durable memU memory files, skills, and resource
-records.
+in its Claude Code sessions into memU memory files, skills, and resource
+submissions.
+
+Memory and skills are durable in both modes. In cloud mode, the current service
+accepts workspace resources from this unchanged pipeline but does not persist or
+retrieve them yet.
 
 Your goal is to **register a recurring headless Claude Code run** whose prompt is
 the three-step pipeline below. You are not running the pipeline now; you are
@@ -112,7 +116,7 @@ work to do once there are new Claude Code sessions since the last run.
 - **The working tree is host-scoped.** Everything under
   `~/.memu/hosts/claude-code/` is this adapter's run-scoped working state; other
   memU host adapters (Codex, Cursor, …) have their own and never race with this
-  one. The durable store they all share is the `MEMU_DB` in
-  `~/.memu/config.env`.
+  one. The durable backend they all share is selected by `MEMU_MEMORY_MODE` in
+  `~/.memu/config.env`; local mode uses the `MEMU_DB` there.
 - **Failure handling.** Steps 1 and 3 are the only failure points that should
   abort the run. A single "do nothing" job in step 2 is normal, not an error.

--- a/src/memu/hosts/claude_code/INSTALL.md
+++ b/src/memu/hosts/claude_code/INSTALL.md
@@ -54,7 +54,7 @@ local mode for backward compatibility.
 
 Otherwise ask the user to choose once:
 
-- **MemU Cloud** — memory and embeddings are hosted; requires a memU project API key.
+- **MemU Cloud** — memory and embeddings are hosted; requires a memU API key.
 - **This device** — use the existing local database and embedding configuration.
 
 For **MemU Cloud**, ask the user to provide their memU API key. If they do not

--- a/src/memu/hosts/claude_code/INSTALL.md
+++ b/src/memu/hosts/claude_code/INSTALL.md
@@ -9,15 +9,15 @@
 
 Installing memU on Claude Code is three parts:
 
-1. **Install memU** — a Python package, and the store + provider it writes to.
+1. **Install memU** — a Python package and the memory backend it uses.
 2. **Register the bridging task** — the scheduled job that turns recent Claude
    Code sessions into durable memory (the *record* seam).
 3. **Patch `~/.claude/CLAUDE.md`** — a standing instruction that tells you to pull
    relevant memory before you answer (the *inject* seam).
 
-Parts 2 and 3 must share one store and one embedding space, or a query is
-compared against vectors written elsewhere and retrieval silently returns
-nothing. Part 1 is what makes them agree.
+Parts 2 and 3 must share one configured mode. In local mode they must also share
+one store and embedding space, or retrieval silently returns nothing. Part 1 is
+what makes them agree.
 
 ---
 
@@ -46,13 +46,40 @@ If it is not found, the install landed in an environment that isn't on your
 `PATH`. Fix that now — the scheduled task in Part 2 runs from a bare,
 non-interactive environment and needs this command to resolve there.
 
-### 1.2 Configure the store and provider
+### 1.2 Configure the memory backend
 
-memU needs a **database** and an **LLM/embedding provider**. Both seams read this
-one config, so decide it once, here. Collect from the user (or reuse values they
-already have — if another memU host adapter such as `memu-codex` is already set
-up on this machine, `~/.memu/config.env` exists and **must be reused as is**;
-skip to the verify gate):
+If `~/.memu/config.env` already exists from another memU host, reuse it as is
+and skip to the verify gate. An existing file without `MEMU_MEMORY_MODE` is
+local mode for backward compatibility.
+
+Otherwise ask the user to choose once:
+
+- **MemU Cloud** — memory and embeddings are hosted; collect a project API key.
+- **This device** — use the existing local database and embedding configuration.
+
+For **MemU Cloud**, write:
+
+```env
+MEMU_MEMORY_MODE=cloud
+MEMU_CLOUD_API_KEY=<project-api-key>
+```
+
+The production endpoint defaults to
+`https://api.memu.so/api/v4/memory/`. Set
+`MEMU_CLOUD_BASE_URL=https://staging-api.memu.so/api/v4/memory/` only when the
+user explicitly wants staging. The key is plaintext in this file: tell the user
+and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
+the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
+for local embedding providers.
+
+Cloud currently persists memory and skill recall files. It accepts workspace
+resources from the existing bridging pipeline for compatibility but does not
+persist or retrieve them yet; tell the user. After writing cloud configuration,
+skip the remaining local-mode guidance and go to the verify gate.
+
+For **This device**, write `MEMU_MEMORY_MODE=local` and collect the settings
+below. "This device" describes memory storage; it is fully offline only when
+the embedding provider is local too:
 
 | Setting | Env var | Example |
 | --- | --- | --- |
@@ -60,7 +87,7 @@ skip to the verify gate):
 | Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
 | API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
 
-**No `MEMU_API_KEY`? Say so, then go local.** If the user has no API key to
+**No embedding `MEMU_API_KEY`? Say so, then use a local embedding server.** If the user has no API key to
 give, tell them up front what that means: memory cannot be called across
 devices — everything stays on this machine, in a local database created for
 them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
@@ -104,7 +131,7 @@ and ask the user.
 memu-claude-code doctor
 ```
 
-It prints the store and provider it resolved and runs a smoke-test retrieval. It
+It prints the resolved mode plus its endpoint or local store/provider, and runs a smoke-test retrieval. It
 must exit cleanly. **Zero hits is the expected result** on a new store.
 
 ---
@@ -112,7 +139,8 @@ must exit cleanly. **Zero hits is the expected result** on a new store.
 ## Part 2 — Register the bridging (record) task
 
 The *record* seam: a scheduled job that periodically mines recent sessions under
-`~/.claude/projects` into durable memU memory, skills, and resources.
+`~/.claude/projects` into memU memory, skills, and resources. In cloud mode,
+workspace resources are submitted but are not currently persisted.
 
 **Do not reinvent this.** Follow the packaged procedure:
 
@@ -191,7 +219,7 @@ neither is in your own context yet.
 
 ## Done
 
-Report back to the user: the store (`MEMU_DB`) and provider in use; the scheduled
+Report back to the user: the selected mode and its cloud endpoint or local store/provider; the scheduled
 job and its schedule in words; and that the retrieval instruction is now in
 `~/.claude/CLAUDE.md`, pointing at the `memu-retrieve` skill and taking effect in
-their next session. Record and inject both read `~/.memu/config.env`, so they provably share one store — what the task learns tonight is what retrieval finds tomorrow.
+their next session. Record and inject both read `~/.memu/config.env`, so they provably share one backend — what the task learns tonight is what retrieval finds tomorrow.

--- a/src/memu/hosts/claude_code/INSTALL.md
+++ b/src/memu/hosts/claude_code/INSTALL.md
@@ -54,20 +54,20 @@ local mode for backward compatibility.
 
 Otherwise ask the user to choose once:
 
-- **MemU Cloud** — memory and embeddings are hosted; collect a project API key.
+- **MemU Cloud** — memory and embeddings are hosted; requires a memU project API key.
 - **This device** — use the existing local database and embedding configuration.
 
-For **MemU Cloud**, write:
+For **MemU Cloud**, ask the user to provide their memU API key. If they do not
+have one, direct them to [memu.so](https://memu.so) to register and create one,
+then wait for the key before continuing. Write:
 
 ```env
 MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<project-api-key>
+MEMU_CLOUD_API_KEY=<memu-api-key>
 ```
 
-The production endpoint defaults to
-`https://api.memu.so/api/v4/memory/`. Set
-`MEMU_CLOUD_BASE_URL=https://staging-api.memu.so/api/v4/memory/` only when the
-user explicitly wants staging. The key is plaintext in this file: tell the user
+The production endpoint defaults to `https://api.memu.so/api/v4/memory/`. The
+key is plaintext in this file: tell the user
 and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
 the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
 for local embedding providers.

--- a/src/memu/hosts/codex/BRIDGING_TASK.md
+++ b/src/memu/hosts/codex/BRIDGING_TASK.md
@@ -1,13 +1,17 @@
 ---
 name: create-memu-bridging-task
-description: Create a Codex scheduled task that bridges the agent's recent Codex sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
+description: Create a Codex scheduled task that bridges recent Codex sessions into memU memory, skills, and resource submissions. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
 ---
 
 # Create the memU bridging scheduled task
 
 Use this when the user asks to **set up (or change) the recurring memU "bridging"
 task** — the job that periodically turns what the agent recently did in its Codex
-sessions into durable memU memory files, skills, and resource records.
+sessions into memU memory files, skills, and resource submissions.
+
+Memory and skills are durable in both modes. In cloud mode, the current service
+accepts workspace resources from this unchanged pipeline but does not persist or
+retrieve them yet.
 
 Your goal is to **create a Codex scheduled task** whose recurring prompt runs the
 three-step pipeline below. You are not running the pipeline now; you are
@@ -48,7 +52,7 @@ instruct the agent to do it, not shell out to a script.
   memu-codex doctor
   ```
 
-  It prints the store and provider in use and runs a smoke-test retrieval. If it
+  It prints the selected mode and endpoint or local store/provider, then runs a smoke-test retrieval. If it
   fails, stop — do `INSTALL.md` Part 1 first. Do not proceed with a broken store:
   the task would happily run and write nowhere useful.
 

--- a/src/memu/hosts/codex/INSTALL.md
+++ b/src/memu/hosts/codex/INSTALL.md
@@ -59,7 +59,7 @@ local mode for backward compatibility.
 
 Otherwise ask the user to choose once:
 
-- **MemU Cloud** — memory and embeddings are hosted; requires a memU project API key.
+- **MemU Cloud** — memory and embeddings are hosted; requires a memU API key.
 - **This device** — use the existing local database and embedding configuration.
 
 For **MemU Cloud**, ask the user to provide their memU API key. If they do not

--- a/src/memu/hosts/codex/INSTALL.md
+++ b/src/memu/hosts/codex/INSTALL.md
@@ -9,15 +9,15 @@
 
 Installing memU on Codex is three parts:
 
-1. **Install memU** — a Python package, and the store + provider it writes to.
+1. **Install memU** — a Python package and the memory backend it uses.
 2. **Register the bridging task** — the scheduled job that turns recent Codex
    sessions into durable memory (the *record* seam).
 3. **Patch `~/.codex/AGENTS.md`** — a standing instruction that tells you to pull
    relevant memory before you answer (the *inject* seam).
 
-Parts 2 and 3 must share one store and one embedding space, or a query is
-compared against vectors written elsewhere and retrieval silently returns
-nothing. Part 1 is what makes them agree.
+Parts 2 and 3 must share one configured mode. In local mode they must also share
+one store and embedding space, or retrieval silently returns nothing. Part 1 is
+what makes them agree.
 
 ---
 
@@ -51,12 +51,40 @@ If it is not found, the install landed in an environment that isn't on your
 and the hook in Part 3 both need this command to resolve from a bare, non-
 interactive environment.
 
-### 1.2 Configure the store and provider
+### 1.2 Configure the memory backend
 
-memU needs a **database** and an **LLM/embedding provider**. Both seams read this
-one config, so decide it once, here.
+If `~/.memu/config.env` already exists from another memU host, reuse it as is
+and skip to the verify gate. An existing file without `MEMU_MEMORY_MODE` is
+local mode for backward compatibility.
 
-Collect from the user (or reuse values they already have):
+Otherwise ask the user to choose once:
+
+- **MemU Cloud** — memory and embeddings are hosted; collect a project API key.
+- **This device** — use the existing local database and embedding configuration.
+
+For **MemU Cloud**, write:
+
+```env
+MEMU_MEMORY_MODE=cloud
+MEMU_CLOUD_API_KEY=<project-api-key>
+```
+
+The production endpoint defaults to
+`https://api.memu.so/api/v4/memory/`. Set
+`MEMU_CLOUD_BASE_URL=https://staging-api.memu.so/api/v4/memory/` only when the
+user explicitly wants staging. The key is plaintext in this file: tell the user
+and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
+the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
+for local embedding providers.
+
+Cloud currently persists memory and skill recall files. It accepts workspace
+resources from the existing bridging pipeline for compatibility but does not
+persist or retrieve them yet; tell the user. After writing cloud configuration,
+skip the remaining local-mode guidance and go to the verify gate.
+
+For **This device**, write `MEMU_MEMORY_MODE=local` and collect the settings
+below. "This device" describes memory storage; it is fully offline only when
+the embedding provider is local too:
 
 | Setting | Env var | Example |
 | --- | --- | --- |
@@ -64,7 +92,7 @@ Collect from the user (or reuse values they already have):
 | Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
 | API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
 
-**No `MEMU_API_KEY`? Say so, then go local.** If the user has no API key to
+**No embedding `MEMU_API_KEY`? Say so, then use a local embedding server.** If the user has no API key to
 give, tell them up front what that means: memory cannot be called across
 devices — everything stays on this machine, in a local database created for
 them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
@@ -93,6 +121,7 @@ Write them to **`~/.memu/config.env`**, which every memU command loads:
 
 ```
 MEMU_DB=/Users/<you>/.memu/memu.sqlite3
+MEMU_MEMORY_MODE=local
 MEMU_EMBED_PROVIDER=openai
 MEMU_API_KEY=<key or env-var name>
 ```
@@ -125,7 +154,7 @@ and ask the user.
 memu-codex doctor
 ```
 
-It prints the store and provider it resolved and runs a smoke-test retrieval. It
+It prints the resolved mode plus its endpoint or local store/provider, and runs a smoke-test retrieval. It
 must exit cleanly. **Zero hits is the expected result** — the store is new; you
 are testing that config resolves and the store answers, not that it has content.
 
@@ -137,7 +166,8 @@ on this working, and both fail *silently* if it is wrong.
 ## Part 2 — Register the bridging (record) task
 
 The *record* seam: a Codex scheduled task that periodically mines recent
-`~/.codex/sessions` into durable memU memory, skills, and resources.
+`~/.codex/sessions` into memU memory, skills, and resources. In cloud mode,
+workspace resources are submitted but are not currently persisted.
 
 **Do not reinvent this.** Follow the packaged procedure:
 
@@ -251,11 +281,11 @@ do not be surprised that the instruction is not in your own context yet.
 
 Report back to the user:
 
-- the store (`MEMU_DB`) and provider now in use;
+- the selected mode and its cloud endpoint or local store/provider;
 - the scheduled task's name and cron, in words (e.g. "daily at 00:00 local");
 - that the retrieval instruction is now in `~/.codex/AGENTS.md`, pointing at the
   `memu-retrieve` skill, and that it takes effect in their next Codex session.
 
 Record (Part 2) and inject (Part 3) both read `~/.memu/config.env`, so they
-provably share the store you configured in Part 1 — what the task learns tonight
+provably share the backend configured in Part 1 — what the task learns tonight
 is what retrieval finds tomorrow.

--- a/src/memu/hosts/codex/INSTALL.md
+++ b/src/memu/hosts/codex/INSTALL.md
@@ -59,20 +59,20 @@ local mode for backward compatibility.
 
 Otherwise ask the user to choose once:
 
-- **MemU Cloud** — memory and embeddings are hosted; collect a project API key.
+- **MemU Cloud** — memory and embeddings are hosted; requires a memU project API key.
 - **This device** — use the existing local database and embedding configuration.
 
-For **MemU Cloud**, write:
+For **MemU Cloud**, ask the user to provide their memU API key. If they do not
+have one, direct them to [memu.so](https://memu.so) to register and create one,
+then wait for the key before continuing. Write:
 
 ```env
 MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<project-api-key>
+MEMU_CLOUD_API_KEY=<memu-api-key>
 ```
 
-The production endpoint defaults to
-`https://api.memu.so/api/v4/memory/`. Set
-`MEMU_CLOUD_BASE_URL=https://staging-api.memu.so/api/v4/memory/` only when the
-user explicitly wants staging. The key is plaintext in this file: tell the user
+The production endpoint defaults to `https://api.memu.so/api/v4/memory/`. The
+key is plaintext in this file: tell the user
 and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
 the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
 for local embedding providers.

--- a/src/memu/hosts/cursor/BRIDGING_TASK.md
+++ b/src/memu/hosts/cursor/BRIDGING_TASK.md
@@ -1,14 +1,18 @@
 ---
 name: create-memu-bridging-task
-description: Register a scheduled job that bridges the agent's recent Cursor agent sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
+description: Register a scheduled job that bridges recent Cursor agent sessions into memU memory, skills, and resource submissions. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
 ---
 
 # Create the memU bridging scheduled task (Cursor)
 
 Use this when the user asks to **set up (or change) the recurring memU
 "bridging" task** — the job that periodically turns what the agent recently did
-in its Cursor agent sessions into durable memU memory files, skills, and
-resource records.
+in its Cursor agent sessions into memU memory files, skills, and resource
+submissions.
+
+Memory and skills are durable in both modes. In cloud mode, the current service
+accepts workspace resources from this unchanged pipeline but does not persist or
+retrieve them yet.
 
 Your goal is to **register a recurring headless Cursor agent run** whose prompt
 is the three-step pipeline below. You are not running the pipeline now.
@@ -106,7 +110,8 @@ since the last run.
   resource-describe job last. Always ascending numeric order.
 - **The working tree is host-scoped.** Everything under `~/.memu/hosts/cursor/`
   is this adapter's run-scoped working state; other memU host adapters never
-  race with it. The durable store they all share is the `MEMU_DB` in
-  `~/.memu/config.env`.
+  race with it. The durable backend they all share is selected by
+  `MEMU_MEMORY_MODE` in `~/.memu/config.env`; local mode uses the `MEMU_DB`
+  there.
 - **Failure handling.** Steps 1 and 3 are the only failure points that should
   abort the run. A "do nothing" job in step 2 is normal, not an error.

--- a/src/memu/hosts/cursor/INSTALL.md
+++ b/src/memu/hosts/cursor/INSTALL.md
@@ -9,15 +9,15 @@
 
 Installing memU on Cursor is three parts:
 
-1. **Install memU** — a Python package, and the store + provider it writes to.
+1. **Install memU** — a Python package and the memory backend it uses.
 2. **Register the bridging task** — the scheduled job that turns recent Cursor
    agent sessions into durable memory (the *record* seam).
 3. **Patch `AGENTS.md`** — a standing instruction that tells the agent to pull
    relevant memory before answering (the *inject* seam).
 
-Parts 2 and 3 must share one store and one embedding space, or a query is
-compared against vectors written elsewhere and retrieval silently returns
-nothing. Part 1 is what makes them agree.
+Parts 2 and 3 must share one configured mode. In local mode they must also share
+one store and embedding space, or retrieval silently returns nothing. Part 1 is
+what makes them agree.
 
 **Scope note.** This adapter reads the **Cursor Agent** transcripts under
 `~/.cursor/projects/` — the CLI (`cursor-agent`) and background agents. The IDE's
@@ -36,12 +36,40 @@ This puts `memu` and **`memu-cursor`** on `PATH`. Confirm: `memu-cursor --help`.
 If it is not found, fix `PATH` now — the scheduled task in Part 2 runs from a
 bare, non-interactive environment.
 
-### 1.2 Configure the store and provider
+### 1.2 Configure the memory backend
 
-memU needs a **database** and an **LLM/embedding provider**. Both seams read this
-one config. If another memU host adapter is already set up on this machine,
-`~/.memu/config.env` exists and **must be reused as is**; skip to the verify
-gate. Otherwise collect from the user:
+If `~/.memu/config.env` already exists from another memU host, reuse it as is
+and skip to the verify gate. An existing file without `MEMU_MEMORY_MODE` is
+local mode for backward compatibility.
+
+Otherwise ask the user to choose once:
+
+- **MemU Cloud** — memory and embeddings are hosted; collect a project API key.
+- **This device** — use the existing local database and embedding configuration.
+
+For **MemU Cloud**, write:
+
+```env
+MEMU_MEMORY_MODE=cloud
+MEMU_CLOUD_API_KEY=<project-api-key>
+```
+
+The production endpoint defaults to
+`https://api.memu.so/api/v4/memory/`. Set
+`MEMU_CLOUD_BASE_URL=https://staging-api.memu.so/api/v4/memory/` only when the
+user explicitly wants staging. The key is plaintext in this file: tell the user
+and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
+the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
+for local embedding providers.
+
+Cloud currently persists memory and skill recall files. It accepts workspace
+resources from the existing bridging pipeline for compatibility but does not
+persist or retrieve them yet; tell the user. After writing cloud configuration,
+skip the remaining local-mode guidance and go to the verify gate.
+
+For **This device**, write `MEMU_MEMORY_MODE=local` and collect the settings
+below. "This device" describes memory storage; it is fully offline only when
+the embedding provider is local too:
 
 | Setting | Env var | Example |
 | --- | --- | --- |
@@ -49,7 +77,7 @@ gate. Otherwise collect from the user:
 | Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
 | API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
 
-**No `MEMU_API_KEY`? Say so, then go local.** If the user has no API key to
+**No embedding `MEMU_API_KEY`? Say so, then use a local embedding server.** If the user has no API key to
 give, tell them up front what that means: memory cannot be called across
 devices — everything stays on this machine, in a local database created for
 them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
@@ -91,16 +119,18 @@ and ask the user.
 memu-cursor doctor
 ```
 
-Must exit cleanly. Zero hits on the smoke-test retrieval is expected on a new
-store.
+It prints the resolved mode plus its endpoint or local store/provider and must
+exit cleanly. Zero hits on the smoke-test retrieval is expected on a new
+backend.
 
 ---
 
 ## Part 2 — Register the bridging (record) task
 
 The *record* seam: a scheduled job that mines recent transcripts under
-`~/.cursor/projects/*/agent-transcripts/` into durable memU memory, skills, and
-resources. **Do not reinvent this** — follow the packaged procedure:
+`~/.cursor/projects/*/agent-transcripts/` into memU memory, skills, and
+resources. In cloud mode, workspace resources are submitted but are not
+currently persisted. **Do not reinvent this** — follow the packaged procedure:
 
 ```
 memu-cursor docs task
@@ -154,6 +184,6 @@ AGENTS.md.
 
 ## Done
 
-Report back to the user: the store and provider in use; the scheduled job and its
+Report back to the user: the selected mode and its cloud endpoint or local store/provider; the scheduled job and its
 schedule in words; which projects got the `AGENTS.md` instruction. Record and
-inject both read `~/.memu/config.env`, so they provably share one store.
+inject both read `~/.memu/config.env`, so they provably share one backend.

--- a/src/memu/hosts/cursor/INSTALL.md
+++ b/src/memu/hosts/cursor/INSTALL.md
@@ -44,20 +44,20 @@ local mode for backward compatibility.
 
 Otherwise ask the user to choose once:
 
-- **MemU Cloud** — memory and embeddings are hosted; collect a project API key.
+- **MemU Cloud** — memory and embeddings are hosted; requires a memU project API key.
 - **This device** — use the existing local database and embedding configuration.
 
-For **MemU Cloud**, write:
+For **MemU Cloud**, ask the user to provide their memU API key. If they do not
+have one, direct them to [memu.so](https://memu.so) to register and create one,
+then wait for the key before continuing. Write:
 
 ```env
 MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<project-api-key>
+MEMU_CLOUD_API_KEY=<memu-api-key>
 ```
 
-The production endpoint defaults to
-`https://api.memu.so/api/v4/memory/`. Set
-`MEMU_CLOUD_BASE_URL=https://staging-api.memu.so/api/v4/memory/` only when the
-user explicitly wants staging. The key is plaintext in this file: tell the user
+The production endpoint defaults to `https://api.memu.so/api/v4/memory/`. The
+key is plaintext in this file: tell the user
 and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
 the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
 for local embedding providers.

--- a/src/memu/hosts/cursor/INSTALL.md
+++ b/src/memu/hosts/cursor/INSTALL.md
@@ -44,7 +44,7 @@ local mode for backward compatibility.
 
 Otherwise ask the user to choose once:
 
-- **MemU Cloud** — memory and embeddings are hosted; requires a memU project API key.
+- **MemU Cloud** — memory and embeddings are hosted; requires a memU API key.
 - **This device** — use the existing local database and embedding configuration.
 
 For **MemU Cloud**, ask the user to provide their memU API key. If they do not

--- a/src/memu/hosts/generic/BRIDGING_TASK.md
+++ b/src/memu/hosts/generic/BRIDGING_TASK.md
@@ -1,14 +1,18 @@
 ---
 name: create-memu-bridging-task
-description: Register a scheduled job that bridges an agent's recent sessions into durable memU memory, skills, and resources via the generic memu-agent adapter. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
+description: Register a scheduled job that bridges recent sessions into memU memory, skills, and resource submissions via the generic adapter. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
 ---
 
 # Create the memU bridging scheduled task (generic `memu-agent`)
 
 Use this when the user asks to **set up (or change) the recurring memU
 "bridging" task** for an agent that has no dedicated memU adapter — the job
-that periodically turns what the agent recently did into durable memU memory
-files, skills, and resource records.
+that periodically turns what the agent recently did into memU memory files,
+skills, and resource submissions.
+
+Memory and skills are durable in both modes. In cloud mode, the current service
+accepts workspace resources from this unchanged pipeline but does not persist or
+retrieve them yet.
 
 Your goal is to **register a recurring headless run** whose prompt is the
 three-step pipeline below. You are not running the pipeline now.

--- a/src/memu/hosts/generic/INSTALL.md
+++ b/src/memu/hosts/generic/INSTALL.md
@@ -61,7 +61,7 @@ compatibility.
 
 Otherwise ask the user to choose once:
 
-- **MemU Cloud** — memory and embeddings are hosted; requires a memU project API key.
+- **MemU Cloud** — memory and embeddings are hosted; requires a memU API key.
 - **This device** — use the existing local database and embedding configuration.
 
 For **MemU Cloud**, ask the user to provide their memU API key. If they do not

--- a/src/memu/hosts/generic/INSTALL.md
+++ b/src/memu/hosts/generic/INSTALL.md
@@ -52,11 +52,41 @@ memU cannot integrate with this agent yet, and no amount of setup changes that.
 
 ---
 
-## Part 1 — Configure the store and provider
+## Part 1 — Configure the memory backend
 
 If another memU host adapter is already set up on this machine,
 `~/.memu/config.env` exists and **must be reused as is**; skip to the verify
-gate. Otherwise collect from the user:
+gate. An existing file without `MEMU_MEMORY_MODE` is local mode for backward
+compatibility.
+
+Otherwise ask the user to choose once:
+
+- **MemU Cloud** — memory and embeddings are hosted; collect a project API key.
+- **This device** — use the existing local database and embedding configuration.
+
+For **MemU Cloud**, write:
+
+```env
+MEMU_MEMORY_MODE=cloud
+MEMU_CLOUD_API_KEY=<project-api-key>
+```
+
+The production endpoint defaults to
+`https://api.memu.so/api/v4/memory/`. Set
+`MEMU_CLOUD_BASE_URL=https://staging-api.memu.so/api/v4/memory/` only when the
+user explicitly wants staging. The key is plaintext in this file: tell the user
+and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
+the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
+for local embedding providers.
+
+Cloud currently persists memory and skill recall files. It accepts workspace
+resources from the existing bridging pipeline for compatibility but does not
+persist or retrieve them yet; tell the user. After writing cloud configuration,
+skip the remaining local-mode guidance and go to the verify gate.
+
+For **This device**, write `MEMU_MEMORY_MODE=local` and collect the settings
+below. "This device" describes memory storage; it is fully offline only when
+the embedding provider is local too:
 
 | Setting | Env var | Example |
 | --- | --- | --- |
@@ -64,7 +94,7 @@ gate. Otherwise collect from the user:
 | Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
 | API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
 
-**No `MEMU_API_KEY`? Say so, then go local.** If the user has no API key to
+**No embedding `MEMU_API_KEY`? Say so, then use a local embedding server.** If the user has no API key to
 give, tell them up front what that means: memory cannot be called across
 devices — everything stays on this machine, in a local database created for
 them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
@@ -106,15 +136,17 @@ and ask the user.
 memu-agent doctor
 ```
 
-Must exit cleanly. Zero hits on the smoke-test retrieval is expected on a new
-store.
+It prints the resolved mode plus its endpoint or local store/provider and must
+exit cleanly. Zero hits on the smoke-test retrieval is expected on a new
+backend.
 
 ---
 
 ## Part 2 — Memorization (only if detect said it works)
 
 Register the bridging task against the session directory detect found. Follow
-the packaged procedure:
+the packaged procedure. In cloud mode, workspace resources are submitted by the
+same pipeline but are not currently persisted:
 
 ```
 memu-agent docs task
@@ -176,9 +208,9 @@ Report back to the user:
 
 - **which seams work**: memorization (and from which session directory),
   retrieval (and into which instruction file), both, or neither;
-- the store (`MEMU_DB`) and provider in use;
+- the selected mode and its cloud endpoint or local store/provider;
 - what was scheduled and where the instruction landed, for the seams that work.
 
-Both seams read `~/.memu/config.env`, so they provably share one store — and
+Both seams read `~/.memu/config.env`, so they provably share one backend — and
 they share it with every dedicated adapter too: what this agent's sessions
 teach memU, every other integrated agent retrieves.

--- a/src/memu/hosts/generic/INSTALL.md
+++ b/src/memu/hosts/generic/INSTALL.md
@@ -61,20 +61,20 @@ compatibility.
 
 Otherwise ask the user to choose once:
 
-- **MemU Cloud** — memory and embeddings are hosted; collect a project API key.
+- **MemU Cloud** — memory and embeddings are hosted; requires a memU project API key.
 - **This device** — use the existing local database and embedding configuration.
 
-For **MemU Cloud**, write:
+For **MemU Cloud**, ask the user to provide their memU API key. If they do not
+have one, direct them to [memu.so](https://memu.so) to register and create one,
+then wait for the key before continuing. Write:
 
 ```env
 MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<project-api-key>
+MEMU_CLOUD_API_KEY=<memu-api-key>
 ```
 
-The production endpoint defaults to
-`https://api.memu.so/api/v4/memory/`. Set
-`MEMU_CLOUD_BASE_URL=https://staging-api.memu.so/api/v4/memory/` only when the
-user explicitly wants staging. The key is plaintext in this file: tell the user
+The production endpoint defaults to `https://api.memu.so/api/v4/memory/`. The
+key is plaintext in this file: tell the user
 and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
 the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
 for local embedding providers.

--- a/src/memu/hosts/hermes/BRIDGING_TASK.md
+++ b/src/memu/hosts/hermes/BRIDGING_TASK.md
@@ -1,14 +1,17 @@
 ---
 name: create-memu-bridging-task
-description: Register a scheduled job that bridges the agent's recent Hermes sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
+description: Register a scheduled job that bridges recent Hermes sessions into memU memory, skills, and resource submissions. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
 ---
 
 # Create the memU bridging scheduled task (Hermes)
 
 Use this when the user asks to **set up (or change) the recurring memU
 "bridging" task** — the job that periodically turns what the agent recently did
-in its Hermes sessions into durable memU memory files, skills, and resource
-records.
+in its Hermes sessions into memU memory files, skills, and resource submissions.
+
+Memory and skills are durable in both modes. In cloud mode, the current service
+accepts workspace resources from this unchanged pipeline but does not persist or
+retrieve them yet.
 
 Your goal is to **register a recurring headless Hermes run** whose prompt is the
 three-step pipeline below. You are not running the pipeline now.
@@ -109,7 +112,8 @@ the last run.
   resource-describe job last. Always ascending numeric order.
 - **The working tree is host-scoped.** Everything under `~/.memu/hosts/hermes/`
   is this adapter's run-scoped working state; other memU host adapters never
-  race with it. The durable store they all share is the `MEMU_DB` in
-  `~/.memu/config.env`.
+  race with it. The durable backend they all share is selected by
+  `MEMU_MEMORY_MODE` in `~/.memu/config.env`; local mode uses the `MEMU_DB`
+  there.
 - **Failure handling.** Steps 1 and 3 are the only failure points that should
   abort the run. A "do nothing" job in step 2 is normal, not an error.

--- a/src/memu/hosts/hermes/INSTALL.md
+++ b/src/memu/hosts/hermes/INSTALL.md
@@ -9,15 +9,15 @@
 
 Installing memU on Hermes is three parts:
 
-1. **Install memU** — a Python package, and the store + provider it writes to.
+1. **Install memU** — a Python package and the memory backend it uses.
 2. **Register the bridging task** — the scheduled job that turns recent Hermes
    sessions into durable memory (the *record* seam).
 3. **Patch `~/.hermes/SOUL.md`** — a standing instruction that tells the agent to
    pull relevant memory before answering (the *inject* seam).
 
-Parts 2 and 3 must share one store and one embedding space, or a query is
-compared against vectors written elsewhere and retrieval silently returns
-nothing. Part 1 is what makes them agree.
+Parts 2 and 3 must share one configured mode. In local mode they must also share
+one store and embedding space, or retrieval silently returns nothing. Part 1 is
+what makes them agree.
 
 **Scope note.** This adapter reads Hermes's SQLite session store —
 `~/.hermes/state.db` (the `sessions` and `messages` tables), opened read-only so
@@ -37,12 +37,40 @@ This puts `memu` and **`memu-hermes`** on `PATH`. Confirm: `memu-hermes --help`.
 If it is not found, fix `PATH` now — the scheduled task in Part 2 runs from a
 bare, non-interactive environment.
 
-### 1.2 Configure the store and provider
+### 1.2 Configure the memory backend
 
-memU needs a **database** and an **LLM/embedding provider**. Both seams read this
-one config. If another memU host adapter is already set up on this machine,
-`~/.memu/config.env` exists and **must be reused as is**; skip to the verify
-gate. Otherwise collect from the user:
+If `~/.memu/config.env` already exists from another memU host, reuse it as is
+and skip to the verify gate. An existing file without `MEMU_MEMORY_MODE` is
+local mode for backward compatibility.
+
+Otherwise ask the user to choose once:
+
+- **MemU Cloud** — memory and embeddings are hosted; collect a project API key.
+- **This device** — use the existing local database and embedding configuration.
+
+For **MemU Cloud**, write:
+
+```env
+MEMU_MEMORY_MODE=cloud
+MEMU_CLOUD_API_KEY=<project-api-key>
+```
+
+The production endpoint defaults to
+`https://api.memu.so/api/v4/memory/`. Set
+`MEMU_CLOUD_BASE_URL=https://staging-api.memu.so/api/v4/memory/` only when the
+user explicitly wants staging. The key is plaintext in this file: tell the user
+and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
+the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
+for local embedding providers.
+
+Cloud currently persists memory and skill recall files. It accepts workspace
+resources from the existing bridging pipeline for compatibility but does not
+persist or retrieve them yet; tell the user. After writing cloud configuration,
+skip the remaining local-mode guidance and go to the verify gate.
+
+For **This device**, write `MEMU_MEMORY_MODE=local` and collect the settings
+below. "This device" describes memory storage; it is fully offline only when
+the embedding provider is local too:
 
 | Setting | Env var | Example |
 | --- | --- | --- |
@@ -50,7 +78,7 @@ gate. Otherwise collect from the user:
 | Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
 | API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
 
-**No `MEMU_API_KEY`? Say so, then go local.** If the user has no API key to
+**No embedding `MEMU_API_KEY`? Say so, then use a local embedding server.** If the user has no API key to
 give, tell them up front what that means: memory cannot be called across
 devices — everything stays on this machine, in a local database created for
 them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
@@ -92,15 +120,17 @@ and ask the user.
 memu-hermes doctor
 ```
 
-Must exit cleanly. Zero hits on the smoke-test retrieval is expected on a new
-store.
+It prints the resolved mode plus its endpoint or local store/provider and must
+exit cleanly. Zero hits on the smoke-test retrieval is expected on a new
+backend.
 
 ---
 
 ## Part 2 — Register the bridging (record) task
 
 The *record* seam: a scheduled job that mines recent sessions out of
-`~/.hermes/state.db` into durable memU memory, skills, and resources. **Do not
+`~/.hermes/state.db` into memU memory, skills, and resources. In cloud mode,
+workspace resources are submitted but are not currently persisted. **Do not
 reinvent this** — follow the packaged procedure:
 
 ```
@@ -167,8 +197,8 @@ what picks up the new SOUL.md and skill.
 
 ## Done
 
-Report back to the user: the store and provider in use; the scheduled job and its
+Report back to the user: the selected mode and its cloud endpoint or local store/provider; the scheduled job and its
 schedule in words; and that the retrieval instruction is now in
 `~/.hermes/SOUL.md`, pointing at the `memu-retrieve` skill and taking effect next
 session. Record and inject both read `~/.memu/config.env`, so they provably share
-one store.
+one backend.

--- a/src/memu/hosts/hermes/INSTALL.md
+++ b/src/memu/hosts/hermes/INSTALL.md
@@ -45,20 +45,20 @@ local mode for backward compatibility.
 
 Otherwise ask the user to choose once:
 
-- **MemU Cloud** — memory and embeddings are hosted; collect a project API key.
+- **MemU Cloud** — memory and embeddings are hosted; requires a memU project API key.
 - **This device** — use the existing local database and embedding configuration.
 
-For **MemU Cloud**, write:
+For **MemU Cloud**, ask the user to provide their memU API key. If they do not
+have one, direct them to [memu.so](https://memu.so) to register and create one,
+then wait for the key before continuing. Write:
 
 ```env
 MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<project-api-key>
+MEMU_CLOUD_API_KEY=<memu-api-key>
 ```
 
-The production endpoint defaults to
-`https://api.memu.so/api/v4/memory/`. Set
-`MEMU_CLOUD_BASE_URL=https://staging-api.memu.so/api/v4/memory/` only when the
-user explicitly wants staging. The key is plaintext in this file: tell the user
+The production endpoint defaults to `https://api.memu.so/api/v4/memory/`. The
+key is plaintext in this file: tell the user
 and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
 the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
 for local embedding providers.

--- a/src/memu/hosts/hermes/INSTALL.md
+++ b/src/memu/hosts/hermes/INSTALL.md
@@ -45,7 +45,7 @@ local mode for backward compatibility.
 
 Otherwise ask the user to choose once:
 
-- **MemU Cloud** — memory and embeddings are hosted; requires a memU project API key.
+- **MemU Cloud** — memory and embeddings are hosted; requires a memU API key.
 - **This device** — use the existing local database and embedding configuration.
 
 For **MemU Cloud**, ask the user to provide their memU API key. If they do not

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -13,8 +13,9 @@ Working state is per host. Codex predates this module and keeps its original
 ``~/.memu`` working tree; every later host defaults to ``~/.memu/hosts/<host>``,
 so two hosts' bridging runs never race over one ``jobs/`` directory (the open
 issue ADR 0009 required settling before a second host shipped — see ADR 0010).
-The durable store is shared regardless: every host reads ``~/.memu/config.env``,
-which is the point — what one host's sessions taught memU, another host retrieves.
+The durable backend is shared regardless: every host reads
+``~/.memu/config.env``, which is the point — what one host's sessions taught
+memU, another host retrieves.
 """
 
 from __future__ import annotations
@@ -201,28 +202,38 @@ def _proxy_hint(base_url: str) -> str | None:
 
 
 async def _cmd_doctor(spec: HostSpec, args: argparse.Namespace) -> int:
-    """Prove config resolves and the store answers — the install guide's verify gate.
+    """Prove config resolves and the selected backend answers.
 
     Deliberately exercises the same call the inject hook will, so a green doctor
-    means the hook's retrieval works, not merely that some store opened.
+    means the hook's retrieval works, not merely that some local store opened.
     """
-    from memu.env import CONFIG_ENV, embedding_provider, env
+    from memu.env import CONFIG_ENV, cloud_base_url, embedding_provider, env, memory_mode
 
     try:
+        mode = memory_mode()
         result = await retrieval.retrieve("smoke test")
     except Exception as exc:
         if os.environ.get("MEMU_DEBUG") == "1":
             raise
         print(f"error: {exc} (set MEMU_DEBUG=1 for a traceback)", file=sys.stderr)
         if _smells_like_transport(exc):
-            hint = _proxy_hint(env("MEMU_BASE_URL", "") or "")
+            try:
+                target = cloud_base_url() if memory_mode() == "cloud" else (env("MEMU_BASE_URL", "") or "")
+            except Exception:
+                target = ""
+            hint = _proxy_hint(target)
             if hint:
                 print(hint, file=sys.stderr)
         return 1
     found = sum(len(result.get(layer, [])) for layer in ("segments", "files", "resources"))
     print(f"config    {os.path.expanduser(CONFIG_ENV)}")
-    print(f"store     {env('MEMU_DB')}")
-    print(f"provider  {embedding_provider()}")
+    print(f"mode      {mode}")
+    if mode == "cloud":
+        print(f"endpoint  {cloud_base_url()}")
+        print("resources accepted but not currently persisted by memU Cloud")
+    else:
+        print(f"store     {env('MEMU_DB')}")
+        print(f"provider  {embedding_provider()}")
     print(f"retrieval ok ({found} hit(s) for a smoke-test query; 0 is fine on a new store)")
     return 0
 
@@ -279,7 +290,7 @@ def build_parser(spec: HostSpec) -> argparse.ArgumentParser:
     )
     p.set_defaults(handler=bind(_cmd_verify_resources))
 
-    p = sub.add_parser("doctor", help="Verify MEMU_* config resolves and the store is reachable")
+    p = sub.add_parser("doctor", help="Verify MEMU_* config resolves and the selected memory backend is reachable")
     p.set_defaults(handler=bind(_cmd_doctor))
 
     p = sub.add_parser("docs", help="Print a packaged agent-facing guide")

--- a/src/memu/hosts/openclaw/BRIDGING_TASK.md
+++ b/src/memu/hosts/openclaw/BRIDGING_TASK.md
@@ -1,14 +1,18 @@
 ---
 name: create-memu-bridging-task
-description: Create an OpenClaw cron job that bridges the agent's recent OpenClaw sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
+description: Create an OpenClaw cron job that bridges recent OpenClaw sessions into memU memory, skills, and resource submissions. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
 ---
 
 # Create the memU bridging scheduled task (OpenClaw)
 
 Use this when the user asks to **set up (or change) the recurring memU
 "bridging" task** — the job that periodically turns what the agent recently did
-in its OpenClaw sessions into durable memU memory files, skills, and resource
-records.
+in its OpenClaw sessions into memU memory files, skills, and resource
+submissions.
+
+Memory and skills are durable in both modes. In cloud mode, the current service
+accepts workspace resources from this unchanged pipeline but does not persist or
+retrieve them yet.
 
 Your goal is to **create an OpenClaw cron job** (OpenClaw schedules agent runs
 natively) whose recurring prompt runs the three-step pipeline below. You are not
@@ -134,6 +138,7 @@ OpenClaw sessions since the last run.
 - **The working tree is host-scoped.** Everything under
   `~/.memu/hosts/openclaw/` is this adapter's run-scoped working state; other
   memU host adapters never race with it. The durable store they all share is the
-  `MEMU_DB` in `~/.memu/config.env`.
+  backend selected by `MEMU_MEMORY_MODE` in `~/.memu/config.env`; local mode
+  uses the `MEMU_DB` there.
 - **Failure handling.** Steps 1 and 3 are the only failure points that should
   abort the run. A "do nothing" job in step 2 is normal, not an error.

--- a/src/memu/hosts/openclaw/INSTALL.md
+++ b/src/memu/hosts/openclaw/INSTALL.md
@@ -9,15 +9,15 @@
 
 Installing memU on OpenClaw is three parts:
 
-1. **Install memU** — a Python package, and the store + provider it writes to.
+1. **Install memU** — a Python package and the memory backend it uses.
 2. **Register the bridging task** — the scheduled job that turns recent OpenClaw
    sessions into durable memory (the *record* seam).
 3. **Patch `~/.openclaw/workspace/AGENTS.md`** — a standing instruction that
    tells the agent to pull relevant memory before answering (the *inject* seam).
 
-Parts 2 and 3 must share one store and one embedding space, or a query is
-compared against vectors written elsewhere and retrieval silently returns
-nothing. Part 1 is what makes them agree.
+Parts 2 and 3 must share one configured mode. In local mode they must also share
+one store and embedding space, or retrieval silently returns nothing. Part 1 is
+what makes them agree.
 
 **Scope note.** This adapter reads the JSONL transcripts under
 `~/.openclaw/agents/<agentId>/sessions/` (all agents). If this install runs a
@@ -37,12 +37,40 @@ This puts `memu` and **`memu-openclaw`** on `PATH`. Confirm:
 `memu-openclaw --help`. If it is not found, fix `PATH` now — the scheduled task
 in Part 2 runs from a bare, non-interactive environment.
 
-### 1.2 Configure the store and provider
+### 1.2 Configure the memory backend
 
-memU needs a **database** and an **LLM/embedding provider**. Both seams read this
-one config. If another memU host adapter is already set up on this machine,
-`~/.memu/config.env` exists and **must be reused as is**; skip to the verify
-gate. Otherwise collect from the user:
+If `~/.memu/config.env` already exists from another memU host, reuse it as is
+and skip to the verify gate. An existing file without `MEMU_MEMORY_MODE` is
+local mode for backward compatibility.
+
+Otherwise ask the user to choose once:
+
+- **MemU Cloud** — memory and embeddings are hosted; collect a project API key.
+- **This device** — use the existing local database and embedding configuration.
+
+For **MemU Cloud**, write:
+
+```env
+MEMU_MEMORY_MODE=cloud
+MEMU_CLOUD_API_KEY=<project-api-key>
+```
+
+The production endpoint defaults to
+`https://api.memu.so/api/v4/memory/`. Set
+`MEMU_CLOUD_BASE_URL=https://staging-api.memu.so/api/v4/memory/` only when the
+user explicitly wants staging. The key is plaintext in this file: tell the user
+and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
+the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
+for local embedding providers.
+
+Cloud currently persists memory and skill recall files. It accepts workspace
+resources from the existing bridging pipeline for compatibility but does not
+persist or retrieve them yet; tell the user. After writing cloud configuration,
+skip the remaining local-mode guidance and go to the verify gate.
+
+For **This device**, write `MEMU_MEMORY_MODE=local` and collect the settings
+below. "This device" describes memory storage; it is fully offline only when
+the embedding provider is local too:
 
 | Setting | Env var | Example |
 | --- | --- | --- |
@@ -50,7 +78,7 @@ gate. Otherwise collect from the user:
 | Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
 | API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
 
-**No `MEMU_API_KEY`? Say so, then go local.** If the user has no API key to
+**No embedding `MEMU_API_KEY`? Say so, then use a local embedding server.** If the user has no API key to
 give, tell them up front what that means: memory cannot be called across
 devices — everything stays on this machine, in a local database created for
 them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
@@ -92,16 +120,18 @@ and ask the user.
 memu-openclaw doctor
 ```
 
-Must exit cleanly. Zero hits on the smoke-test retrieval is expected on a new
-store.
+It prints the resolved mode plus its endpoint or local store/provider and must
+exit cleanly. Zero hits on the smoke-test retrieval is expected on a new
+backend.
 
 ---
 
 ## Part 2 — Register the bridging (record) task
 
 The *record* seam: a scheduled job that mines recent transcripts under
-`~/.openclaw/agents/*/sessions/` into durable memU memory, skills, and
-resources. **Do not reinvent this** — follow the packaged procedure:
+`~/.openclaw/agents/*/sessions/` into memU memory, skills, and resources. In
+cloud mode, workspace resources are submitted but are not currently persisted.
+**Do not reinvent this** — follow the packaged procedure:
 
 ```
 memu-openclaw docs task
@@ -172,8 +202,8 @@ what picks up the new AGENTS.md and skill.
 
 ## Done
 
-Report back to the user: the store and provider in use; the cron job's name and
+Report back to the user: the selected mode and its cloud endpoint or local store/provider; the cron job's name and
 schedule in words; and that the retrieval instruction is now in the workspace
 AGENTS.md, pointing at the `memu-retrieve` skill and taking effect next session.
 Record and inject both read `~/.memu/config.env`, so they provably share one
-store.
+backend.

--- a/src/memu/hosts/openclaw/INSTALL.md
+++ b/src/memu/hosts/openclaw/INSTALL.md
@@ -45,20 +45,20 @@ local mode for backward compatibility.
 
 Otherwise ask the user to choose once:
 
-- **MemU Cloud** — memory and embeddings are hosted; collect a project API key.
+- **MemU Cloud** — memory and embeddings are hosted; requires a memU project API key.
 - **This device** — use the existing local database and embedding configuration.
 
-For **MemU Cloud**, write:
+For **MemU Cloud**, ask the user to provide their memU API key. If they do not
+have one, direct them to [memu.so](https://memu.so) to register and create one,
+then wait for the key before continuing. Write:
 
 ```env
 MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<project-api-key>
+MEMU_CLOUD_API_KEY=<memu-api-key>
 ```
 
-The production endpoint defaults to
-`https://api.memu.so/api/v4/memory/`. Set
-`MEMU_CLOUD_BASE_URL=https://staging-api.memu.so/api/v4/memory/` only when the
-user explicitly wants staging. The key is plaintext in this file: tell the user
+The production endpoint defaults to `https://api.memu.so/api/v4/memory/`. The
+key is plaintext in this file: tell the user
 and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
 the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
 for local embedding providers.

--- a/src/memu/hosts/openclaw/INSTALL.md
+++ b/src/memu/hosts/openclaw/INSTALL.md
@@ -45,7 +45,7 @@ local mode for backward compatibility.
 
 Otherwise ask the user to choose once:
 
-- **MemU Cloud** — memory and embeddings are hosted; requires a memU project API key.
+- **MemU Cloud** — memory and embeddings are hosted; requires a memU API key.
 - **This device** — use the existing local database and embedding configuration.
 
 For **MemU Cloud**, ask the user to provide their memU API key. If they do not

--- a/src/memu/hosts/retrieval.py
+++ b/src/memu/hosts/retrieval.py
@@ -22,21 +22,21 @@ import os
 from pathlib import Path
 from typing import Any
 
-from memu.env import build_service_from_env
+from memu.env import build_agentic_memory_backend_from_env
 from memu.hosts.bridging.layout import BASE_DIR, TRACK_DIRS
 from memu.hosts.bridging.recall_files import recall_file_path
 
 
 async def retrieve(query: str, where: dict[str, Any] | None = None) -> dict[str, Any]:
-    """Retrieve against the configured store. Returns ``segments``/``files``/``resources``.
+    """Retrieve against the configured backend. Returns ``segments``/``files``/``resources``.
 
     Embeddings are already stripped from the hits, so the result is safe to print.
     :func:`_shape_for_agent` then reshapes the raw store records into the
     progressive form the standing instruction promises (see
     :mod:`memu.hosts.instruction`).
     """
-    service = build_service_from_env()
-    result: dict[str, Any] = await service.progressive_retrieve(query, where=where)
+    backend = build_agentic_memory_backend_from_env()
+    result: dict[str, Any] = await backend.progressive_retrieve(query, where=where)
     return _shape_for_agent(result)
 
 

--- a/src/memu/hosts/workbuddy/BRIDGING_TASK.md
+++ b/src/memu/hosts/workbuddy/BRIDGING_TASK.md
@@ -1,14 +1,18 @@
 ---
 name: create-memu-bridging-task
-description: Register a scheduled automation that bridges the agent's recent WorkBuddy sessions into durable memU memory, skills, and resources. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
+description: Register a scheduled automation that bridges recent WorkBuddy sessions into memU memory, skills, and resource submissions. Runs the prepare → self-evolve → commit pipeline on a schedule (default: every hour).
 ---
 
 # Create the memU bridging scheduled task (WorkBuddy)
 
 Use this when the user asks to **set up (or change) the recurring memU
 "bridging" task** — the automation that periodically turns what the agent
-recently did in its WorkBuddy sessions into durable memU memory files, skills,
-and resource records.
+recently did in its WorkBuddy sessions into memU memory files, skills, and
+resource submissions.
+
+Memory and skills are durable in both modes. In cloud mode, the current service
+accepts workspace resources from this unchanged pipeline but does not persist or
+retrieve them yet.
 
 Your goal is to **register a recurring WorkBuddy automation** whose prompt is
 the three-step pipeline below. You are not running the pipeline now; you are
@@ -109,7 +113,8 @@ are new WorkBuddy sessions since the last run.
 - **The working tree is host-scoped.** Everything under
   `~/.memu/hosts/workbuddy/` is this adapter's run-scoped working state; other
   memU host adapters (Codex, Claude Code, …) have their own and never race with
-  this one. The durable store they all share is the `MEMU_DB` in
-  `~/.memu/config.env`.
+  this one. The durable backend they all share is selected by
+  `MEMU_MEMORY_MODE` in `~/.memu/config.env`; local mode uses the `MEMU_DB`
+  there.
 - **Failure handling.** Steps 1 and 3 are the only failure points that should
   abort the run. A single "do nothing" job in step 2 is normal, not an error.

--- a/src/memu/hosts/workbuddy/INSTALL.md
+++ b/src/memu/hosts/workbuddy/INSTALL.md
@@ -54,7 +54,7 @@ local mode for backward compatibility.
 
 Otherwise ask the user to choose once:
 
-- **MemU Cloud** — memory and embeddings are hosted; requires a memU project API key.
+- **MemU Cloud** — memory and embeddings are hosted; requires a memU API key.
 - **This device** — use the existing local database and embedding configuration.
 
 For **MemU Cloud**, ask the user to provide their memU API key. If they do not

--- a/src/memu/hosts/workbuddy/INSTALL.md
+++ b/src/memu/hosts/workbuddy/INSTALL.md
@@ -9,15 +9,15 @@
 
 Installing memU on WorkBuddy is three parts:
 
-1. **Install memU** — a Python package, and the store + provider it writes to.
+1. **Install memU** — a Python package and the memory backend it uses.
 2. **Register the bridging task** — the scheduled job that turns recent WorkBuddy
    sessions into durable memory (the *record* seam).
 3. **Patch `~/.workbuddy/MEMORY.md`** — a standing instruction that tells you to
    pull relevant memory before you answer (the *inject* seam).
 
-Parts 2 and 3 must share one store and one embedding space, or a query is
-compared against vectors written elsewhere and retrieval silently returns
-nothing. Part 1 is what makes them agree.
+Parts 2 and 3 must share one configured mode. In local mode they must also share
+one store and embedding space, or retrieval silently returns nothing. Part 1 is
+what makes them agree.
 
 ---
 
@@ -46,13 +46,40 @@ If it is not found, the install landed in an environment that isn't on your
 `PATH`. Fix that now — the scheduled task in Part 2 runs from a bare,
 non-interactive environment and needs this command to resolve there.
 
-### 1.2 Configure the store and provider
+### 1.2 Configure the memory backend
 
-memU needs a **database** and an **LLM/embedding provider**. Both seams read this
-one config, so decide it once, here. Collect from the user (or reuse values they
-already have — if another memU host adapter such as `memu-codex` or
-`memu-claude-code` is already set up on this machine, `~/.memu/config.env`
-exists and **must be reused as is**; skip to the verify gate):
+If `~/.memu/config.env` already exists from another memU host, reuse it as is
+and skip to the verify gate. An existing file without `MEMU_MEMORY_MODE` is
+local mode for backward compatibility.
+
+Otherwise ask the user to choose once:
+
+- **MemU Cloud** — memory and embeddings are hosted; collect a project API key.
+- **This device** — use the existing local database and embedding configuration.
+
+For **MemU Cloud**, write:
+
+```env
+MEMU_MEMORY_MODE=cloud
+MEMU_CLOUD_API_KEY=<project-api-key>
+```
+
+The production endpoint defaults to
+`https://api.memu.so/api/v4/memory/`. Set
+`MEMU_CLOUD_BASE_URL=https://staging-api.memu.so/api/v4/memory/` only when the
+user explicitly wants staging. The key is plaintext in this file: tell the user
+and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
+the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
+for local embedding providers.
+
+Cloud currently persists memory and skill recall files. It accepts workspace
+resources from the existing bridging pipeline for compatibility but does not
+persist or retrieve them yet; tell the user. After writing cloud configuration,
+skip the remaining local-mode guidance and go to the verify gate.
+
+For **This device**, write `MEMU_MEMORY_MODE=local` and collect the settings
+below. "This device" describes memory storage; it is fully offline only when
+the embedding provider is local too:
 
 | Setting | Env var | Example |
 | --- | --- | --- |
@@ -60,7 +87,7 @@ exists and **must be reused as is**; skip to the verify gate):
 | Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
 | API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
 
-**No `MEMU_API_KEY`? Say so, then go local.** If the user has no API key to
+**No embedding `MEMU_API_KEY`? Say so, then use a local embedding server.** If the user has no API key to
 give, tell them up front what that means: memory cannot be called across
 devices — everything stays on this machine, in a local database created for
 them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
@@ -80,7 +107,7 @@ task does not inherit your interactive shell.
 memu-workbuddy doctor
 ```
 
-It prints the store and provider it resolved and runs a smoke-test retrieval. It
+It prints the resolved mode plus its endpoint or local store/provider, and runs a smoke-test retrieval. It
 must exit cleanly. **Zero hits is the expected result** on a new store.
 
 ---
@@ -88,7 +115,8 @@ must exit cleanly. **Zero hits is the expected result** on a new store.
 ## Part 2 — Register the bridging (record) task
 
 The *record* seam: a scheduled job that periodically mines recent sessions under
-`~/.workbuddy/projects` into durable memU memory, skills, and resources.
+`~/.workbuddy/projects` into memU memory, skills, and resources. In cloud mode,
+workspace resources are submitted but are not currently persisted.
 
 **Do not reinvent this.** Follow the packaged procedure:
 
@@ -155,8 +183,8 @@ the instruction is not in your own context yet.
 
 ## Done
 
-Report back to the user: the store (`MEMU_DB`) and provider in use; the scheduled
+Report back to the user: the selected mode and its cloud endpoint or local store/provider; the scheduled
 automation and its schedule in words; and that the retrieval instruction is now in
 `~/.workbuddy/MEMORY.md`, taking effect in their next session. Record and inject
-both read `~/.memu/config.env`, so they provably share one store — what the task
+both read `~/.memu/config.env`, so they provably share one backend — what the task
 learns tonight is what retrieval finds tomorrow.

--- a/src/memu/hosts/workbuddy/INSTALL.md
+++ b/src/memu/hosts/workbuddy/INSTALL.md
@@ -54,20 +54,20 @@ local mode for backward compatibility.
 
 Otherwise ask the user to choose once:
 
-- **MemU Cloud** — memory and embeddings are hosted; collect a project API key.
+- **MemU Cloud** — memory and embeddings are hosted; requires a memU project API key.
 - **This device** — use the existing local database and embedding configuration.
 
-For **MemU Cloud**, write:
+For **MemU Cloud**, ask the user to provide their memU API key. If they do not
+have one, direct them to [memu.so](https://memu.so) to register and create one,
+then wait for the key before continuing. Write:
 
 ```env
 MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<project-api-key>
+MEMU_CLOUD_API_KEY=<memu-api-key>
 ```
 
-The production endpoint defaults to
-`https://api.memu.so/api/v4/memory/`. Set
-`MEMU_CLOUD_BASE_URL=https://staging-api.memu.so/api/v4/memory/` only when the
-user explicitly wants staging. The key is plaintext in this file: tell the user
+The production endpoint defaults to `https://api.memu.so/api/v4/memory/`. The
+key is plaintext in this file: tell the user
 and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
 the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
 for local embedding providers.

--- a/tests/test_bridging_promotion.py
+++ b/tests/test_bridging_promotion.py
@@ -57,7 +57,7 @@ def rig(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> tuple[FakeSo
     service = FakeService()
     import memu.hosts.bridging.pipeline as pipeline
 
-    monkeypatch.setattr(pipeline, "build_service_from_env", lambda: service)
+    monkeypatch.setattr(pipeline, "build_agentic_memory_backend_from_env", lambda: service)
     return FakeSource(logs), layout, service
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,10 +7,13 @@ handlers.
 
 from __future__ import annotations
 
+import json
 import pathlib
+from typing import Any
 
 import pytest
 
+from memu import cli
 from memu.cli import build_parser, main
 from memu.env import database_config
 
@@ -49,3 +52,55 @@ def test_database_config_dispatch(tmp_path: pathlib.Path) -> None:
 def test_commit_missing_payload_exits_2(capsys: pytest.CaptureFixture[str]) -> None:
     assert main(["commit", "/definitely/not/a/payload.json"]) == 2
     assert "no such file" in capsys.readouterr().err
+
+
+def test_commit_forwards_user_and_resources(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "user": {"user_id": "u1", "agent_id": "a1"},
+        "recall_files": [{"name": "profile"}],
+        "resource": [{"path": "/workspace/notes.md"}],
+    }
+    path = tmp_path / "payload.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    received: dict[str, Any] = {}
+
+    class Backend:
+        async def commit_results(self, **kwargs: Any) -> dict[str, Any]:
+            received.update(kwargs)
+            return {"recall_files": [], "resources": []}
+
+    monkeypatch.setattr(cli, "build_agentic_memory_backend_from_env", lambda **kwargs: Backend())
+
+    assert main(["commit", str(path)]) == 0
+    assert received == {
+        "recall_files": payload["recall_files"],
+        "resource": payload["resource"],
+        "user": payload["user"],
+    }
+
+
+def test_retrieve_and_list_files_use_selected_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[tuple[str, Any]] = []
+
+    class Backend:
+        async def progressive_retrieve(self, query: str) -> dict[str, Any]:
+            calls.append(("retrieve", query))
+            return {"segments": [], "files": [], "resources": []}
+
+        async def list_all_recall_files(self) -> dict[str, Any]:
+            calls.append(("list", None))
+            return {"categories": []}
+
+    backend = Backend()
+    monkeypatch.setattr(cli, "build_agentic_memory_backend_from_env", lambda **kwargs: backend)
+
+    assert main(["retrieve", "tea"]) == 0
+    assert main(["list-files"]) == 0
+    assert calls == [("retrieve", "tea"), ("list", None)]
+    assert "0 recall file(s)" in capsys.readouterr().out

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import httpx
+import pytest
+
+from memu import env as menv
+from memu.cloud import (
+    DEFAULT_CLOUD_BASE_URL,
+    CloudAuthenticationError,
+    CloudAuthorizationError,
+    CloudMemoryClient,
+    CloudRateLimitError,
+    CloudServiceError,
+    CloudTransportError,
+    CloudValidationError,
+)
+from memu.hosts import retrieval
+from memu.hosts.codex.cli import SPEC
+from memu.hosts.host_cli import _cmd_doctor
+
+Handler = Callable[[httpx.Request], httpx.Response]
+
+
+def _client(handler: Handler, *, max_attempts: int = 3) -> CloudMemoryClient:
+    return CloudMemoryClient(
+        base_url="https://cloud.example/api/v4/memory/",
+        api_key="project-key",
+        max_attempts=max_attempts,
+        transport=httpx.MockTransport(handler),
+    )
+
+
+async def test_list_uses_v4_base_auth_and_explicit_default_scope() -> None:
+    seen: list[httpx.Request] = []
+    payload = {"categories": [{"name": "profile"}]}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json=payload)
+
+    result = await _client(handler).list_all_recall_files()
+
+    assert result == payload
+    assert len(seen) == 1
+    request = seen[0]
+    assert request.method == "GET"
+    assert request.url.path == "/api/v4/memory"
+    assert dict(request.url.params) == {"user_id": "default", "agent_id": "default"}
+    assert request.headers["Authorization"] == "Bearer project-key"
+
+
+async def test_search_maps_scope_and_passes_response_through() -> None:
+    response_payload = {
+        "segments": [{"id": "s1", "score": 0.9}],
+        "files": [{"id": "f1", "score": 0.9}],
+        "resources": [],
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/api/v4/memory/search"
+        assert json.loads(request.content) == {
+            "query": "tea",
+            "user_id": "u1",
+            "agent_id": "a1",
+        }
+        return httpx.Response(200, json=response_payload)
+
+    result = await _client(handler).progressive_retrieve("tea", where={"user_id": "u1", "agent_id": "a1"})
+    assert result == response_payload
+
+
+async def test_base_operation_uses_slashless_collection_route() -> None:
+    paths: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        paths.append(request.url.path)
+        return httpx.Response(200, json={"categories": []})
+
+    assert await _client(handler).list_all_recall_files() == {"categories": []}
+    assert paths == ["/api/v4/memory"]
+
+
+async def test_commit_sends_recall_files_resources_and_default_user() -> None:
+    recall_files = [{"name": "profile", "track": "memory", "content": "likes tea"}]
+    resources = [{"path": "/workspace/notes.md", "description": "launch notes"}]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v4/memory"
+        assert json.loads(request.content) == {
+            "user": {"user_id": "default", "agent_id": "default"},
+            "recall_files": recall_files,
+            "resource": resources,
+        }
+        return httpx.Response(200, json={"recall_files": recall_files, "resources": []})
+
+    result = await _client(handler).commit_results(recall_files=recall_files, resource=resources)
+    assert result == {"recall_files": recall_files, "resources": []}
+
+
+async def test_commit_maps_named_user_scope() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert json.loads(request.content)["user"] == {
+            "user_id": "u1",
+            "agent_id": "a1",
+            "user_name": "User",
+            "agent_name": "Agent",
+        }
+        return httpx.Response(200, json={"recall_files": [], "resources": []})
+
+    await _client(handler).commit_results(
+        user={"user_id": "u1", "agent_id": "a1", "user_name": "User", "agent_name": "Agent"}
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "error_type"),
+    [
+        (401, CloudAuthenticationError),
+        (403, CloudAuthorizationError),
+        (422, CloudValidationError),
+        (429, CloudRateLimitError),
+        (500, CloudServiceError),
+    ],
+)
+async def test_structured_errors_are_typed_and_include_service_message(
+    status: int,
+    error_type: type[Exception],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status,
+            json={"message": "useful service message", "details": [{"code": "MEMORY_ERROR"}]},
+        )
+
+    with pytest.raises(error_type, match=r"useful service message.*MEMORY_ERROR"):
+        await _client(handler, max_attempts=1).list_all_recall_files()
+
+
+async def test_transient_status_is_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    async def no_sleep(delay: float) -> None:
+        assert delay >= 0
+
+    monkeypatch.setattr("memu.cloud.asyncio.sleep", no_sleep)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(503, json={"message": "try again"})
+        return httpx.Response(200, json={"categories": []})
+
+    assert await _client(handler).list_all_recall_files() == {"categories": []}
+    assert calls == 2
+
+
+async def test_authentication_error_is_not_retried() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(401, json={"message": "bad key"})
+
+    with pytest.raises(CloudAuthenticationError):
+        await _client(handler).list_all_recall_files()
+    assert calls == 1
+
+
+async def test_transport_failure_is_retried_then_classified(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    async def no_sleep(delay: float) -> None:
+        assert delay >= 0
+
+    monkeypatch.setattr("memu.cloud.asyncio.sleep", no_sleep)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        raise httpx.ConnectError("offline", request=request)
+
+    with pytest.raises(CloudTransportError, match="offline"):
+        await _client(handler, max_attempts=2).list_all_recall_files()
+    assert calls == 2
+
+
+async def test_cloud_rejects_unsupported_scope_filters() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        pytest.fail("request should not be sent")
+
+    with pytest.raises(ValueError, match="user_id__in"):
+        await _client(handler).progressive_retrieve("query", where={"user_id__in": ["u1"]})
+
+
+async def test_invalid_success_response_is_not_silently_accepted() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=["unexpected"])
+
+    with pytest.raises(CloudServiceError, match="unexpected response shape"):
+        await _client(handler).list_all_recall_files()
+
+
+@pytest.fixture()
+def config_file(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> Iterator[pathlib.Path]:
+    for key in (
+        "MEMU_MEMORY_MODE",
+        "MEMU_CLOUD_BASE_URL",
+        "MEMU_CLOUD_API_KEY",
+        "MEMU_DB",
+        "MEMU_EMBED_PROVIDER",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    path = tmp_path / "config.env"
+    monkeypatch.setenv("MEMU_CONFIG_ENV", str(path))
+    menv.reload()
+    yield path
+    menv.reload()
+
+
+def test_unset_mode_defaults_to_local(config_file: pathlib.Path) -> None:
+    backend = menv.build_agentic_memory_backend_from_env(
+        local_database=":memory:",
+        local_embedding_profile={"provider": "openai"},
+    )
+    from memu.app import MemoryService
+
+    assert menv.memory_mode() == "local"
+    assert isinstance(backend, MemoryService)
+
+
+def test_cloud_factory_needs_no_local_configuration(config_file: pathlib.Path) -> None:
+    config_file.write_text(
+        "MEMU_MEMORY_MODE=cloud\nMEMU_CLOUD_API_KEY=secret\n",
+        encoding="utf-8",
+    )
+    menv.reload()
+
+    backend = menv.build_agentic_memory_backend_from_env()
+
+    assert isinstance(backend, CloudMemoryClient)
+    assert backend.base_url == DEFAULT_CLOUD_BASE_URL
+    assert backend.api_key == "secret"
+
+
+def test_cloud_factory_accepts_staging_override(config_file: pathlib.Path) -> None:
+    staging = "https://staging-api.memu.so/api/v4/memory/"
+    config_file.write_text(
+        f"MEMU_MEMORY_MODE=cloud\nMEMU_CLOUD_BASE_URL={staging}\nMEMU_CLOUD_API_KEY=secret\n",
+        encoding="utf-8",
+    )
+    menv.reload()
+
+    backend = menv.build_agentic_memory_backend_from_env()
+
+    assert isinstance(backend, CloudMemoryClient)
+    assert backend.base_url == staging
+
+
+def test_cloud_factory_requires_cloud_key(config_file: pathlib.Path) -> None:
+    config_file.write_text("MEMU_MEMORY_MODE=cloud\n", encoding="utf-8")
+    menv.reload()
+
+    with pytest.raises(menv.ConfigError, match=r"MEMU_CLOUD_API_KEY.*required in cloud mode"):
+        menv.build_agentic_memory_backend_from_env()
+
+
+def test_cloud_factory_does_not_create_local_database_path(
+    config_file: pathlib.Path,
+    tmp_path: pathlib.Path,
+) -> None:
+    config_file.write_text("MEMU_MEMORY_MODE=cloud\nMEMU_CLOUD_API_KEY=secret\n", encoding="utf-8")
+    menv.reload()
+    local_db = tmp_path / "should-not-exist" / "memu.sqlite3"
+
+    menv.build_agentic_memory_backend_from_env(local_database=str(local_db))
+
+    assert not local_db.parent.exists()
+
+
+def test_invalid_mode_is_a_clear_config_error(config_file: pathlib.Path) -> None:
+    config_file.write_text("MEMU_MEMORY_MODE=remote\n", encoding="utf-8")
+    menv.reload()
+
+    with pytest.raises(menv.ConfigError, match=r"local.*cloud"):
+        menv.memory_mode()
+
+
+async def test_doctor_reports_cloud_mode_endpoint_and_resource_limitation(
+    config_file: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config_file.write_text(
+        "MEMU_MEMORY_MODE=cloud\nMEMU_CLOUD_API_KEY=secret\n",
+        encoding="utf-8",
+    )
+    menv.reload()
+
+    async def retrieve_ok(query: str) -> dict[str, list[Any]]:
+        assert query == "smoke test"
+        return {"segments": [], "files": [], "resources": []}
+
+    monkeypatch.setattr(retrieval, "retrieve", retrieve_ok)
+
+    assert await _cmd_doctor(SPEC, argparse.Namespace()) == 0
+    output = capsys.readouterr().out
+    assert "mode      cloud" in output
+    assert f"endpoint  {DEFAULT_CLOUD_BASE_URL}" in output
+    assert "accepted but not currently persisted" in output
+    assert "retrieval ok" in output
+
+
+async def test_host_retrieval_uses_shared_backend_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Backend:
+        async def progressive_retrieve(
+            self,
+            query: str,
+            where: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            assert query == "tea"
+            assert where == {"user_id": "u1"}
+            return {"segments": [], "files": [], "resources": []}
+
+    monkeypatch.setattr(retrieval, "build_agentic_memory_backend_from_env", lambda: Backend())
+
+    assert await retrieval.retrieve("tea", where={"user_id": "u1"}) == {
+        "segments": [],
+        "files": [],
+        "resources": [],
+    }

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -251,10 +251,10 @@ def test_cloud_factory_needs_no_local_configuration(config_file: pathlib.Path) -
     assert backend.api_key == "secret"
 
 
-def test_cloud_factory_accepts_staging_override(config_file: pathlib.Path) -> None:
-    staging = "https://staging-api.memu.so/api/v4/memory/"
+def test_cloud_factory_accepts_custom_base_url(config_file: pathlib.Path) -> None:
+    custom_base_url = "https://cloud.example/api/v4/memory/"
     config_file.write_text(
-        f"MEMU_MEMORY_MODE=cloud\nMEMU_CLOUD_BASE_URL={staging}\nMEMU_CLOUD_API_KEY=secret\n",
+        f"MEMU_MEMORY_MODE=cloud\nMEMU_CLOUD_BASE_URL={custom_base_url}\nMEMU_CLOUD_API_KEY=secret\n",
         encoding="utf-8",
     )
     menv.reload()
@@ -262,7 +262,7 @@ def test_cloud_factory_accepts_staging_override(config_file: pathlib.Path) -> No
     backend = menv.build_agentic_memory_backend_from_env()
 
     assert isinstance(backend, CloudMemoryClient)
-    assert backend.base_url == staging
+    assert backend.base_url == custom_base_url
 
 
 def test_cloud_factory_requires_cloud_key(config_file: pathlib.Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -405,7 +405,7 @@ wheels = [
 
 [[package]]
 name = "memu-cli"
-version = "1.5.1"
+version = "2.0.0b0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Pull Request Summary

Add memU Cloud as an optional backend behind the existing `memu` and `memu-<host>` CLI commands while preserving local mode as the backward-compatible default.

Closes #545.

---

## What does this PR do?

- Adds `MEMU_MEMORY_MODE=local|cloud`, defaulting to `local`.
- Adds a structural `AgenticMemoryBackend` boundary and a shared environment-driven backend factory.
- Adds `CloudMemoryClient` for list, progressive retrieval, and commit.
- Keeps `MemoryService` and its public surface unchanged.
- Routes the main CLI, host retrieval, bridging pipeline, and doctor command through the shared factory.
- Uses separate `MEMU_CLOUD_BASE_URL` and `MEMU_CLOUD_API_KEY` settings.
- Sends explicit `user_id=default` and `agent_id=default` values when cloud scope is absent.
- Preserves the existing resource preparation/commit flow while documenting that memU Cloud currently accepts but does not persist resources.
- Adds bounded retries, explicit timeouts, structured error classification, and `Retry-After` support.
- Updates the README, packaged host installation/bridging documentation, and ADR index.
- Synchronizes `uv.lock` root-package metadata in a separate commit without changing third-party dependency versions.

The configured cloud base URL may include a trailing slash. Collection requests are normalized to `/api/v4/memory` because the deployed API treats `/api/v4/memory/` as a different, missing route.

---

## Why is this change needed?

The hosted memU v4 service exposes the same agentic operations used by the open-source host integrations. Selecting the backend through configuration lets agents and scheduled tasks keep using the same stable CLI commands, without introducing duplicate cloud-specific binaries or changing local storage behavior.

Related issue: #545.

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [x] Refactor / cleanup
- [ ] Other

---

## Validation

- `159 passed`
- `ruff check` passed
- `ruff format --check` passed
- `mypy` passed
- `uv lock --locked --offline` passed
- `git diff --check` passed
- Live Cloud API smoke test passed for list, commit, and search in the `default/default` scope.
- The live smoke test confirmed committed recall files are retrievable and resource responses remain empty as documented.

The local Windows environment does not have the MSVC `link.exe` required to rebuild the repository's existing Rust extension. The Python suite was therefore run with a temporary in-memory stub for the extension's current `hello_from_bin()` function; no Rust or package-build behavior is changed by this PR. CI performs the normal package build.

---

## PR Quality Checklist

- [x] PR title follows an allowed format
- [x] Changes are limited to cloud backend selection and its required documentation/tests
- [x] Documentation updated where applicable
- [x] No breaking changes; an unset mode preserves local behavior
- [x] Related issue linked

---

## Additional notes

- The production cloud base URL defaults to `https://api.memu.so/api/v4/memory/`.
- Users obtain a memU API key by registering at [memu.so](https://memu.so).
- API keys are never logged; process environment values override `~/.memu/config.env`.
