### PR TITLE
docs: remove coming soon label

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ memU works with Codex, Claude Code, Cursor, OpenClaw, Hermes, WorkBuddy, and mor
 
 Choose Cloud or Local, then send the corresponding message to your agent.
 
-### Cloud (coming soon)
+### Cloud
 
 **Cross-device · Free · Unlimited · [View online](https://memu.so)**
 


### PR DESCRIPTION
## What changed

- Removed the `coming soon` qualifier from the Cloud heading in the README.

## Why

The Cloud option is available, so the README should no longer present it as upcoming.

## Impact

Documentation-only change. No runtime behavior is affected.

## Validation

- `git diff --check`
- Confirmed no `coming soon` text remains in README files