### PR TITLE
fix(inject): use the binary's absolute path when the bare name isn't on a minimal PATH

### DIFF
--- a/src/memu/hosts/instruction.py
+++ b/src/memu/hosts/instruction.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import argparse
 import difflib
+import os
 import re
 import shutil
 from pathlib import Path
@@ -97,9 +98,22 @@ def begin(binary: str) -> str:
     return BEGIN_TEMPLATE.format(binary=binary)
 
 
+def _invocation(binary: str) -> str:
+    """The command the agent runs: the bare name, or its absolute path when the
+    name only resolves via a dir a GUI-launched agent may drop (pipx's
+    ``~/.local/bin``) — so the inject can't 'command not found' at runtime."""
+    if os.name != "posix":
+        return binary
+    found = shutil.which(binary)
+    if found is None:
+        return binary
+    minimal = os.pathsep.join(["/usr/local/bin", "/opt/homebrew/bin", os.defpath])
+    return binary if shutil.which(binary, path=minimal) else found
+
+
 def skill_document(binary: str) -> str:
     """The ``SKILL.md`` as written to disk, telling the agent how to retrieve."""
-    return SKILL_TEMPLATE.format(binary=binary)
+    return SKILL_TEMPLATE.format(binary=_invocation(binary))
 
 
 def instruction(binary: str, *, skill: bool = False) -> str:
@@ -110,7 +124,7 @@ def instruction(binary: str, *, skill: bool = False) -> str:
     """
     if skill:
         return SKILL_INSTRUCTION_TEMPLATE.format(skill=SKILL_NAME, binary=binary)
-    return INSTRUCTION_TEMPLATE.format(binary=binary)
+    return INSTRUCTION_TEMPLATE.format(binary=_invocation(binary))
 
 
 def block(binary: str, *, skill: bool = False) -> str:

--- a/tests/test_host_instruction.py
+++ b/tests/test_host_instruction.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import pathlib
 
+import pytest
+
 from memu.hosts import instruction
 from memu.hosts.codex.cli import AGENTS_MD, SKILLS_DIR, build_parser
 
@@ -128,6 +130,28 @@ def test_instruction_names_the_llm_free_retrieval() -> None:
     """`memu retrieve` is LLM-routed — one LLM call per turn is what this avoids."""
     assert "memu-codex retrieve" in instruction.instruction(BINARY)
     assert "`memu retrieve" not in instruction.instruction(BINARY)
+
+
+def test_invocation_uses_absolute_path_when_binary_is_off_the_minimal_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A GUI-launched agent's PATH may drop pipx's ~/.local/bin, so a bare name
+    would 'command not found' at runtime. Fall back to the absolute path."""
+    abs_path = "/Users/dev/.local/bin/memu-codex"
+    monkeypatch.setattr("os.name", "posix")
+    monkeypatch.setattr("shutil.which", lambda cmd, path=None: abs_path if path is None else None)
+    assert f"{abs_path} retrieve" in instruction.instruction(BINARY)
+    assert f"{abs_path} retrieve" in instruction.skill_document(BINARY)
+
+
+def test_invocation_keeps_the_bare_name_when_it_is_on_a_standard_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("os.name", "posix")
+    monkeypatch.setattr("shutil.which", lambda cmd, path=None: "/opt/homebrew/bin/memu-codex")
+    text = instruction.instruction(BINARY)
+    assert "`memu-codex retrieve" in text
+    assert "/opt/homebrew/bin" not in text
 
 
 def test_remove_restores_user_content_byte_for_byte(tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
Fixes #569.

## Problem

The inject runs `<binary> retrieve` by **bare name**, which only resolves if the binary is on the **agent's runtime PATH**. GUI/desktop clients get a minimal PATH that drops pipx's `~/.local/bin`, so the command hits *command not found*, the agent concludes the tool isn't installed, and the inject **silently no-ops**. Real case (Hermes desktop): the agent ran `memu-hermes retrieve …`, replied *"memu-hermes isn't installed on this machine"*, and answered with no memory — while the exact command worked from a terminal.

## Fix

At instruction-build time, resolve the binary from a minimal, GUI-like PATH (`/usr/local/bin:/opt/homebrew/bin` + `os.defpath`). If it only lives in a non-standard dir (`~/.local/bin`, a venv), embed its **absolute path** in the inject instead of the bare name; otherwise keep the bare name. No user action, and terminal installs are unchanged.

This follows #568's precedent of verifying/invoking by full path when PATH is unreliable.

## Changes

- `src/memu/hosts/instruction.py` — `_invocation(binary)` helper; used by the inline `instruction()` and by `skill_document()`. The `begin()` marker keeps the bare name (it's a label, not a command).
- `tests/test_host_instruction.py` — two tests: absolute path when the name is off a minimal PATH, bare name when it's on one.

Existing assertions are substrings (`"memu-codex retrieve" in …`), which an absolute path still satisfies, so they're unaffected.

## Not a full guarantee

The path is resolved at install time. If memU is later moved/reinstalled elsewhere, re-run `install-instruction` to refresh it — the same assumption as any install; day-to-day pipx upgrades keep the path stable.

## Test

`uv run pytest` → 179 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
