### PR TITLE
fix(hosts): isolate each host's write tree so concurrent memorize can't corrupt (#544)

### DIFF
--- a/src/memu/hosts/bridging/recall_files.py
+++ b/src/memu/hosts/bridging/recall_files.py
@@ -7,8 +7,34 @@ agent left behind.
 
 from __future__ import annotations
 
+import contextlib
+import os
+import tempfile
 from pathlib import Path
 from typing import Any
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write ``text`` to ``path`` so a concurrent reader never sees it half-written.
+
+    The inject hook (``retrieval``) now writes mirror files on the per-turn hot
+    path while agents read them, so a plain ``write_text`` could hand back a torn
+    file. Write to a uniquely-named temp in the same directory (so the final
+    ``os.replace`` is a same-filesystem atomic rename) and swap it in whole. The
+    unique temp name also lets two writers of the same target run without
+    clobbering each other's in-progress file — last rename wins, and since both
+    derive their content from the same store, the content is identical anyway.
+    """
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".tmp-", suffix=path.suffix)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp, path)
+    except BaseException:
+        # Never leave the temp file behind if the write or rename failed.
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
 
 
 def recall_file_path(base_dir: Path, subdir: str, name: str) -> Path:
@@ -32,7 +58,7 @@ def write_recall_file(base_dir: Path, subdir: str, recall_file: dict[str, Any]) 
     out_dir.mkdir(parents=True, exist_ok=True)
 
     out_path = recall_file_path(base_dir, subdir, name)
-    out_path.write_text(f"---\nname: {name}\ndescription: {description}\n---\n{content}", encoding="utf-8")
+    _atomic_write_text(out_path, f"---\nname: {name}\ndescription: {description}\n---\n{content}")
     return out_path
 
 

--- a/src/memu/hosts/codex/BRIDGING_TASK.md
+++ b/src/memu/hosts/codex/BRIDGING_TASK.md
@@ -22,15 +22,15 @@ installed.
 Each run walks a fixed pipeline that bridges raw session history into memU:
 
 1. **Prepare** — `memu-codex prepare` scans new turns under `~/.codex/sessions`,
-   mirrors the current memU recall files to `~/.memu/memory` and `~/.memu/skill`,
+   mirrors the current memU recall files to `~/.memu/hosts/codex/memory` and `~/.memu/hosts/codex/skill`,
    snapshots them by content hash, and writes a set of numbered **job-instruction
-   files** to `~/.memu/jobs/` (`1.txt`, `2.txt`, …). Each job is a self-contained
+   files** to `~/.memu/hosts/codex/jobs/` (`1.txt`, `2.txt`, …). Each job is a self-contained
    prompt telling the agent exactly what to mine from one session.
-2. **Self-evolve** — the agent opens each `~/.memu/jobs/*.txt` **in numeric
+2. **Self-evolve** — the agent opens each `~/.memu/hosts/codex/jobs/*.txt` **in numeric
    order** and follows it. Jobs come in three kinds: mine a session into user
    **memory**, mine a session into a **skill**, and **describe** the files the
-   sessions touched. They write and patch markdown under `~/.memu/memory` and
-   `~/.memu/skill`, and fill in `~/.memu/resources.md`. "Do nothing" is an
+   sessions touched. They write and patch markdown under `~/.memu/hosts/codex/memory` and
+   `~/.memu/hosts/codex/skill`, and fill in `~/.memu/hosts/codex/resources.md`. "Do nothing" is an
    allowed, common outcome for any job.
 3. **Commit** — `memu-codex commit` diffs the tracked directories against the
    step-1 snapshot, collects only the files the agent actually created or changed
@@ -70,7 +70,7 @@ and set its recurring prompt to this block **verbatim**:
 Run the memU bridging pipeline. Do the four steps strictly in order; do not
 skip a step even if the previous one looks like it produced nothing.
 
-1. LEFTOVERS. If ~/.memu/jobs/ already contains job files, they are unfinished
+1. LEFTOVERS. If ~/.memu/hosts/codex/jobs/ already contains job files, they are unfinished
    work from an earlier run (a crash, or the install itself). Process them
    exactly as step 3 describes, then run memu-codex commit — and only then
    continue.
@@ -79,10 +79,10 @@ skip a step even if the previous one looks like it produced nothing.
 
      memu-codex prepare
 
-   It regenerates ~/.memu/jobs/. If the command exits non-zero, stop and report
+   It regenerates ~/.memu/hosts/codex/jobs/. If the command exits non-zero, stop and report
    the error — do not continue.
 
-3. SELF-EVOLVE. List ~/.memu/jobs/*.txt and process them in ascending numeric
+3. SELF-EVOLVE. List ~/.memu/hosts/codex/jobs/*.txt and process them in ascending numeric
    order (1.txt, then 2.txt, …). There may be anywhere from 0 to ~21 files, and
    the count changes every run — always glob and sort; never assume a fixed
    number. If there are no job files, skip to step 4.
@@ -118,7 +118,7 @@ are new Codex sessions since the last run.
   be minable again; draining leftovers first turns a half-done cycle into
   bounded re-work instead of silent loss.
 - **Idempotent and incremental.** `prepare` tracks a per-session line cursor in
-  `~/.memu/.session_manifest.codex.json`, so each run only processes turns it
+  `~/.memu/hosts/codex/.session_manifest.codex.json`, so each run only processes turns it
   hasn't seen. A run with no new session activity correctly does nothing.
 - **Ordering is load-bearing.** Memory jobs are numbered before skill jobs, and
   the resource-describe job is last — later jobs depend on files earlier ones

--- a/src/memu/hosts/codex/INSTALL.md
+++ b/src/memu/hosts/codex/INSTALL.md
@@ -148,7 +148,7 @@ memu-codex docs task
 It is authoritative. In summary, you will settle a cron schedule with the user
 (default: every hour, `0 * * * *`) and create a Codex scheduled task whose
 recurring prompt is the three-step block that document gives you verbatim —
-`memu-codex prepare`, then the agent works through `~/.memu/jobs/*.txt` in order,
+`memu-codex prepare`, then the agent works through `~/.memu/hosts/codex/jobs/*.txt` in order,
 then `memu-codex commit`.
 
 Nothing in that prompt is machine-specific. If you find yourself substituting an

--- a/src/memu/hosts/codex/UNINSTALL.md
+++ b/src/memu/hosts/codex/UNINSTALL.md
@@ -68,18 +68,19 @@ Only one thing overrides a default: the user's own explicit words.
   reinstalling later picks it right back up. Delete it only if the user
   explicitly asked to erase their memory as part of this uninstall, and warn
   first, in plain words, that it is irreversible.
-- **The session cursor lives and dies with the store.** The `.session_manifest*` files
-  directly under `~/.memu/`
-  records which session turns have already been mined *into that store*. Store
+- **The session cursor lives and dies with the store.** The `.session_manifest*`
+  files under `~/.memu/hosts/codex/`
+  record which session turns have already been mined *into that store*. Store
   kept (the default)? Keep the cursor — deleting it loses no memory, but the
   next install re-mines every old session for nothing. Store deleted at the
   user's request? Delete the cursor with it — a surviving cursor over an empty
   store marks history as already mined, and it would never be mined again.
-- **Remove this host's residue.** Codex predates the per-host layout, so its
-  run-scoped state sits directly under `~/.memu/`: the `jobs/`, `memory/`,
-  `skill/`, and `resources/` directories — but **not** the `.session_manifest*`
-  cursor files (see above). **Never** sweep `~/.memu/` wholesale to get them —
-  `config.env`, the store file, and the cursor live there too. Also
+- **Remove this host's residue.** Codex's run-scoped working tree is
+  `~/.memu/hosts/codex/`: the `jobs/`, `sessions/`, `memory/`, and `skill/`
+  directories and `resources.md` — but **not** the `.session_manifest*` cursor
+  files there (see above), unless the store is going too. The shared
+  `~/.memu/config.env` and the store file sit at the `~/.memu/` root, outside
+  this tree, so removing the tree never touches them. Also
   `~/.codex/AGENTS.md` itself **if** Part 2
   left it empty (it held only memU's block, so the install created it) — a
   file with the user's own content stays, of course.

--- a/src/memu/hosts/codex/cli.py
+++ b/src/memu/hosts/codex/cli.py
@@ -54,9 +54,6 @@ SPEC = HostSpec(
     session_help="Codex session log",
     instruction_path=AGENTS_MD,
     skills_dir=SKILLS_DIR,
-    # Codex shipped before per-host working trees; its ~/.memu layout is a
-    # compatibility contract with already-scheduled bridging prompts (ADR 0010).
-    base_dir="~/.memu",
 )
 
 

--- a/src/memu/hosts/retrieval.py
+++ b/src/memu/hosts/retrieval.py
@@ -24,7 +24,7 @@ from typing import Any
 
 from memu.env import build_service_from_env
 from memu.hosts.bridging.layout import BASE_DIR, TRACK_DIRS
-from memu.hosts.bridging.recall_files import recall_file_path
+from memu.hosts.bridging.recall_files import write_recall_file
 
 
 async def retrieve(query: str, where: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -38,19 +38,6 @@ async def retrieve(query: str, where: dict[str, Any] | None = None) -> dict[str,
     service = build_service_from_env()
     result: dict[str, Any] = await service.progressive_retrieve(query, where=where)
     return _shape_for_agent(result)
-
-
-def _mirror_path(base: Path, track: Any, name: Any) -> Path | None:
-    """The mirror path a recall file *should* live at, or ``None`` if unlocatable.
-
-    Unlocatable means the file's track has no mirror directory (only
-    ``memory``/``skill`` are mirrored) or it has no name — in either case there
-    is no path to hand the agent, so the caller falls back to inline content.
-    """
-    subdir = TRACK_DIRS.get(track or "")
-    if subdir is None or not name:
-        return None
-    return recall_file_path(base, subdir, str(name))
 
 
 def _source_label(track: Any, name: Any) -> str | None:
@@ -73,12 +60,16 @@ def _shape_for_agent(result: dict[str, Any]) -> dict[str, Any]:
     Matching the instruction's contract that files and resources come back as
     *a location plus a summary* rather than full text:
 
-    * ``files`` shed their ``content``: when the on-disk mirror
-      (``~/.memu/<track>/<name>.md``) exists, they carry a ``path`` to it; when
-      it does not — the user owns that tree and may delete it — they keep the
-      ``content`` inline and emit *no* ``path``, so the agent never sees a
-      location that isn't there. The internal ``resource_urls`` link list is
-      dropped: the standing instruction never names it, so it is noise.
+    * ``files`` shed their ``content`` for a ``path``. The mirror at
+      ``~/.memu/<track>/<name>.md`` is now the retrieve hook's own to keep: since
+      every memorize run writes under its per-host tree (``~/.memu/hosts/<host>/``,
+      #544), nothing else writes this shared root, so retrieve bootstraps the
+      mirror itself — writing the file out (atomically) and handing over the
+      openable ``path``. Only a genuinely unmappable file (a track with no mirror
+      directory, or one with no name) has nowhere to live, and there we keep the
+      ``content`` inline and emit *no* ``path`` rather than dangle a location that
+      can't exist. The internal ``resource_urls`` link list is dropped: the
+      standing instruction never names it, so it is noise.
     * ``segments`` swap the internal ``recall_file_id`` UUID for ``source_file``,
       the ``<track>/<name>`` id of their parent file — an identifier for finding
       the fuller document in ``files``, not a path to open (that is the file's
@@ -90,17 +81,26 @@ def _shape_for_agent(result: dict[str, Any]) -> dict[str, Any]:
 
     file_labels: dict[str, str | None] = {}
     for file in result.get("files", []):
-        file_labels[file.get("id")] = _source_label(file.get("track"), file.get("name"))
+        track = file.get("track")
+        name = file.get("name")
+        file_labels[file.get("id")] = _source_label(track, name)
 
-        path = _mirror_path(base, file.get("track"), file.get("name"))
         content = file.pop("content", None)
         file.pop("resource_urls", None)
-        if path is not None and path.exists():
-            # The mirror is on disk: hand over the openable location, not the text.
-            file["path"] = str(path)
+
+        subdir = TRACK_DIRS.get(track or "")
+        if subdir is not None and name:
+            # Bootstrap the mirror ourselves and hand over the openable location,
+            # not the text. Re-writing an existing mirror is harmless (same store
+            # content) and heals one the user deleted.
+            out_path = write_recall_file(
+                base, subdir, {"name": name, "description": file.get("description", ""), "content": content}
+            )
+            file["path"] = str(out_path)
         else:
-            # Unlocatable, or the mirror is gone: keep the text inline and emit no
-            # dead path, so the agent never reasons about a file that isn't there.
+            # No mirrorable location (unknown track, or no name): keep the text
+            # inline and emit no dead path, so the agent never reasons about a
+            # file that isn't there.
             file["content"] = content
 
     for segment in result.get("segments", []):

--- a/tests/test_host_retrieval.py
+++ b/tests/test_host_retrieval.py
@@ -3,10 +3,11 @@
 ``progressive_retrieve`` returns raw store records; :func:`_shape_for_agent` turns
 them into the progressive form the standing instruction promises — files and
 resources as *a location plus a summary*, segments naming their source. These pin
-that contract: a file gives way to a mirror ``path`` when it is on disk and keeps
-its text inline (with no dead ``path``) when it is not; a segment carries the
-``track/name`` id of its parent file, not a filesystem path; and resources
-collapse the duplicated url/local_path down to one ``path``.
+that contract: a mirrorable file is bootstrapped to disk and gives way to its
+mirror ``path``; an unmappable file (no mirror dir, or no name) keeps its text
+inline with no dead ``path``; a segment carries the ``track/name`` id of its
+parent file, not a filesystem path; and resources collapse the duplicated
+url/local_path down to one ``path``.
 """
 
 from __future__ import annotations
@@ -40,28 +41,44 @@ def _result() -> dict:
     }
 
 
-def test_present_mirror_replaces_content_with_path(tmp_path: pathlib.Path, monkeypatch) -> None:
+def test_mirrorable_file_is_bootstrapped_and_replaces_content_with_path(tmp_path: pathlib.Path, monkeypatch) -> None:
     monkeypatch.setattr(retrieval, "BASE_DIR", str(tmp_path))
-    # The mirror file exists on disk (space in the name becomes a dash).
-    write_recall_file(tmp_path, "memory", {"name": "coffee preferences", "description": "d", "content": "No sugar."})
-
+    # Nothing on disk yet: retrieve now owns this tree and bootstraps the mirror.
     shaped = retrieval._shape_for_agent(_result())
 
     file = shaped["files"][0]
     assert "content" not in file, "a locatable file hands over a path, not its full text"
     assert "resource_urls" not in file, "the internal link list the instruction never names is dropped"
-    assert file["path"] == str(tmp_path / "memory" / "coffee-preferences.md")
+    # The mirror was written out (space in the name becomes a dash) and its path handed back.
+    out_path = tmp_path / "memory" / "coffee-preferences.md"
+    assert file["path"] == str(out_path)
+    assert out_path.read_text(encoding="utf-8").endswith("No sugar."), "the mirror carries the file's content"
 
 
-def test_missing_mirror_keeps_content_inline_with_no_path(tmp_path: pathlib.Path, monkeypatch) -> None:
+def test_bootstrap_overwrites_a_stale_mirror(tmp_path: pathlib.Path, monkeypatch) -> None:
     monkeypatch.setattr(retrieval, "BASE_DIR", str(tmp_path))
-    # No file written: the mirror is gone, so the result must stay self-sufficient
-    # and must NOT dangle a path at a file that isn't there.
+    # A pre-existing mirror with different content must be healed to the store's.
+    write_recall_file(tmp_path, "memory", {"name": "coffee preferences", "description": "d", "content": "STALE"})
+
     shaped = retrieval._shape_for_agent(_result())
 
     file = shaped["files"][0]
-    assert file["content"] == "No sugar.", "with no file to open, the text must survive inline"
-    assert "path" not in file, "a missing mirror must not leave a dead path for the agent to chase"
+    assert file["path"] == str(tmp_path / "memory" / "coffee-preferences.md")
+    assert (tmp_path / "memory" / "coffee-preferences.md").read_text(encoding="utf-8").endswith("No sugar.")
+
+
+def test_unmappable_file_keeps_content_inline_with_no_path(tmp_path: pathlib.Path, monkeypatch) -> None:
+    monkeypatch.setattr(retrieval, "BASE_DIR", str(tmp_path))
+    # A file whose track has no mirror directory has nowhere to live: the result
+    # must stay self-sufficient and must NOT dangle a path at a file that isn't there.
+    result = _result()
+    result["files"][0]["track"] = "resource"  # not in TRACK_DIRS
+
+    shaped = retrieval._shape_for_agent(result)
+
+    file = shaped["files"][0]
+    assert file["content"] == "No sugar.", "with nowhere to mirror, the text must survive inline"
+    assert "path" not in file, "an unmappable file must not leave a dead path for the agent to chase"
 
 
 def test_segment_names_its_source_file_by_track_and_name(tmp_path: pathlib.Path, monkeypatch) -> None:


### PR DESCRIPTION
## Why

Partial mitigation for #544. If a user installs memU for two hosts (e.g. Codex + Claude) and both fire a scheduled memorize at the same time, they could stomp a shared working tree and corrupt each other.

The tree was *already* mostly isolated: every non-codex host writes under `~/.memu/hosts/<host>/`. Only **codex** still sat at the bare `~/.memu` root — which is also the tree the retrieve hook reads. That one host is the remaining collision surface.

## What changed

**1. Codex onto the standard per-host tree.** Dropped codex's legacy `base_dir="~/.memu"` override so it resolves to `~/.memu/hosts/codex` like every other host. No new machinery — `Layout` was already fully host-scoped via `base`. Codex's agent-facing docs (BRIDGING_TASK / INSTALL / UNINSTALL) that embed the working-tree paths into the scheduled prompt are updated to match.

**2. Retrieve owns the shared root.** With the root vacated by memorize, `_shape_for_agent` now bootstraps the mirror itself and always hands the agent an openable `path`, replacing the optimistic `exists()`-check + inline-content fallback. The inline fallback is kept only for genuinely unmappable files (unknown track / no name).

**3. Atomic mirror writes.** `write_recall_file` now writes temp-then-`rename`. Retrieve is now a writer on the per-turn hot path while agents read the same files, so this prevents torn reads; two hosts' retrieves each rename their own temp (last wins, identical store content). `prepare` gets the same atomicity for free.

## Scope / non-goals

- This stops **file-tree** corruption. It does **not** serialize two `commit`s against the shared store — that still needs the real lock discussed in #544.
- No data migration (confirmed with maintainers: still a small internal test env). A fresh codex run simply starts writing under the new tree; old `~/.memu/{jobs,memory,...}` leftovers are ignored.

## Testing

`uv run pytest` — 135 passed. Retrieval tests updated to the new bootstrap contract (bootstrap-and-path, stale-mirror-heals, unmappable-stays-inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)