### PR TITLE
docs: mark memU Cloud as coming soon

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ memU is a lightweight, agent-driven memory system that gives users a shared LLM 
 
 **Installation is agent-driven.** The guides are written for the agent, not for you. Choose Cloud or Local, then send your agent one message:
 
-**Cloud**
+**Cloud (coming soon)**
 
 > Read https://memu.pro/SKILL.md and follow it to install memU.
 


### PR DESCRIPTION
## What changed

- label the Cloud installation option as `Cloud (coming soon)`

## Why

The Cloud install path is not generally available yet, so the README should set the correct availability expectation.

## Validation

- `git diff --check` passes
- documentation-only one-line change; no runtime tests required