### PR TITLE
fix(commit): update recall file description on recommit

### DIFF
--- a/src/memu/app/agentic.py
+++ b/src/memu/app/agentic.py
@@ -303,8 +303,10 @@ class AgenticMixin:
         """Create-or-update each ``{name, track, description, content}`` as a ``RecallFile``.
 
         Keyed by ``name`` within the record's ``track`` (``memory``/``skill``). New files embed
-        their ``name: description`` for file-level recall; existing files keep their embedding
-        and only take the new content. Segments are then reconciled per track.
+        their ``name: description`` for file-level recall. Existing files always take the new
+        content and re-embed only when the description actually changed — commit always carries
+        a description (read from the local file), but it's usually unchanged. Segments are then
+        reconciled per track.
         """
         user_data = dict(user_scope or {})
         committed: list[RecallFile] = []
@@ -328,7 +330,17 @@ class AgenticMixin:
                     user_data=user_data,
                     track=file_track,
                 )
-            file = store.recall_file_repo.update_category(category_id=file.id, content=content)
+            # Commit always carries a description (read from the local file), so re-embed the
+            # file-level ``name: description`` vector only when it actually changed; otherwise
+            # leave the description/embedding untouched and just take the new content.
+            description_changed = bool(description) and description != file.description
+            new_embedding = await _embed_one(embed_client, f"{name}: {description}") if description_changed else None
+            file = store.recall_file_repo.update_category(
+                category_id=file.id,
+                description=description if description_changed else None,
+                embedding=new_embedding,
+                content=content,
+            )
             await self._commit_sync_file_segments(
                 file=file,
                 file_track=file_track,

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -99,6 +99,57 @@ async def test_recommit_updates_content_and_segments(service: MemoryService) -> 
     assert "likes coffee" not in [seg["text"] for seg in result["segments"]]
 
 
+class CountingEmbeddingClient(FakeEmbeddingClient):
+    """Wraps the fake to count ``embed`` calls, so tests can assert re-embeds."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def embed(self, inputs: list[str]) -> tuple[list[list[float]], None]:
+        self.calls += 1
+        return await super().embed(inputs)
+
+
+async def test_recommit_reembeds_description_only_when_changed(service: MemoryService) -> None:
+    counter = CountingEmbeddingClient()
+    service._embedding_pool._cache["default"] = counter
+    service._embedding_pool._cache["embedding"] = counter
+
+    file = {"name": "Profile", "track": "memory", "description": "who the user is", "content": "# P\nlikes coffee"}
+    await service.commit_results(recall_files=[file])
+
+    # Recommit with identical description and content: nothing needs embedding.
+    counter.calls = 0
+    await service.commit_results(recall_files=[dict(file)])
+    assert counter.calls == 0
+
+    # Recommit with a changed description: the file-level vector is refreshed exactly once
+    # (memory segments are per content line, so the unchanged content stays put).
+    counter.calls = 0
+    await service.commit_results(recall_files=[{**file, "description": "the user profile"}])
+    assert counter.calls == 1
+
+    listed = await service.list_all_recall_files()
+    profile = next(f for f in listed["categories"] if f["name"] == "Profile")
+    assert profile["description"] == "the user profile"
+
+
+async def test_recommit_updates_skill_description_and_segment(service: MemoryService) -> None:
+    file = {"name": "deploy-checklist", "track": "skill", "description": "how to deploy", "content": "step 1"}
+    await service.commit_results(recall_files=[file])
+    await service.commit_results(recall_files=[{**file, "description": "deploy the app"}])
+
+    listed = await service.list_all_recall_files()
+    skill = next(f for f in listed["categories"] if f["name"] == "deploy-checklist")
+    assert skill["description"] == "deploy the app"
+
+    # The skill's single segment is ``name: ...\ndescription: ...``, so it re-embeds too.
+    result = await service.progressive_retrieve("deploy")
+    seg_texts = [seg["text"] for seg in result["segments"]]
+    assert "name: deploy-checklist\ndescription: deploy the app" in seg_texts
+    assert "name: deploy-checklist\ndescription: how to deploy" not in seg_texts
+
+
 async def test_where_scope_filters_and_rejects_unknown_fields(service: MemoryService) -> None:
     await service.commit_results(
         recall_files=[{"name": "A", "track": "memory", "description": "d", "content": "alpha"}],


### PR DESCRIPTION
## Problem

`_commit_recall_files` only wrote `content` when a recall file already existed — a changed `description` (and its file-level `name: description` embedding) was silently dropped on recommit.

## Fix

- Propagate `description` on recommit.
- Re-embed the file-level `name: description` vector **only when the description actually changed**. Commit always carries a description (read from the local file) but it's usually unchanged, so the common path stays embed-free.
- An empty description never clobbers an existing one (guarded, plus `update_category`'s `is not None` semantics).
- For `skill`-track files the segment text is `name: ...\ndescription: ...`, so `_commit_sync_file_segments` re-embeds that segment automatically when the description changes.

## Tests

Added to `tests/test_agentic.py` (run against both inmemory and sqlite backends):

- `test_recommit_reembeds_description_only_when_changed` — asserts 0 embed calls when nothing changed, exactly 1 when the description changes, and the new description is persisted.
- `test_recommit_updates_skill_description_and_segment` — asserts a skill file's description and its recall segment both update.

All 14 tests in the file pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)