### PR TITLE
docs: clarify durable memory location

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,7 @@ It works for Codex, Claude Code, Cursor, OpenClaw, Hermes, WorkBuddy — and any
 
 ## Quick start
 
-memU keeps one shared memory store, configured by `MEMU_DB` in `~/.memu/config.env` (typically `~/.memu/memu.sqlite3` for local SQLite). Human-readable memory and skill Markdown files are mirrored under:
-
-- Codex: `~/.memu/memory/` and `~/.memu/skill/`
-- Other hosts: `~/.memu/hosts/<host>/memory/` and `~/.memu/hosts/<host>/skill/`
+Your memory lives in the shared store configured by `MEMU_DB` in `~/.memu/config.env` — typically `~/.memu/memu.sqlite3` for local SQLite, or a Postgres DSN.
 
 Once installed, your agent retrieves relevant memory automatically before answering. To retrieve manually, run the adapter for your host:
 


### PR DESCRIPTION
## Summary

- Remove the per-host `memory/` and `skill/` directories from the Quick start storage description.
- Point users only to the durable shared store configured by `MEMU_DB` in `~/.memu/config.env`.
- Keep the local SQLite and Postgres cases explicit.

## Why

The per-host directories are bridging working mirrors: `prepare` exports committed recall files there for agent editing, and `commit` writes changes back. They are not the canonical cross-host memory location. The durable shared memory is the SQLite or Postgres store behind `MEMU_DB`.

## Validation

- Verified against `src/memu/hosts/bridging/pipeline.py`, `recall_files.py`, and ADR 0010.
- `git diff --check`