### PR TITLE
feat(hosts): self-updating instruction templates and docs from the server (ADR 0013)

### DIFF
--- a/docs/adr/0013-self-updating-instruction-templates.md
+++ b/docs/adr/0013-self-updating-instruction-templates.md
@@ -1,0 +1,156 @@
+ADR 0013: Self-Updating Instruction Templates
+
+- Status: Accepted
+- Date: 2026-07-25
+- Builds on: ADR 0008 (two host seams — record and inject), ADR 0012 (config in
+  `~/.memu`, one shared backend selector)
+- Scope: how the agent-facing instruction *text* the SDK carries — the three
+  self-evolve job templates and the retrieval body — stays current between SDK
+  releases. It changes neither the bridging pipeline's structure nor the host
+  command surface.
+
+## Context
+
+Four blocks of text drive the agents memU steers, and all four ship embedded in
+the SDK as Python string constants:
+
+- `MEMORY_JOB_TEMPLATE`, `SKILL_JOB_TEMPLATE`
+  (`memu/hosts/bridging/instructions.py`) and `RESOURCE_JOB_TEMPLATE`
+  (`memu/hosts/bridging/resources.py`) — the **job templates**, filled with
+  concrete paths at `prepare` time and handed to the self-evolve agent.
+- `RETRIEVAL_BODY` (`memu/hosts/instruction.py`) — the **retrieval body**,
+  installed into a host's `SKILL.md` or its managed instruction block, and read
+  by the agent on every turn. The server publishes it as a *full skill document*
+  (`retrieval-skill.txt` — frontmatter, `# Retrieve…` heading, and body): a skill
+  host writes it verbatim, and an inline host carves out just the body
+  (`_skill_body`) to slot into its own managed block.
+
+Embedded text is a floor, not a ceiling. A wording fix or a better mining prompt
+cannot reach an install until that install upgrades the SDK, and installs upgrade
+rarely. We want these four to track a server-hosted copy so an improvement
+reaches the field without a release — while never becoming *dependent* on the
+server, since the embedded copy is always shippable-correct.
+
+The two kinds of template are consumed on very different duty cycles, which the
+design must respect:
+
+1. **Job templates** are read only on the `prepare` run — hourly-to-daily,
+   latency-tolerant, off the user's interactive path. Pulling every run is fine.
+2. **The retrieval body** backs a file the host re-reads every turn, and the
+   `retrieve` command runs on that same per-turn hot path. It must never fetch
+   there. But its durable copy already lives on disk (the installed `SKILL.md` /
+   managed block), so it needs refreshing only occasionally.
+
+## Decision
+
+### One fail-open resolver, `memu/hosts/templates.py`
+
+A single module fetches `https://memu.pro/sdk/instructions/<name>.txt` for the
+four names `memory-job`, `skill-job`, `resource-job`, `retrieval-skill`, and is
+**fail-open by construction**: a missing network, a non-200, an oversize body
+(> 64 KiB), or a malformed template all collapse to "fall back". No call raises.
+
+The base URL defaults to `https://memu.pro/sdk/instructions` and is overridable
+with `MEMU_TEMPLATE_BASE_URL`; setting it empty switches remote refresh off
+entirely (air-gapped installs, offline CI, the test suite).
+
+The `/sdk/` path segment marks these as SDK-consumed assets, not a human-facing
+page. There is deliberately **no version segment today** (see Open issues).
+
+### Validation is the trust boundary
+
+These templates are instructions an autonomous agent executes with shell access,
+and the job templates are `str.format()`-ed with concrete paths downstream. A
+server-side typo must therefore be rejected before it is trusted, never carried
+into a job file where `.format()` would raise mid-run. A fetched template is used
+only if it is non-empty, contains every required `{placeholder}` for its name,
+and `.format()`-s cleanly against exactly those keys — which rejects a dropped
+placeholder, a stray brace, and an unknown field alike. The same check re-runs on
+every cache read, so a truncated or hand-edited cache file is treated as absent.
+
+### Two fallback shapes, matched to the two duty cycles
+
+- **`resolve(name, embedded)` — server → last-good cache → embedded.** Used for
+  the job templates at `prepare` time. A validated fetch also writes the text to
+  a local last-good cache (`~/.memu/cache/instructions/<name>.txt`, shared across
+  hosts since the templates are host-agnostic). The cache is what makes a
+  *transient* outage a non-event: once an install has seen `v1`, a later day
+  whose pull fails still runs `v1` rather than regressing to the embedded `v0`.
+
+- **`fetch(name)` — server only, no cache.** Used for the retrieval skill
+  (`retrieval-skill`), served as a full `SKILL.md` document. Its durable copy is
+  not a cache but the file already installed on disk, so there is nothing extra to
+  cache. `install-instruction` uses `fetch(...) or embedded` (an explicit, one-off
+  command; the embedded floor is correct when the server is down mid-install). The
+  scheduled refresh (below) uses `fetch(...)` and **skips the write entirely on
+  `None`**, so a transient outage leaves the already-installed — and newer — copy
+  in place rather than downgrading it.
+
+### The retrieval body refreshes on the bridging schedule, never on retrieve
+
+`instruction.refresh()` rewrites whatever holds the retrieval body — the
+`SKILL.md` on a skill host (the server document verbatim), the inline managed
+block on an inline host (just the body, carved out of that document by
+`_skill_body`) — and is called from `_cmd_prepare`. This piggybacks the refresh on the low-frequency
+`prepare` run the host already schedules, giving the "larger interval" the hot
+path requires for free, with no timestamp bookkeeping. It is **best-effort**
+(a failure is a note, never a failed `prepare`), **skip-not-downgrade** (see
+above), and **refresh-not-bootstrap** (it does nothing where nothing is
+installed yet — installing remains `install-instruction`'s job, so a scheduled
+run never creates files a user did not ask for).
+
+## Consequences
+
+Positive:
+
+- A prompt improvement reaches every install on its next `prepare`, without a
+  release.
+- The embedded copy remains a guaranteed floor; the server is pure upside and
+  never a runtime dependency. A total outage degrades to embedded, never to
+  nothing.
+- The per-turn `retrieve` path is untouched — it still performs no network I/O
+  for templates.
+- A malformed server template cannot crash the pipeline or reach an agent.
+
+Costs / limitations:
+
+- `prepare` now makes up to four short, timeout-bounded HTTP calls per run. This
+  is acceptable on its duty cycle and fully disabled by `MEMU_TEMPLATE_BASE_URL=""`.
+- The server copy is trusted after structural validation but is **not
+  cryptographically verified** (see Open issues).
+
+## Open issues
+
+- **No version numbers on the cache (deliberate, for now).** The last-good cache
+  keeps *the last text seen*, not *the newest by version*. One regression follows
+  from this: if the SDK is upgraded while the server is unreachable, a cached
+  older-server copy can momentarily win over a newer embedded template, because
+  nothing lets the resolver compare their ages. We accept this because it
+  self-heals on the next successful pull — and a release publishes the matching
+  server copy, so that pull is imminent — and because it can only affect the
+  low-frequency job templates for at most a run or two (the retrieval body is
+  uncached, so it is immune). The fix, when the infrastructure is ready, is a
+  monotonic version integer on each template so the offline branch can pick the
+  newest of {cache, embedded} while a reachable server stays authoritative
+  (letting deliberate rollbacks still win). Not built yet.
+
+- **No signing / integrity verification.** Because these templates are executed
+  by an agent with shell access, a compromised `memu.pro/sdk/instructions/…` is a
+  meaningful supply-chain surface. Today's guards are HTTPS, a pinned host, a size
+  cap, and structural validation. Shipping a public key in the SDK and verifying
+  a detached signature over each template is the recommended hardening.
+
+- **No URL schema-version segment.** The placeholder set each template requires
+  is a contract between the server copy and the installed SDK. Today an old SDK
+  that fetches a server template needing a new placeholder simply rejects it in
+  validation and falls back — safe, but it silently forgoes the upgrade. A `/v1/`
+  segment bumped only when the placeholder contract changes would let the server
+  serve contract-compatible copies per SDK generation. Cheap to add later; left
+  out now to keep the first cut simple.
+
+## Out of scope
+
+- Versioned or signed template distribution (tracked above).
+- Any change to what the templates *say* — only to how they are delivered.
+- The bridging pipeline's prepare → self-evolve → commit structure (ADR 0008).
+- Backend selection and cloud/local execution (ADR 0012).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,3 +12,4 @@
 - [0010: Multi-Host Adapters — Claude Code, Cursor, OpenClaw, and Hermes](0010-multi-host-adapters.md)
 - [0011: A Generic Host Adapter — Detect First, Then Bind What Works](0011-generic-host-adapter.md)
 - [0012: Cloud-Backed Memory Behind the Existing CLI](0012-cloud-backed-agentic-backend.md)
+- [0013: Self-Updating Instruction Templates — Server First, Last-Good Next, Embedded Last](0013-self-updating-instruction-templates.md)

--- a/src/memu/hosts/bridging/instructions.py
+++ b/src/memu/hosts/bridging/instructions.py
@@ -152,6 +152,9 @@ def prepare_instruction_jobs(
     skill_dir: Path,
     resource_log: Path,
     num_sessions: int,
+    *,
+    memory_template: str = MEMORY_JOB_TEMPLATE,
+    skill_template: str = SKILL_JOB_TEMPLATE,
 ) -> None:
     """Write per-session job-instruction files under ``job_dir``.
 
@@ -160,20 +163,24 @@ def prepare_instruction_jobs(
     (mining ``<idx>_full.jsonl``). Memory jobs are numbered first (1..N), skill
     jobs after them (N+1..2N) — ordering is load-bearing, since the skill jobs
     are what populate ``resource_log`` for the resource job that comes last.
+
+    ``memory_template``/``skill_template`` default to the embedded constants and
+    are overridden by :func:`~memu.hosts.bridging.pipeline.prepare` with the
+    server's current copy when it is reachable (:mod:`memu.hosts.templates`).
     """
     job_dir.mkdir(parents=True, exist_ok=True)
     for stale in job_dir.glob("*.txt"):
         stale.unlink()
 
     for idx in range(1, num_sessions + 1):
-        instruction = MEMORY_JOB_TEMPLATE.format(
+        instruction = memory_template.format(
             input_path=session_dir / f"{idx}.jsonl",
             track_dir=memory_dir,
         )
         (job_dir / f"{idx}.txt").write_text(instruction, encoding="utf-8")
 
     for idx in range(1, num_sessions + 1):
-        instruction = SKILL_JOB_TEMPLATE.format(
+        instruction = skill_template.format(
             input_path=session_dir / f"{idx}_full.jsonl",
             track_dir=skill_dir,
             resource_log=resource_log,

--- a/src/memu/hosts/bridging/pipeline.py
+++ b/src/memu/hosts/bridging/pipeline.py
@@ -15,12 +15,13 @@ import os
 from typing import Any
 
 from memu.env import build_agentic_memory_backend_from_env
+from memu.hosts import templates
 from memu.hosts.base import TranscriptSource
-from memu.hosts.bridging.instructions import prepare_instruction_jobs
+from memu.hosts.bridging.instructions import MEMORY_JOB_TEMPLATE, SKILL_JOB_TEMPLATE, prepare_instruction_jobs
 from memu.hosts.bridging.layout import TRACK_DIRS, Layout
 from memu.hosts.bridging.manifest import diff_tracked, snapshot_tracked
 from memu.hosts.bridging.recall_files import read_recall_file, write_recall_file
-from memu.hosts.bridging.resources import prepare_resource_job, read_resources
+from memu.hosts.bridging.resources import RESOURCE_JOB_TEMPLATE, prepare_resource_job, read_resources
 from memu.hosts.bridging.transcripts import prepare_transcripts
 
 MAX_JOBS = 10
@@ -67,6 +68,10 @@ async def prepare(
     # eventually crowd out every file the current run actually touched.
     layout.resource_log.unlink(missing_ok=True)
 
+    # Pull the current job templates from the server, each falling back to its
+    # last-good cache and then the embedded copy (:mod:`memu.hosts.templates`).
+    # prepare is low-frequency and latency-tolerant, so pulling every run is fine;
+    # a total outage silently degrades to the embedded text the SDK shipped with.
     prepare_instruction_jobs(
         job_dir=layout.jobs,
         session_dir=layout.sessions,
@@ -74,12 +79,15 @@ async def prepare(
         skill_dir=layout.skill,
         resource_log=layout.resource_log,
         num_sessions=num_sessions,
+        memory_template=templates.resolve(templates.MEMORY_JOB, MEMORY_JOB_TEMPLATE),
+        skill_template=templates.resolve(templates.SKILL_JOB, SKILL_JOB_TEMPLATE),
     )
     prepare_resource_job(
         job_dir=layout.jobs,
         verify_command=verify_command,
         resource_file=layout.resources,
         job_index=2 * num_sessions + 1,
+        template=templates.resolve(templates.RESOURCE_JOB, RESOURCE_JOB_TEMPLATE),
     )
     return num_sessions
 

--- a/src/memu/hosts/bridging/resources.py
+++ b/src/memu/hosts/bridging/resources.py
@@ -120,8 +120,20 @@ def read_resources(resource_file: Path) -> list[dict[str, Any]]:
     return records
 
 
-def prepare_resource_job(job_dir: Path, verify_command: str, resource_file: Path, job_index: int) -> None:
-    """Write the resource-describe job as ``<job_index>.txt`` under ``job_dir``."""
-    instruction = RESOURCE_JOB_TEMPLATE.format(verify_command=verify_command, resource_file=resource_file)
+def prepare_resource_job(
+    job_dir: Path,
+    verify_command: str,
+    resource_file: Path,
+    job_index: int,
+    *,
+    template: str = RESOURCE_JOB_TEMPLATE,
+) -> None:
+    """Write the resource-describe job as ``<job_index>.txt`` under ``job_dir``.
+
+    ``template`` defaults to the embedded constant and is overridden by
+    :func:`~memu.hosts.bridging.pipeline.prepare` with the server's current copy
+    when it is reachable (:mod:`memu.hosts.templates`).
+    """
+    instruction = template.format(verify_command=verify_command, resource_file=resource_file)
     job_dir.mkdir(parents=True, exist_ok=True)
     (job_dir / f"{job_index}.txt").write_text(instruction, encoding="utf-8")

--- a/src/memu/hosts/claude_code/BRIDGING_TASK.md
+++ b/src/memu/hosts/claude_code/BRIDGING_TASK.md
@@ -118,7 +118,7 @@ memu-claude-code schedule uninstall   # remove it
 
 `install` writes the prompt to a file plus a small PowerShell wrapper that reads
 it (nothing long ever touches the command line), bakes in the absolute path to
-`claude`, and registers a task named `\memU\memu-bridging-claude-code` under an
+`claude`, and registers a task named `\memU\memu-remember-claude-code` under an
 **S4U** principal — it runs whether or not you're logged in, windowless, and
 catches up a run missed while the machine was off. `--interval <minutes>` changes
 the cadence (default 60).

--- a/src/memu/hosts/codex/BRIDGING_TASK.md
+++ b/src/memu/hosts/codex/BRIDGING_TASK.md
@@ -67,7 +67,7 @@ before creating the task.
 
 ## Step 2 — create the scheduled task
 
-Create a Codex scheduled task with the chosen cron, named e.g. `memu-bridging`,
+Create a Codex scheduled task with the chosen cron, named e.g. `memu-remember`,
 and set its recurring prompt to this block **verbatim**:
 
 ```

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -29,6 +29,7 @@ import urllib.request
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from importlib.resources import files
+from pathlib import Path
 from typing import Any
 
 from memu.hosts import instruction, retrieval
@@ -130,6 +131,24 @@ def _layout(spec: HostSpec, args: argparse.Namespace) -> Layout:
     return Layout.default(host=spec.host, base=args.base_dir)
 
 
+def _refresh_retrieval(spec: HostSpec) -> None:
+    """Piggyback the retrieval-procedure refresh on the scheduled prepare.
+
+    The retrieval body self-updates from the server on this low-frequency run
+    instead of on the per-turn retrieve hook, which must never fetch. Best-effort
+    and firewalled: any failure here is a note, never a failed bridging run — and
+    :func:`instruction.refresh` skips (rather than downgrades) when the server is
+    unreachable, so a note here means the installed copy simply stayed put.
+    """
+    skills_dir = Path(spec.skills_dir) if spec.skills_dir else None
+    try:
+        for target, changed in instruction.refresh(Path(spec.instruction_path), spec.binary, skills_dir=skills_dir):
+            if changed:
+                print(f"refreshed the retrieval procedure at {target}")
+    except Exception as exc:
+        print(f"note: could not refresh the retrieval procedure ({exc})", file=sys.stderr)
+
+
 async def _cmd_prepare(spec: HostSpec, args: argparse.Namespace) -> int:
     source = spec.source_factory(args.session_dir)
     if not source.exists():
@@ -142,6 +161,7 @@ async def _cmd_prepare(spec: HostSpec, args: argparse.Namespace) -> int:
     print(f"prepared {num_sessions} session(s) -> {num_jobs} job(s) in {layout.jobs}")
     if num_sessions == 0:
         print("no new session turns since the last run; nothing to mine")
+    _refresh_retrieval(spec)
     return 0
 
 

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -32,7 +32,7 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
-from memu.hosts import instruction, retrieval
+from memu.hosts import instruction, retrieval, templates
 from memu.hosts.base import TranscriptSource
 from memu.hosts.bridging import Layout, commit, prepare
 from memu.hosts.bridging.pipeline import MAX_JOBS
@@ -289,7 +289,14 @@ async def _cmd_doctor(spec: HostSpec, args: argparse.Namespace) -> int:
 
 
 async def _cmd_docs(spec: HostSpec, args: argparse.Namespace) -> int:
-    print((files(spec.package) / DOCS[args.doc]).read_text(encoding="utf-8"))
+    # Server-first, then last-good cache, then the embedded floor — the same
+    # self-updating shape ADR 0013 gives the instruction templates, applied to the
+    # host guides. `docs task` prints the guide named BRIDGING_TASK.md; the doc key
+    # ("task") and its filename differ, and both the URL and cache key off the
+    # filename so the server layout mirrors the package layout.
+    filename = DOCS[args.doc]
+    embedded = (files(spec.package) / filename).read_text(encoding="utf-8")
+    print(templates.resolve_doc(spec.host, filename, embedded))
     return 0
 
 

--- a/src/memu/hosts/instruction.py
+++ b/src/memu/hosts/instruction.py
@@ -40,6 +40,8 @@ import shutil
 from pathlib import Path
 from typing import Any
 
+from memu.hosts import templates
+
 BEGIN_TEMPLATE = "<!-- memu:begin — managed block, do not edit ({binary} install-instruction) -->"
 END = "<!-- memu:end -->"
 
@@ -64,12 +66,16 @@ plus a summary. Work from the summaries; open a `path` only when you need what i
 leaves out.
 """
 
-INSTRUCTION_TEMPLATE = f"""\
+# The body is a ``{body}`` slot rather than baked in, so the same document can be
+# rendered with either the embedded :data:`RETRIEVAL_BODY` or the body carved out
+# of the server's current skill (:mod:`memu.hosts.templates`) — see :func:`_body`,
+# :func:`_skill_body`, and :func:`refresh`.
+INSTRUCTION_TEMPLATE = """\
 ## memU — retrieve before answering
 
 Before answering:
 
-{RETRIEVAL_BODY}"""
+{body}"""
 
 SKILL_INSTRUCTION_TEMPLATE = """\
 ## memU — retrieve before answering
@@ -78,9 +84,9 @@ Before answering, use the `{skill}` skill to pull any relevant memory into
 context. It fails open: if nothing comes back, answer normally.
 """
 
-SKILL_TEMPLATE = f"""\
+SKILL_TEMPLATE = """\
 ---
-name: {SKILL_NAME}
+name: {name}
 description: Retrieve the user's durable memory from memU before answering. Run it
   at the start of every turn, even when the request seems self-contained — it is
   one cheap command and fails open; skipping it means answering without what the
@@ -89,7 +95,7 @@ description: Retrieve the user's durable memory from memU before answering. Run 
 
 # Retrieve from memU before answering
 
-{RETRIEVAL_BODY}"""
+{body}"""
 
 
 def begin(binary: str) -> str:
@@ -97,25 +103,60 @@ def begin(binary: str) -> str:
     return BEGIN_TEMPLATE.format(binary=binary)
 
 
-def skill_document(binary: str) -> str:
-    """The ``SKILL.md`` as written to disk, telling the agent how to retrieve."""
-    return SKILL_TEMPLATE.format(binary=binary)
+def _skill_body(skill_text: str) -> str:
+    """The retrieval body carved out of a full ``SKILL.md`` document.
+
+    The server now serves the whole skill — YAML frontmatter, ``# Retrieve…``
+    heading, and body (see :func:`refresh`). A skill host writes that document
+    verbatim; an inline host wants only the *procedure* to slot into its own
+    :data:`INSTRUCTION_TEMPLATE`, under its own heading. So strip the leading
+    frontmatter block and the first H1, leaving the body (still carrying
+    ``{binary}``, which :func:`_body` fills).
+    """
+    without_frontmatter = re.sub(r"\A---\n.*?\n---\n+", "", skill_text, count=1, flags=re.DOTALL)
+    return re.sub(r"\A#[^\n]*\n+", "", without_frontmatter, count=1)
 
 
-def instruction(binary: str, *, skill: bool = False) -> str:
+def _body(binary: str, skill_text: str | None) -> str:
+    """The retrieval body with ``{binary}`` filled: from the server skill, else embedded.
+
+    ``skill_text`` is a full skill document as a caller fetched it from the server;
+    its body is carved out with :func:`_skill_body`. ``None`` means the embedded
+    copy. ``{binary}`` is filled here, before the body is slotted into a document,
+    so a body that happens to contain other braces stays safe — ``.format`` never
+    re-parses a value it substituted in.
+    """
+    body = RETRIEVAL_BODY if skill_text is None else _skill_body(skill_text)
+    return body.format(binary=binary)
+
+
+def skill_document(binary: str, *, skill_text: str | None = None) -> str:
+    """The ``SKILL.md`` as written to disk, telling the agent how to retrieve.
+
+    ``skill_text`` is the server's current full skill document, written verbatim
+    with only ``{binary}`` filled; ``None`` renders the embedded skill.
+    """
+    if skill_text is not None:
+        return skill_text.format(binary=binary)
+    return SKILL_TEMPLATE.format(name=SKILL_NAME, body=_body(binary, None))
+
+
+def instruction(binary: str, *, skill: bool = False, skill_text: str | None = None) -> str:
     """The instruction text, telling the agent to run this host's ``retrieve``.
 
     ``skill=True`` returns the short pointer for hosts where :func:`install_skill`
-    has put the detail in a skill; otherwise the full inline text.
+    has put the detail in a skill; otherwise the full inline text. ``skill_text``
+    overrides the embedded retrieval body with the body carved out of a
+    server-fetched skill (ignored for the pointer, which carries no body).
     """
     if skill:
         return SKILL_INSTRUCTION_TEMPLATE.format(skill=SKILL_NAME, binary=binary)
-    return INSTRUCTION_TEMPLATE.format(binary=binary)
+    return INSTRUCTION_TEMPLATE.format(body=_body(binary, skill_text))
 
 
-def block(binary: str, *, skill: bool = False) -> str:
+def block(binary: str, *, skill: bool = False, skill_text: str | None = None) -> str:
     """The managed block exactly as it is written to disk, markers included."""
-    return f"{begin(binary)}\n{instruction(binary, skill=skill)}{END}\n"
+    return f"{begin(binary)}\n{instruction(binary, skill=skill, skill_text=skill_text)}{END}\n"
 
 
 def _block_re(binary: str) -> re.Pattern[str]:
@@ -125,7 +166,7 @@ def _block_re(binary: str) -> re.Pattern[str]:
     )
 
 
-def patch(current: str, binary: str, *, skill: bool = False) -> str:
+def patch(current: str, binary: str, *, skill: bool = False, skill_text: str | None = None) -> str:
     """Return ``current`` with the managed block installed — replaced, or appended.
 
     Pure, so the interesting half of :func:`install` is testable without a
@@ -135,11 +176,11 @@ def patch(current: str, binary: str, *, skill: bool = False) -> str:
     """
     pattern = _block_re(binary)
     if pattern.search(current):
-        return pattern.sub(lambda _: block(binary, skill=skill), current, count=1)
+        return pattern.sub(lambda _: block(binary, skill=skill, skill_text=skill_text), current, count=1)
     if current and not current.endswith("\n"):
         current += "\n"
     separator = "\n" if current else ""
-    return f"{current}{separator}{block(binary, skill=skill)}"
+    return f"{current}{separator}{block(binary, skill=skill, skill_text=skill_text)}"
 
 
 def strip(current: str, binary: str) -> str:
@@ -182,7 +223,9 @@ def _write(path: Path, updated: str, *, backup: bool, dry_run: bool) -> tuple[bo
     return True, diff
 
 
-def install(path: Path, binary: str, *, skill: bool = False, dry_run: bool = False) -> tuple[bool, str]:
+def install(
+    path: Path, binary: str, *, skill: bool = False, skill_text: str | None = None, dry_run: bool = False
+) -> tuple[bool, str]:
     """Install the managed block into ``path``. Returns ``(changed, diff)``.
 
     Creates the file (and its parent) if absent, and backs up any existing content
@@ -191,11 +234,13 @@ def install(path: Path, binary: str, *, skill: bool = False, dry_run: bool = Fal
 
     ``skill`` installs the short block that points at :func:`install_skill`'s skill
     instead of the full inline text; pass it only when that skill is being
-    installed too, or the block points at nothing.
+    installed too, or the block points at nothing. ``skill_text`` overrides the
+    embedded retrieval body (for an inline host being refreshed from the server's
+    current skill).
     """
     path = path.expanduser()
     current = path.read_text(encoding="utf-8") if path.is_file() else ""
-    return _write(path, patch(current, binary, skill=skill), backup=True, dry_run=dry_run)
+    return _write(path, patch(current, binary, skill=skill, skill_text=skill_text), backup=True, dry_run=dry_run)
 
 
 def remove(path: Path, binary: str, *, dry_run: bool = False) -> tuple[bool, str]:
@@ -219,15 +264,59 @@ def skill_path(skills_dir: Path) -> Path:
     return skills_dir.expanduser() / SKILL_NAME / "SKILL.md"
 
 
-def install_skill(skills_dir: Path, binary: str, *, dry_run: bool = False) -> tuple[bool, str]:
+def install_skill(
+    skills_dir: Path, binary: str, *, skill_text: str | None = None, dry_run: bool = False
+) -> tuple[bool, str]:
     """Install the retrieval skill under ``skills_dir``. Returns ``(changed, diff)``.
 
     Unlike the instruction file, ``<skills_dir>/memu-retrieve/`` is memU's own —
     nothing of the user's lives there — so it is overwritten whole rather than
     marker-fenced and backed up. Same upgrade story either way: re-run and the
-    release's text replaces the installed one.
+    release's text replaces the installed one. ``skill_text`` overrides the
+    embedded skill with the server's current full document (for a skill host being
+    refreshed from the server).
     """
-    return _write(skill_path(skills_dir), skill_document(binary), backup=False, dry_run=dry_run)
+    return _write(skill_path(skills_dir), skill_document(binary, skill_text=skill_text), backup=False, dry_run=dry_run)
+
+
+def refresh(path: Path, binary: str, *, skills_dir: Path | None = None) -> list[tuple[Path, bool]]:
+    """Refresh an already-installed retrieval procedure from the server, in place.
+
+    The scheduled counterpart to :func:`install`: the bridging run calls this so
+    the installed copy tracks server improvements, while the per-turn retrieve
+    hook never touches the network. The server serves the full skill document; this
+    rewrites whatever holds the retrieval procedure — the ``SKILL.md`` on a skill
+    host with that document verbatim, the inline managed block on an inline host
+    with the body carved out of it (:func:`_skill_body`) — from
+    :mod:`memu.hosts.templates`'s current server copy.
+
+    Two properties matter here and differ from :func:`install`:
+
+    * **Skip, never downgrade.** On an unreachable or malformed server the fetch
+      is ``None`` and this writes nothing, so a transient outage leaves the
+      already-installed (newer) copy in place instead of overwriting it with the
+      embedded text. This is *why* the retrieval skill needs no cache of its own:
+      the installed file already is the last-good.
+    * **Refresh, never bootstrap.** With nothing installed here yet, it does
+      nothing — installing is ``install-instruction``'s job. A scheduled run must
+      not silently create files the user never asked for.
+
+    Returns ``(target, changed)`` for each file touched — empty when it skipped.
+    """
+    skill_text = templates.fetch(templates.RETRIEVAL_SKILL)
+    if skill_text is None:
+        return []
+    if skills_dir is not None:
+        target = skill_path(skills_dir)
+        if not target.is_file():
+            return []
+        changed, _ = install_skill(skills_dir, binary, skill_text=skill_text)
+        return [(target, changed)]
+    target = path.expanduser()
+    if not target.is_file() or not _block_re(binary).search(target.read_text(encoding="utf-8")):
+        return []
+    changed, _ = install(path, binary, skill=False, skill_text=skill_text)
+    return [(target, changed)]
 
 
 def _report(path: Path, changed: bool, diff: str, *, dry_run: bool) -> None:
@@ -242,20 +331,24 @@ def _report(path: Path, changed: bool, diff: str, *, dry_run: bool) -> None:
 def _cmd_install_instruction(args: argparse.Namespace) -> int:
     skills_dir = Path(args.skills_dir) if args.skills_dir else None
     skill = skills_dir is not None
+    # An explicit, one-off, latency-tolerant command, so it pulls the server's
+    # current retrieval skill here (fail-open to embedded on any failure); the
+    # scheduled `refresh` keeps it current afterwards.
+    skill_text = templates.fetch(templates.RETRIEVAL_SKILL)
     if args.print_only:
         if skills_dir is not None:
-            print(f"# {skill_path(skills_dir)}\n\n{skill_document(args.binary)}")
-        print(block(args.binary, skill=skill), end="")
+            print(f"# {skill_path(skills_dir)}\n\n{skill_document(args.binary, skill_text=skill_text)}")
+        print(block(args.binary, skill=skill, skill_text=skill_text), end="")
         return 0
 
     # The skill goes in first: between the two writes, an instruction block naming
     # a skill that is not there yet is the only order that can mislead an agent.
     if skills_dir is not None:
-        changed, diff = install_skill(skills_dir, args.binary, dry_run=args.dry_run)
+        changed, diff = install_skill(skills_dir, args.binary, skill_text=skill_text, dry_run=args.dry_run)
         _report(skill_path(skills_dir), changed, diff, dry_run=args.dry_run)
 
     path = Path(args.path)
-    changed, diff = install(path, args.binary, skill=skill, dry_run=args.dry_run)
+    changed, diff = install(path, args.binary, skill=skill, skill_text=skill_text, dry_run=args.dry_run)
     _report(path.expanduser(), changed, diff, dry_run=args.dry_run)
     return 0
 

--- a/src/memu/hosts/openclaw/BRIDGING_TASK.md
+++ b/src/memu/hosts/openclaw/BRIDGING_TASK.md
@@ -54,7 +54,7 @@ hour**, cron `0 * * * *` (local time). Confirm before creating.
 
 ## Step 2 — create the cron job
 
-Create an OpenClaw cron job (e.g. named `memu-bridging`) with the chosen
+Create an OpenClaw cron job (e.g. named `memu-remember`) with the chosen
 schedule, and set its recurring prompt to this block **verbatim**:
 
 **The scheduled turn runs in the gateway's environment, not your shell.** The

--- a/src/memu/hosts/templates.py
+++ b/src/memu/hosts/templates.py
@@ -1,0 +1,172 @@
+"""Self-updating instruction templates: server first, last-good next, embedded last.
+
+Every template the SDK feeds an agent — the three self-evolve job templates and
+the retrieval skill — ships embedded in the SDK as a Python string. Embedded text
+is a floor, not a ceiling: it is frozen at release time, so a wording fix or a
+better mining prompt cannot reach an install until that install upgrades. This
+module lets the SDK *try* the server's current copy at
+``https://memu.pro/sdk/instructions/<name>.txt`` and use it when it is reachable
+and well-formed, falling back otherwise.
+
+Two fallback shapes, because the two kinds of template are consumed differently:
+
+* :func:`resolve` — server, then a local **last-good cache**, then embedded. For
+  the job templates, which are read on the low-frequency, latency-tolerant
+  ``prepare`` run and can be pulled every time. The cache is what makes a
+  *transient* server outage a non-event: once an install has seen ``v1``, a day
+  where the pull fails still runs ``v1`` rather than regressing to the embedded
+  ``v0``.
+* :func:`fetch` — server only, no cache. For the retrieval skill, whose durable
+  copy is not a cache but the file already installed on disk
+  (``…/memu-retrieve/SKILL.md`` or the managed instruction block). Its caller
+  refreshes that file *only* on a successful fetch, so the installed copy is the
+  de-facto last-good and there is nothing extra to cache.
+
+Everything here is **fail-open and never raises**: a missing network, a non-200,
+an oversize body, or a malformed template all collapse to "fall back". The
+embedded template is always a correct answer, so the server is pure upside and
+never a dependency.
+
+One deliberate limitation, without version numbers (see ADR 0013): the cache
+holds *the last text seen*, not *the newest by version*. If the SDK is upgraded
+while the server is unreachable, a cached older-remote could momentarily win over
+a newer embedded template. It self-heals on the next successful pull — which is
+imminent, since a release publishes the matching server copy — and touches at
+most a handful of low-frequency jobs. Adding a version field to arbitrate this is
+tracked as the open issue in ADR 0013.
+"""
+
+from __future__ import annotations
+
+import os
+import urllib.request
+from collections.abc import Iterable
+from pathlib import Path
+
+from memu.hosts.bridging.layout import BASE_DIR
+
+DEFAULT_BASE_URL = "https://memu.pro/sdk/instructions"
+"""Where the server keeps the current templates. Override with
+``MEMU_TEMPLATE_BASE_URL``; set it empty to switch remote refresh off entirely
+(air-gapped installs, offline CI, tests)."""
+
+# Each template's stable id: both the URL stem (``<base>/<name>.txt``) and the
+# cache-file stem. Kept next to the `{placeholder}` contract each one must honour,
+# so a caller names the template and the required keys are looked up here.
+MEMORY_JOB = "memory-job"
+SKILL_JOB = "skill-job"
+RESOURCE_JOB = "resource-job"
+RETRIEVAL_SKILL = "retrieval-skill"
+
+REQUIRED_KEYS: dict[str, frozenset[str]] = {
+    MEMORY_JOB: frozenset({"input_path", "track_dir"}),
+    SKILL_JOB: frozenset({"input_path", "track_dir", "resource_log"}),
+    RESOURCE_JOB: frozenset({"verify_command", "resource_file"}),
+    RETRIEVAL_SKILL: frozenset({"binary"}),
+}
+
+_TIMEOUT_SECONDS = 4.0
+_MAX_BYTES = 64 * 1024
+
+
+def _base_url() -> str | None:
+    """The server root, or ``None`` when remote refresh is switched off.
+
+    Read live rather than captured at import, so a test or an air-gapped install
+    can steer it per process; an empty value disables the fetch.
+    """
+    value = os.environ.get("MEMU_TEMPLATE_BASE_URL", DEFAULT_BASE_URL)
+    return value or None
+
+
+def _cache_dir() -> Path:
+    """Where last-good templates live — shared across hosts, since the templates
+    are host-agnostic (only ``{binary}`` differs, and it is filled after fetch)."""
+    return Path(os.path.expanduser(BASE_DIR)) / "cache" / "instructions"
+
+
+def _valid(text: str, required_keys: Iterable[str]) -> bool:
+    """True only if the template is non-empty, keeps its placeholder contract,
+    and ``.format()``-s cleanly.
+
+    The last two are the load-bearing guard: a server-side typo — a dropped
+    ``{input_path}``, a stray ``{``, an ``{unknown}`` field — must be rejected
+    here, never carried into a job file where ``.format()`` would raise mid-run.
+    """
+    if not text.strip():
+        return False
+    if any(("{" + key) not in text for key in required_keys):
+        return False
+    try:
+        text.format(**dict.fromkeys(required_keys, ""))
+    except (KeyError, IndexError, ValueError):
+        return False
+    return True
+
+
+def fetch(name: str) -> str | None:
+    """The server's current ``name`` template, validated — or ``None``.
+
+    Never raises: offline, non-200, oversize, or malformed all return ``None``,
+    which every caller treats as "fall back". A successful, valid fetch also
+    refreshes the on-disk last-good cache as a side effect.
+    """
+    base = _base_url()
+    if base is None:
+        return None
+    required_keys = REQUIRED_KEYS[name]
+    try:
+        with urllib.request.urlopen(f"{base}/{name}.txt", timeout=_TIMEOUT_SECONDS) as resp:  # noqa: S310
+            if getattr(resp, "status", 200) != 200:
+                return None
+            # Read one byte past the cap so an exactly-cap body is still accepted
+            # while anything larger is rejected without buffering the whole thing.
+            raw: bytes = resp.read(_MAX_BYTES + 1)
+    except Exception:
+        return None
+    if len(raw) > _MAX_BYTES:
+        return None
+    try:
+        text: str = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+    if not _valid(text, required_keys):
+        return None
+    _write_cache(name, text)
+    return text
+
+
+def _write_cache(name: str, text: str) -> None:
+    """Refresh the last-good copy, atomically. Best-effort: a cache we cannot
+    write is not fatal, since the fetched text is already in hand for this run."""
+    try:
+        cache_dir = _cache_dir()
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        tmp = cache_dir / f"{name}.txt.tmp"
+        tmp.write_text(text, encoding="utf-8")
+        os.replace(tmp, cache_dir / f"{name}.txt")
+    except OSError:
+        pass
+
+
+def _read_cache(name: str) -> str | None:
+    """The last server template we saw and trusted, if it is still valid on disk.
+
+    Re-validated on read: a truncated or hand-edited cache file is treated as
+    absent, so a corrupt cache is never worse than no cache.
+    """
+    try:
+        text = (_cache_dir() / f"{name}.txt").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    return text if _valid(text, REQUIRED_KEYS[name]) else None
+
+
+def resolve(name: str, embedded: str) -> str:
+    """The best template available: server, then last-good cache, then ``embedded``.
+
+    For the job templates — low-frequency, latency-tolerant, so pulled on every
+    ``prepare``. The embedded copy shipped with the SDK is the guaranteed floor,
+    so a total outage degrades to it, never to nothing.
+    """
+    return fetch(name) or _read_cache(name) or embedded

--- a/src/memu/hosts/templates.py
+++ b/src/memu/hosts/templates.py
@@ -104,19 +104,15 @@ def _valid(text: str, required_keys: Iterable[str]) -> bool:
     return True
 
 
-def fetch(name: str) -> str | None:
-    """The server's current ``name`` template, validated — or ``None``.
+def _get(url: str) -> str | None:
+    """Raw GET of one small UTF-8 asset, fail-open — the shared transport for
+    both templates and docs. ``None`` on offline, non-200, oversize, or
+    undecodable; content trust is the *caller's* job, applied to what this returns.
 
-    Never raises: offline, non-200, oversize, or malformed all return ``None``,
-    which every caller treats as "fall back". A successful, valid fetch also
-    refreshes the on-disk last-good cache as a side effect.
+    Never raises.
     """
-    base = _base_url()
-    if base is None:
-        return None
-    required_keys = REQUIRED_KEYS[name]
     try:
-        with urllib.request.urlopen(f"{base}/{name}.txt", timeout=_TIMEOUT_SECONDS) as resp:  # noqa: S310
+        with urllib.request.urlopen(url, timeout=_TIMEOUT_SECONDS) as resp:  # noqa: S310
             if getattr(resp, "status", 200) != 200:
                 return None
             # Read one byte past the cap so an exactly-cap body is still accepted
@@ -127,10 +123,23 @@ def fetch(name: str) -> str | None:
     if len(raw) > _MAX_BYTES:
         return None
     try:
-        text: str = raw.decode("utf-8")
+        return raw.decode("utf-8")
     except UnicodeDecodeError:
         return None
-    if not _valid(text, required_keys):
+
+
+def fetch(name: str) -> str | None:
+    """The server's current ``name`` template, validated — or ``None``.
+
+    Never raises: offline, non-200, oversize, or malformed all return ``None``,
+    which every caller treats as "fall back". A successful, valid fetch also
+    refreshes the on-disk last-good cache as a side effect.
+    """
+    base = _base_url()
+    if base is None:
+        return None
+    text = _get(f"{base}/{name}.txt")
+    if text is None or not _valid(text, REQUIRED_KEYS[name]):
         return None
     _write_cache(name, text)
     return text
@@ -170,3 +179,99 @@ def resolve(name: str, embedded: str) -> str:
     so a total outage degrades to it, never to nothing.
     """
     return fetch(name) or _read_cache(name) or embedded
+
+
+# --------------------------------------------------------------------------- #
+# Host-facing docs (``<binary> docs install|task|uninstall``)
+#
+# Same server-first / cache / embedded shape as the templates above, but for the
+# per-host guides the SDK ships in each host package (``INSTALL.md`` etc). Two
+# differences drive the separate code path:
+#
+#   * **Host-scoped, not host-agnostic.** Each host has its own copy, so the URL
+#     and cache carry a ``<host>`` segment: ``<base>/<host>/<filename>`` and
+#     ``~/.memu/cache/docs/<host>/<filename>``. (The templates share one flat
+#     namespace precisely because they are host-agnostic.)
+#   * **Printed, not executed.** ``docs`` prints the guide to a human's terminal;
+#     the text is never ``.format()``-ed or fed to an agent. So there is no
+#     ``{placeholder}`` contract to enforce — the trust check is just "non-empty,
+#     decodes, under the size cap", which ``_get`` already covers. See
+#     :func:`_valid_doc`.
+#
+# Duty cycle is interactive and one-off (like ``install-instruction``), and a user
+# may re-run ``docs`` offline, so this keeps the cached :func:`resolve`-style
+# fallback rather than the uncached :func:`fetch` shape.
+# --------------------------------------------------------------------------- #
+
+DEFAULT_DOCS_BASE_URL = "https://memu.pro/sdk/docs"
+"""Server root for the host guides. Override with ``MEMU_DOCS_BASE_URL``; set it
+empty to switch remote doc refresh off (air-gapped installs, offline CI, tests).
+Kept distinct from ``MEMU_TEMPLATE_BASE_URL`` so the two can be steered — and
+disabled — independently."""
+
+
+def _docs_base_url() -> str | None:
+    """The docs server root, or ``None`` when remote doc refresh is off. Read live
+    (not captured at import) so a test or air-gapped install can steer it."""
+    value = os.environ.get("MEMU_DOCS_BASE_URL", DEFAULT_DOCS_BASE_URL)
+    return value or None
+
+
+def _docs_cache_dir(host: str) -> Path:
+    """Last-good docs for one host. Host-scoped, since the guides differ per host."""
+    return Path(os.path.expanduser(BASE_DIR)) / "cache" / "docs" / host
+
+
+def _valid_doc(text: str) -> bool:
+    """True if the doc is worth trusting. Unlike a template it is only printed for
+    a human, so there is no placeholder contract — non-empty is the whole check.
+
+    TODO(review): consider a light sanity marker (e.g. a leading ``#`` heading) so
+    an accidentally-served error page or redirect body is rejected as well.
+    """
+    return bool(text.strip())
+
+
+def fetch_doc(host: str, filename: str) -> str | None:
+    """The server's current ``<host>/<filename>`` guide, validated — or ``None``.
+
+    Never raises; a valid fetch refreshes the host-scoped last-good cache.
+    """
+    base = _docs_base_url()
+    if base is None:
+        return None
+    text = _get(f"{base}/{host}/{filename}")
+    if text is None or not _valid_doc(text):
+        return None
+    _write_doc_cache(host, filename, text)
+    return text
+
+
+def _write_doc_cache(host: str, filename: str, text: str) -> None:
+    """Refresh a host's last-good doc, atomically. Best-effort (see :func:`_write_cache`)."""
+    try:
+        cache_dir = _docs_cache_dir(host)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        tmp = cache_dir / f"{filename}.tmp"
+        tmp.write_text(text, encoding="utf-8")
+        os.replace(tmp, cache_dir / filename)
+    except OSError:
+        pass
+
+
+def _read_doc_cache(host: str, filename: str) -> str | None:
+    """The last server doc we saw for this host, re-validated on read."""
+    try:
+        text = (_docs_cache_dir(host) / filename).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    return text if _valid_doc(text) else None
+
+
+def resolve_doc(host: str, filename: str, embedded: str) -> str:
+    """The best guide available: server, then host-scoped cache, then ``embedded``.
+
+    ``embedded`` is the copy shipped in the host package — the guaranteed floor,
+    so a total outage degrades to it, never to nothing.
+    """
+    return fetch_doc(host, filename) or _read_doc_cache(host, filename) or embedded

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared test fixtures.
+
+Default every test to the *embedded* instruction templates. Two isolations, both
+autouse so a test never has to remember them: no test reaches the network for a
+template (``MEMU_TEMPLATE_BASE_URL`` blanked switches the fetch off), and no test
+reads or writes the real ``~/.memu`` template cache (redirected under ``tmp_path``).
+The handful of tests that exercise the fetch/cache path re-enable the base URL and
+stub ``urlopen`` themselves — the later ``setenv`` on the same monkeypatch wins.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from memu.hosts import templates
+
+
+@pytest.fixture(autouse=True)
+def _offline_templates(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    monkeypatch.setenv("MEMU_TEMPLATE_BASE_URL", "")
+    monkeypatch.setattr(templates, "_cache_dir", lambda: tmp_path / "template-cache")

--- a/tests/test_host_templates.py
+++ b/tests/test_host_templates.py
@@ -30,8 +30,8 @@ class _FakeResponse:
     def __enter__(self) -> _FakeResponse:
         return self
 
-    def __exit__(self, *exc: object) -> bool:
-        return False
+    def __exit__(self, *exc: object) -> None:
+        return None
 
 
 def _serve(monkeypatch: pytest.MonkeyPatch, body: bytes, status: int = 200) -> None:

--- a/tests/test_host_templates.py
+++ b/tests/test_host_templates.py
@@ -1,0 +1,204 @@
+"""Self-updating templates: server first, last-good cache next, embedded last.
+
+These pin the properties the feature rests on: a server typo can never crash the
+pipeline (validation), a *transient* outage keeps the last good copy instead of
+regressing to embedded (the cache), and the retrieve procedure's scheduled
+refresh skips rather than downgrades when the server is unreachable.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from memu.hosts import instruction, templates
+
+BINARY = "memu-codex"
+
+MEMORY_KEYS = "{input_path} {track_dir}"  # the memory-job template's required placeholders
+
+
+class _FakeResponse:
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def read(self, n: int = -1) -> bytes:
+        return self._body if n < 0 else self._body[:n]
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+
+def _serve(monkeypatch: pytest.MonkeyPatch, body: bytes, status: int = 200) -> None:
+    monkeypatch.setenv("MEMU_TEMPLATE_BASE_URL", "https://example.test/inst")
+    monkeypatch.setattr("urllib.request.urlopen", lambda url, timeout=None: _FakeResponse(body, status))
+
+
+def _server_down(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MEMU_TEMPLATE_BASE_URL", "https://example.test/inst")
+
+    def _boom(url: str, timeout: float | None = None) -> _FakeResponse:
+        raise OSError
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+
+
+# --- validation: a bad server copy is rejected, never carried into a job ---
+
+
+def test_valid_accepts_a_well_formed_template() -> None:
+    assert templates._valid(f"do the thing {MEMORY_KEYS}", {"input_path", "track_dir"})
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",  # empty
+        "only {input_path} here",  # a required placeholder is missing
+        f"lone }} brace {MEMORY_KEYS}",  # would raise ValueError at .format()
+        f"{{unknown}} field {MEMORY_KEYS}",  # references a key the SDK never supplies
+    ],
+)
+def test_valid_rejects_malformed_templates(text: str) -> None:
+    assert not templates._valid(text, {"input_path", "track_dir"})
+
+
+# --- fetch: validated server copy, or None; a good fetch refreshes the cache ---
+
+
+def test_fetch_returns_and_caches_a_valid_server_copy(monkeypatch: pytest.MonkeyPatch) -> None:
+    body = f"server memory job {MEMORY_KEYS}"
+    _serve(monkeypatch, body.encode())
+
+    assert templates.fetch(templates.MEMORY_JOB) == body
+    assert (templates._cache_dir() / f"{templates.MEMORY_JOB}.txt").read_text(encoding="utf-8") == body
+
+
+def test_fetch_is_off_when_base_url_is_blank() -> None:
+    # The conftest default: no network, so no fetch and no cache write.
+    assert templates.fetch(templates.MEMORY_JOB) is None
+
+
+@pytest.mark.parametrize(
+    "body, status",
+    [
+        (f"server {MEMORY_KEYS}".encode(), 404),  # non-200
+        (b"x" * (templates._MAX_BYTES + 1), 200),  # oversize
+        (b"missing the placeholders", 200),  # malformed
+    ],
+)
+def test_fetch_rejects_bad_responses_without_caching(monkeypatch: pytest.MonkeyPatch, body: bytes, status: int) -> None:
+    _serve(monkeypatch, body, status)
+
+    assert templates.fetch(templates.MEMORY_JOB) is None
+    assert not (templates._cache_dir() / f"{templates.MEMORY_JOB}.txt").exists()
+
+
+# --- resolve: the whole point — a transient outage keeps last-good, not embedded ---
+
+
+def test_resolve_prefers_the_last_good_cache_over_embedded_on_outage(monkeypatch: pytest.MonkeyPatch) -> None:
+    embedded = f"embedded v0 {MEMORY_KEYS}"
+    remote_v1 = f"server v1 {MEMORY_KEYS}"
+
+    _serve(monkeypatch, remote_v1.encode())
+    assert templates.resolve(templates.MEMORY_JOB, embedded) == remote_v1  # seen once, now cached
+
+    _server_down(monkeypatch)  # the next day the pull fails
+    assert templates.resolve(templates.MEMORY_JOB, embedded) == remote_v1, (
+        "a transient outage must keep the last-good v1, not regress to the embedded v0"
+    )
+
+
+def test_resolve_falls_to_embedded_with_no_cache_and_no_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    embedded = f"embedded floor {MEMORY_KEYS}"
+    _server_down(monkeypatch)
+
+    assert templates.resolve(templates.MEMORY_JOB, embedded) == embedded
+
+
+def test_resolve_ignores_a_corrupt_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = templates._cache_dir()
+    cache.mkdir(parents=True, exist_ok=True)
+    (cache / f"{templates.MEMORY_JOB}.txt").write_text("corrupt } cache", encoding="utf-8")
+    embedded = f"embedded floor {MEMORY_KEYS}"
+    _server_down(monkeypatch)
+
+    assert templates.resolve(templates.MEMORY_JOB, embedded) == embedded
+
+
+# --- refresh: the installed file is the retrieval skill's last-good, so skip on failure ---
+
+
+def _skill(body: str) -> bytes:
+    """A full SKILL.md document, as the server now serves it — frontmatter,
+    heading, and body — wrapping ``body`` (which may carry ``{binary}``)."""
+    return (
+        f"---\nname: memu-retrieve\ndescription: Retrieve durable memory from memU.\n---\n\n"
+        f"# Retrieve from memU before answering\n\n{body}\n"
+    ).encode()
+
+
+def test_refresh_updates_the_installed_skill_from_the_server(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    skills = tmp_path / "skills"
+    instruction.install_skill(skills, BINARY)  # embedded, as install-instruction would
+    _serve(monkeypatch, _skill("Fresh retrieval body: run {binary} retrieve."))
+
+    touched = instruction.refresh(tmp_path / "AGENTS.md", BINARY, skills_dir=skills)
+
+    text = (skills / instruction.SKILL_NAME / "SKILL.md").read_text(encoding="utf-8")
+    assert touched == [(instruction.skill_path(skills), True)]
+    # The server's full document lands verbatim, with only {binary} filled.
+    assert text.startswith("---\nname: memu-retrieve\n")
+    assert "Fresh retrieval body: run memu-codex retrieve." in text
+
+
+def test_refresh_skips_and_does_not_downgrade_when_server_is_down(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    skills = tmp_path / "skills"
+    # A newer skill is already installed (as a prior successful refresh would leave it).
+    instruction.install_skill(skills, BINARY, skill_text=_skill("Installed v1 body: run {binary} retrieve.").decode())
+    installed = (skills / instruction.SKILL_NAME / "SKILL.md").read_text(encoding="utf-8")
+    _server_down(monkeypatch)
+
+    touched = instruction.refresh(tmp_path / "AGENTS.md", BINARY, skills_dir=skills)
+
+    assert touched == []
+    assert (skills / instruction.SKILL_NAME / "SKILL.md").read_text(encoding="utf-8") == installed
+
+
+def test_refresh_does_not_bootstrap_an_uninstalled_skill(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    skills = tmp_path / "skills"
+    _serve(monkeypatch, _skill("Fresh retrieval body: run {binary} retrieve."))
+
+    touched = instruction.refresh(tmp_path / "AGENTS.md", BINARY, skills_dir=skills)
+
+    assert touched == []
+    assert not (skills / instruction.SKILL_NAME / "SKILL.md").exists()
+
+
+def test_refresh_updates_an_inline_host_in_place(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "AGENTS.md"
+    path.write_text("# My rules\n", encoding="utf-8")
+    instruction.install(path, BINARY)  # inline host: full body in the managed block
+    _serve(monkeypatch, _skill("Inline refreshed body: run {binary} retrieve."))
+
+    touched = instruction.refresh(path, BINARY, skills_dir=None)
+
+    text = path.read_text(encoding="utf-8")
+    assert touched == [(path, True)]
+    # Only the body is carved into the inline block — no frontmatter, no skill heading.
+    assert "Inline refreshed body: run memu-codex retrieve." in text
+    assert "name: memu-retrieve" not in text
+    assert "# Retrieve from memU before answering" not in text
+    assert "# My rules" in text, "the user's own content survives the refresh"


### PR DESCRIPTION
## What

Lets the agent-facing text the SDK carries track a server-hosted copy, so a wording fix or a better mining prompt reaches the field without a release — while the copy embedded in the release stays a guaranteed floor. Two commits:

1. **`d6311f1` — self-updating instruction templates (ADR 0013).** The three self-evolve job templates and the retrieval skill now resolve *server → last-good cache → embedded*, via a single fail-open resolver (`memu/hosts/templates.py`). Server copies are trusted only after structural validation (non-empty, every required `{placeholder}` present, `.format()`-clean), so a server-side typo can never reach a job file. Full rationale in [ADR 0013](docs/adr/0013-self-updating-instruction-templates.md).

2. **`a812f42` — extend the same pattern to the `docs` guides.** `<binary> docs install|task|uninstall` printed only the embedded guide; it now routes through the same fallback (`docs install` → `https://memu.pro/sdk/docs/<host>/INSTALL.md`, cached under `~/.memu/cache/docs/<host>/`). Because docs are *printed to a human*, not `.format()`-ed into an agent job, there is no placeholder contract — the check is just non-empty and under the size cap. The raw fail-open HTTP get is factored into a shared `_get(url)` that both paths use.

## Design notes

- **Fail-open by construction.** A missing network, non-200, oversize body (>64 KiB), or malformed template all collapse to "fall back". No call raises; a total outage degrades to embedded, never to nothing.
- **Two duty cycles, two shapes.** Job templates pull every `prepare` (low-frequency, off the hot path) with a last-good cache; the retrieval body refreshes on the `prepare` schedule and never on the per-turn `retrieve` path. Docs use the cached resolve shape since they're interactive and may be re-run offline.
- **`MEMU_TEMPLATE_BASE_URL` / `MEMU_DOCS_BASE_URL`** each disable remote refresh when set empty (air-gapped installs, offline CI, tests).

## Testing

- `tests/test_host_templates.py` (17 tests) covers the template resolver; all pass after the `_get` refactor.

## Follow-ups (not in this PR)

- No tests yet for the docs path; `_valid_doc` only checks non-empty (no error-page guard).
- No URL version segment. Docs track the *installed* SDK's CLI contract more tightly than the prompt templates do, so a newer server doc can reference a flag an older SDK lacks — tracked as an ADR 0013 open issue.
- No signing/integrity verification of server templates (ADR 0013 open issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)