### PR TITLE
fix(workbuddy): install retrieval instruction in SOUL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ memU runs as a sidecar to a desktop agent (ADR 0008/0009/0010), one binary per h
 | Cursor (Agent/CLI) | `memu-cursor` | `~/.cursor/projects/<project>/agent-transcripts/**.jsonl` | `./AGENTS.md` (per project) |
 | OpenClaw | `memu-openclaw` | `~/.openclaw/agents/<agentId>/sessions/*.jsonl` | `~/.openclaw/workspace/AGENTS.md` |
 | Hermes Agent | `memu-hermes` | `~/.hermes/state.db` (SQLite, read-only) | `~/.hermes/SOUL.md` |
-| WorkBuddy | `memu-workbuddy` | `~/.workbuddy/projects/<project>/<session>.jsonl` | `~/.workbuddy/MEMORY.md` |
+| WorkBuddy | `memu-workbuddy` | `~/.workbuddy/projects/<project>/<session>.jsonl` | `~/.workbuddy/SOUL.md` |
 | **any other agent** | `memu-agent` | found by `memu-agent detect` (JSONL dialect sniffed) | found by `detect` (AGENTS.md / CLAUDE.md / SOUL.md / …) |
 
 For agents without a dedicated binary, `memu-agent detect` probes the machine and reports per agent whether **memorization** works (a recognizable session log exists) and whether **retrieval** works (an instruction file exists to patch) — then the same verbs run against what it found.

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -66,6 +66,12 @@ class HostSpec:
     instruction_path: str
     """The host's global instruction file — where the inject seam lands."""
 
+    legacy_instruction_paths: tuple[str, ...] = ()
+    """Previous default instruction files to unpatch after installing the current
+    target, and to inspect during uninstall. Only used when the CLI's default
+    ``--path`` is in effect, so an explicit custom target never rewrites unrelated
+    files. This is an upgrade seam, not a second active instruction location."""
+
     skills_dir: str = ""
     """The host's skills directory, for hosts that have skills (``~/.codex/skills``,
     ``~/.claude/skills``). Given one, ``install-instruction`` puts the retrieval
@@ -361,7 +367,13 @@ def build_parser(spec: HostSpec) -> argparse.ArgumentParser:
     # Shared across hosts, so they are registered, not redefined — only the file
     # the instruction lands in and the binary it names are ours to fill in.
     retrieval.register(sub)
-    instruction.register(sub, path=spec.instruction_path, binary=spec.binary, skills_dir=spec.skills_dir)
+    instruction.register(
+        sub,
+        path=spec.instruction_path,
+        binary=spec.binary,
+        skills_dir=spec.skills_dir,
+        legacy_paths=spec.legacy_instruction_paths,
+    )
 
     p = with_base(sub.add_parser("prepare", help=f"Slice new {spec.display} sessions into self-evolve job files"))
     # A host with no universal session location (the generic adapter) leaves

--- a/src/memu/hosts/instruction.py
+++ b/src/memu/hosts/instruction.py
@@ -350,19 +350,41 @@ def _cmd_install_instruction(args: argparse.Namespace) -> int:
     path = Path(args.path)
     changed, diff = install(path, args.binary, skill=skill, skill_text=skill_text, dry_run=args.dry_run)
     _report(path.expanduser(), changed, diff, dry_run=args.dry_run)
+
+    # Migrate only when the host's default target is in use. An explicit --path
+    # describes a separate profile or workspace and must not rewrite files under
+    # the default home. Install the new target first so a failed write can never
+    # remove the user's only working retrieval instruction.
+    if args.path == args.default_instruction_path:
+        for legacy_text in args.legacy_paths:
+            legacy = Path(legacy_text)
+            if legacy.expanduser() == path.expanduser():
+                continue
+            legacy_changed, legacy_diff = remove(legacy, args.binary, dry_run=args.dry_run)
+            if legacy_diff:
+                _report(legacy.expanduser(), legacy_changed, legacy_diff, dry_run=args.dry_run)
     return 0
 
 
 def _cmd_remove_instruction(args: argparse.Namespace) -> int:
-    path = Path(args.path)
-    changed, diff = remove(path, args.binary, dry_run=args.dry_run)
-    if not diff:
-        print(f"{path}: no managed block to remove")
-        return 0
-    if args.dry_run:
-        print(f"{path}: would change\n\n{diff}", end="")
-        return 0
-    print(f"{path}: {'updated' if changed else 'unchanged'}\n\n{diff}", end="")
+    paths = [Path(args.path)]
+    if args.path == args.default_instruction_path:
+        paths.extend(Path(path) for path in args.legacy_paths)
+
+    reported = False
+    seen: set[Path] = set()
+    for path in paths:
+        expanded = path.expanduser()
+        if expanded in seen:
+            continue
+        seen.add(expanded)
+        changed, diff = remove(path, args.binary, dry_run=args.dry_run)
+        if not diff:
+            continue
+        reported = True
+        _report(expanded, changed, diff, dry_run=args.dry_run)
+    if not reported:
+        print(f"{Path(args.path)}: no managed block to remove")
     return 0
 
 
@@ -376,7 +398,14 @@ async def _cmd_remove_instruction_async(args: argparse.Namespace) -> int:
     return _cmd_remove_instruction(args)
 
 
-def register(sub: Any, *, path: str, binary: str, skills_dir: str = "") -> None:
+def register(
+    sub: Any,
+    *,
+    path: str,
+    binary: str,
+    skills_dir: str = "",
+    legacy_paths: tuple[str, ...] = (),
+) -> None:
     """Add ``install-instruction`` to a host CLI, bound to that host's ``path``.
 
     ``binary`` is the host adapter's own command name (``memu-codex``, …) — it is
@@ -386,6 +415,11 @@ def register(sub: Any, *, path: str, binary: str, skills_dir: str = "") -> None:
     has one. Given it, the command installs the retrieval skill there and patches
     ``path`` with a two-sentence pointer to it; left empty, it patches ``path``
     with the full text and writes no skill.
+
+    ``legacy_paths`` names earlier defaults owned by the same host adapter. A
+    default-path install removes this binary's managed block from them only after
+    the current target is installed; default-path uninstall checks both. Custom
+    ``--path`` calls leave them alone.
     """
     parser = sub.add_parser(
         "install-instruction",
@@ -405,7 +439,12 @@ def register(sub: Any, *, path: str, binary: str, skills_dir: str = "") -> None:
     parser.add_argument(
         "--print", dest="print_only", action="store_true", help="Print what would be installed and exit"
     )
-    parser.set_defaults(handler=_cmd_install_instruction_async, binary=binary)
+    parser.set_defaults(
+        handler=_cmd_install_instruction_async,
+        binary=binary,
+        default_instruction_path=path,
+        legacy_paths=legacy_paths,
+    )
 
     remover = sub.add_parser(
         "remove-instruction",
@@ -413,4 +452,9 @@ def register(sub: Any, *, path: str, binary: str, skills_dir: str = "") -> None:
     )
     remover.add_argument("--path", default=path, help=f"Instruction file to unpatch (default: {path})")
     remover.add_argument("--dry-run", action="store_true", help="Show the diff without writing")
-    remover.set_defaults(handler=_cmd_remove_instruction_async, binary=binary)
+    remover.set_defaults(
+        handler=_cmd_remove_instruction_async,
+        binary=binary,
+        default_instruction_path=path,
+        legacy_paths=legacy_paths,
+    )

--- a/src/memu/hosts/workbuddy/INSTALL.md
+++ b/src/memu/hosts/workbuddy/INSTALL.md
@@ -12,7 +12,7 @@ Installing memU on WorkBuddy is three parts:
 1. **Install memU** — a Python package and the memory backend it uses.
 2. **Register the bridging task** — the scheduled job that turns recent WorkBuddy
    sessions into durable memory (the *record* seam).
-3. **Patch `~/.workbuddy/MEMORY.md`** — a standing instruction that tells you to
+3. **Patch `~/.workbuddy/SOUL.md`** — a standing instruction that tells you to
    pull relevant memory before you answer (the *inject* seam).
 
 Parts 2 and 3 must share one configured mode. In local mode they must also share
@@ -147,12 +147,13 @@ since the cursor — that is fine and correct).
 
 ---
 
-## Part 3 — Patch `~/.workbuddy/MEMORY.md` with the retrieval instruction
+## Part 3 — Patch `~/.workbuddy/SOUL.md` with the retrieval instruction
 
-The *inject* seam: a standing instruction in WorkBuddy's **global memory file**
+The *inject* seam: a standing instruction in WorkBuddy's **global behavior file**
 telling you to pull relevant memory before you answer. WorkBuddy loads
-`~/.workbuddy/MEMORY.md` into every session, so the instruction is simply always
-there — no hook, no wrapper, no per-turn process.
+`~/.workbuddy/SOUL.md` into every session, so the instruction is simply always
+there — no hook, no wrapper, no per-turn process. The behavior belongs here, not
+in `MEMORY.md` alongside user facts and conversation summaries.
 
 **Do not hand-write the instruction.** memU owns the text and installs it for you:
 
@@ -160,24 +161,33 @@ there — no hook, no wrapper, no per-turn process.
 memu-workbuddy install-instruction
 ```
 
-It writes memU's block into `~/.workbuddy/MEMORY.md`, creating the file if it
+It writes memU's block into `~/.workbuddy/SOUL.md`, creating the file if it
 does not exist, and prints the diff. It appends rather than overwrites (existing
-content is backed up to `~/.workbuddy/MEMORY.md.bak`), and it is idempotent: the
+content is backed up to `~/.workbuddy/SOUL.md.bak`), and it is idempotent: the
 text sits in a marked block that a re-run — or a later memU release — replaces in
 place. `--dry-run` shows the diff without writing; `--print` prints just the
 block.
 
+For an install made by an older memU release, the command also removes only
+memU's marked block from the former `~/.workbuddy/MEMORY.md` target after the
+new `SOUL.md` block is safely installed. User-authored memory stays byte-for-byte
+intact, and the previous file contents are backed up to `MEMORY.md.bak`. This
+migration runs only for the default target; an explicit `--path` never rewrites
+files under the default WorkBuddy home.
+
 ### ✅ Verify Part 3
 
 ```
+cat ~/.workbuddy/SOUL.md
 cat ~/.workbuddy/MEMORY.md
 memu-workbuddy retrieve "smoke test"
 ```
 
-The memU block must appear exactly once, anything the user had there must be
-intact, and `retrieve` must exit cleanly (empty result lists are fine). A *fresh*
-WorkBuddy session is what picks up the new MEMORY.md — do not be surprised that
-the instruction is not in your own context yet.
+The memU block must appear exactly once in `SOUL.md` and not at all in the legacy
+`MEMORY.md`; anything the user had in either file must be intact, and `retrieve`
+must exit cleanly (empty result lists are fine). A *fresh* WorkBuddy session is
+what picks up the new SOUL.md — do not be surprised that the instruction is not
+in your own context yet.
 
 ---
 
@@ -185,6 +195,6 @@ the instruction is not in your own context yet.
 
 Report back to the user: the selected mode and its cloud endpoint or local store/provider; the scheduled
 automation and its schedule in words; and that the retrieval instruction is now in
-`~/.workbuddy/MEMORY.md`, taking effect in their next session. Record and inject
+`~/.workbuddy/SOUL.md`, taking effect in their next session. Record and inject
 both read `~/.memu/config.env`, so they provably share one backend — what the task
 learns tonight is what retrieval finds tomorrow.

--- a/src/memu/hosts/workbuddy/UNINSTALL.md
+++ b/src/memu/hosts/workbuddy/UNINSTALL.md
@@ -8,8 +8,8 @@ Uninstalling is the install run in reverse, and it is three parts:
 
 1. **Unregister the bridging task** — stop the scheduled automation first, so
    nothing fires mid-teardown (the *record* seam).
-2. **Unpatch `~/.workbuddy/MEMORY.md`** — remove the standing retrieval
-   instruction (the *inject* seam).
+2. **Unpatch `~/.workbuddy/SOUL.md`** — remove the standing retrieval instruction
+   (the *inject* seam), including any block left in the legacy `MEMORY.md` target.
 3. **Apply the data-and-package defaults** — the user's memory is kept, the
    tooling is removed — and close by reporting both.
 
@@ -40,18 +40,19 @@ The automation no longer appears in WorkBuddy's automation list.
 memu-workbuddy remove-instruction
 ```
 
-It deletes memU's marked block from `~/.workbuddy/MEMORY.md` and prints the
-diff. Everything outside the markers is the user's and survives; the previous
-contents are backed up to `~/.workbuddy/MEMORY.md.bak` before the rewrite.
-`--dry-run` shows the diff without writing. Re-running is a clean no-op — a
-file with no block left is already the desired end state.
+It deletes memU's marked block from `~/.workbuddy/SOUL.md` and also checks the
+former `~/.workbuddy/MEMORY.md` target so an older install is removed cleanly.
+Everything outside the markers is the user's and survives; each changed file is
+backed up to its adjacent `.bak` path before the rewrite. `--dry-run` shows both
+diffs without writing. Re-running is a clean no-op — files with no block left are
+already the desired end state.
 
 ### ✅ Verify Part 2
 
-`cat ~/.workbuddy/MEMORY.md` — no `memu:begin`/`memu:end` markers remain, and
-the user's own content is intact. The session you are working in already loaded
-the old file, so the instruction may still be in your own context; a fresh
-session is what picks the removal up.
+Check both `cat ~/.workbuddy/SOUL.md` and `cat ~/.workbuddy/MEMORY.md`: no
+`memu:begin`/`memu:end` markers remain, and the user's own content is intact. The
+session you are working in already loaded the old file, so the instruction may
+still be in your own context; a fresh session is what picks the removal up.
 
 ---
 
@@ -75,7 +76,7 @@ Only one thing overrides a default: the user's own explicit words.
   history as already mined, and it would never be mined again.
 - **Remove this host's residue.** Everything else under
   `~/.memu/hosts/workbuddy/` — job files and mirrors, sparing the session
-  cursor above; `~/.workbuddy/MEMORY.md` itself **if** Part 2 left it empty
+  cursor above; `~/.workbuddy/SOUL.md` itself **if** Part 2 left it empty
   (it held only memU's block, so the install created it) — a file with the
   user's own content stays, of course.
 - **Uninstall the package** — `pip uninstall memu-cli` (or `pipx uninstall

--- a/src/memu/hosts/workbuddy/__init__.py
+++ b/src/memu/hosts/workbuddy/__init__.py
@@ -2,7 +2,7 @@
 
 Binds ADR 0008's two seams onto WorkBuddy: *record* as a scheduled bridging
 task over ``~/.workbuddy/projects`` (see :mod:`memu.hosts.bridging`), *inject* as
-a standing instruction in ``~/.workbuddy/MEMORY.md`` that points the agent at
+a standing instruction in ``~/.workbuddy/SOUL.md`` that points the agent at
 the ``memu-workbuddy retrieve`` command.
 """
 

--- a/src/memu/hosts/workbuddy/cli.py
+++ b/src/memu/hosts/workbuddy/cli.py
@@ -6,7 +6,7 @@ standing instruction lands in.
 
 Usage:
     memu-workbuddy retrieve "<query>"    # the inject seam — what the agent runs each turn
-    memu-workbuddy install-instruction   # the inject seam — patch ~/.workbuddy/MEMORY.md
+    memu-workbuddy install-instruction   # the inject seam — patch ~/.workbuddy/SOUL.md
     memu-workbuddy prepare               # slice new sessions into job files
     memu-workbuddy verify-resources      # filter the touched-file log (run by a job)
     memu-workbuddy commit                # submit what the agent produced back to memU
@@ -24,10 +24,14 @@ from memu.hosts.workbuddy.sessions import SESSION_DIR, WorkBuddyTranscriptSource
 
 HOST = "workbuddy"
 
+SOUL_MD = "~/.workbuddy/SOUL.md"
+"""WorkBuddy's global behavior file — loaded into every session, so standing
+instructions that must run before every answer belong here rather than among the
+facts and summaries in long-term memory."""
+
 MEMORY_MD = "~/.workbuddy/MEMORY.md"
-"""WorkBuddy's global memory file — loaded into every session, so the inject
-seam lands here.  (User-level: ``~/.workbuddy/MEMORY.md``; per-project memory
-files also exist but the instruction belongs at the level retrieval works at.)"""
+"""The legacy inject target. Existing installs are migrated from this file when
+``install-instruction`` runs against the default ``SOUL_MD`` target."""
 
 SPEC = HostSpec(
     host=HOST,
@@ -36,7 +40,8 @@ SPEC = HostSpec(
     source_factory=WorkBuddyTranscriptSource,
     session_dir=SESSION_DIR,
     session_help="WorkBuddy session log (one project dir per escaped cwd)",
-    instruction_path=MEMORY_MD,
+    instruction_path=SOUL_MD,
+    legacy_instruction_paths=(MEMORY_MD,),
 )
 
 

--- a/tests/test_host_instruction.py
+++ b/tests/test_host_instruction.py
@@ -12,12 +12,32 @@ about today's behaviour moves.
 
 from __future__ import annotations
 
+import argparse
 import pathlib
+
+import pytest
 
 from memu.hosts import instruction
 from memu.hosts.codex.cli import AGENTS_MD, SKILLS_DIR, build_parser
+from memu.hosts.host_cli import build_parser as build_host_parser
+from memu.hosts.workbuddy.cli import MEMORY_MD as WORKBUDDY_LEGACY_MEMORY_MD
+from memu.hosts.workbuddy.cli import SOUL_MD as WORKBUDDY_SOUL_MD
+from memu.hosts.workbuddy.cli import SPEC as WORKBUDDY_SPEC
 
 BINARY = "memu-codex"
+WORKBUDDY_BINARY = "memu-workbuddy"
+
+
+def _migration_parser(current: pathlib.Path, legacy: pathlib.Path) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    instruction.register(
+        sub,
+        path=str(current),
+        binary=WORKBUDDY_BINARY,
+        legacy_paths=(str(legacy),),
+    )
+    return parser
 
 
 def test_creates_file_when_absent(tmp_path: pathlib.Path) -> None:
@@ -122,6 +142,102 @@ def test_openclaw_is_a_skill_host() -> None:
     from memu.hosts.openclaw.cli import SPEC
 
     assert SPEC.skills_dir == "~/.openclaw/skills"
+
+
+def test_workbuddy_defaults_to_soul_as_an_inline_host() -> None:
+    args = build_host_parser(WORKBUDDY_SPEC).parse_args(["install-instruction"])
+
+    assert args.path == WORKBUDDY_SOUL_MD
+    assert args.legacy_paths == (WORKBUDDY_LEGACY_MEMORY_MD,)
+    assert WORKBUDDY_SPEC.skills_dir == ""
+
+
+def test_default_install_migrates_the_legacy_instruction_after_writing_the_new_target(
+    tmp_path: pathlib.Path,
+) -> None:
+    soul = tmp_path / "SOUL.md"
+    memory = tmp_path / "MEMORY.md"
+    soul.write_text("# My identity\n", encoding="utf-8")
+    memory.write_text("# My memories\n", encoding="utf-8")
+    instruction.install(memory, WORKBUDDY_BINARY)
+    old_memory = memory.read_text(encoding="utf-8")
+
+    args = _migration_parser(soul, memory).parse_args(["install-instruction"])
+    assert instruction._cmd_install_instruction(args) == 0
+
+    soul_text = soul.read_text(encoding="utf-8")
+    assert "# My identity" in soul_text
+    assert "memu-workbuddy retrieve" in soul_text
+    assert soul_text.count(instruction.begin(WORKBUDDY_BINARY)) == 1
+    assert memory.read_text(encoding="utf-8") == "# My memories\n"
+    assert soul.with_suffix(".md.bak").read_text(encoding="utf-8") == "# My identity\n"
+    assert memory.with_suffix(".md.bak").read_text(encoding="utf-8") == old_memory
+
+    before = (soul_text, memory.read_text(encoding="utf-8"))
+    assert instruction._cmd_install_instruction(args) == 0
+    assert (soul.read_text(encoding="utf-8"), memory.read_text(encoding="utf-8")) == before
+
+
+def test_default_install_dry_run_reports_but_does_not_migrate(tmp_path: pathlib.Path) -> None:
+    soul = tmp_path / "SOUL.md"
+    memory = tmp_path / "MEMORY.md"
+    memory.write_text("# My memories\n", encoding="utf-8")
+    instruction.install(memory, WORKBUDDY_BINARY)
+    old_memory = memory.read_text(encoding="utf-8")
+
+    args = _migration_parser(soul, memory).parse_args(["install-instruction", "--dry-run"])
+    assert instruction._cmd_install_instruction(args) == 0
+
+    assert not soul.exists()
+    assert memory.read_text(encoding="utf-8") == old_memory
+
+
+def test_default_remove_cleans_current_and_legacy_instruction_paths(tmp_path: pathlib.Path) -> None:
+    soul = tmp_path / "SOUL.md"
+    memory = tmp_path / "MEMORY.md"
+    soul.write_text("# My identity\n", encoding="utf-8")
+    memory.write_text("# My memories\n", encoding="utf-8")
+    instruction.install(soul, WORKBUDDY_BINARY)
+    instruction.install(memory, WORKBUDDY_BINARY)
+
+    args = _migration_parser(soul, memory).parse_args(["remove-instruction"])
+    assert instruction._cmd_remove_instruction(args) == 0
+
+    assert soul.read_text(encoding="utf-8") == "# My identity\n"
+    assert memory.read_text(encoding="utf-8") == "# My memories\n"
+
+
+def test_custom_instruction_path_leaves_default_legacy_path_alone(tmp_path: pathlib.Path) -> None:
+    soul = tmp_path / "SOUL.md"
+    memory = tmp_path / "MEMORY.md"
+    custom = tmp_path / "profile" / "SOUL.md"
+    instruction.install(memory, WORKBUDDY_BINARY)
+    old_memory = memory.read_text(encoding="utf-8")
+
+    args = _migration_parser(soul, memory).parse_args(["install-instruction", "--path", str(custom)])
+    assert instruction._cmd_install_instruction(args) == 0
+
+    assert "memu-workbuddy retrieve" in custom.read_text(encoding="utf-8")
+    assert memory.read_text(encoding="utf-8") == old_memory
+
+
+def test_failed_new_target_install_keeps_the_legacy_instruction(monkeypatch, tmp_path: pathlib.Path) -> None:
+    soul = tmp_path / "SOUL.md"
+    memory = tmp_path / "MEMORY.md"
+    instruction.install(memory, WORKBUDDY_BINARY)
+    old_memory = memory.read_text(encoding="utf-8")
+    args = _migration_parser(soul, memory).parse_args(["install-instruction"])
+
+    install_error = OSError("new target is not writable")
+
+    def fail_install(*_args: object, **_kwargs: object) -> None:
+        raise install_error
+
+    monkeypatch.setattr(instruction, "install", fail_install)
+    with pytest.raises(OSError, match="not writable"):
+        instruction._cmd_install_instruction(args)
+
+    assert memory.read_text(encoding="utf-8") == old_memory
 
 
 def test_instruction_names_the_llm_free_retrieval() -> None:


### PR DESCRIPTION
## Pull Request Summary

Fixes WorkBuddy's inject seam by moving memU's managed retrieval instruction from `~/.workbuddy/MEMORY.md` to `~/.workbuddy/SOUL.md`, where standing behavior instructions belong. Existing installations migrate safely without losing user-authored memory.

---

## ✅ What does this PR do?

- Changes the WorkBuddy adapter's default instruction target to `~/.workbuddy/SOUL.md`.
- Adds an optional legacy-instruction-path upgrade seam shared by host adapters.
- Installs the new `SOUL.md` block before removing memU's managed block from the legacy `MEMORY.md` target.
- Preserves user-authored content and creates the existing adjacent `.bak` backups for every changed file.
- Keeps installation and removal idempotent.
- Leaves legacy defaults untouched when the user supplies an explicit custom `--path`.
- Makes default uninstall check both `SOUL.md` and the former `MEMORY.md` target.
- Updates the README and WorkBuddy install/uninstall documentation.
- Adds regression coverage for the new default and migration behavior.

---

## 🔧 Why is this change needed?

`MEMORY.md` contains user facts and conversation summaries, while the retrieval directive is standing agent behavior. Installing that directive in the memory file can make the retrieve-before-answer behavior less reliably applied. `SOUL.md` is the correct WorkBuddy behavior file for the inject seam.

This is a host-adapter bug fix. It does not change the memU service, storage backends, retrieval contract, or embedding behavior, so no ADR is required.

Related issue or discussion: N/A — the bug was identified while validating the WorkBuddy adapter's retrieval-trigger behavior.

---

## 🔍 Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / cleanup
- [ ] Other

---

## 🧪 Testing

- GitHub Actions:
  - `Validate PR title` — passed
  - `build (3.11)` — passed
  - `build (3.13)` — passed
- Focused host-instruction and CLI tests — 37 passed.
- Host-template regression tests — 14 passed.
- Ruff lint and format checks — passed.
- mypy on the touched source paths — passed.

---

## ✅ PR Quality Checklist

- [x] PR title follows the allowed conventional format.
- [x] Changes are limited to the WorkBuddy inject target and its migration seam.
- [x] Documentation is updated.
- [x] No breaking changes.
- [x] Related issue/discussion is marked N/A with context.
- [x] New behavior and migration edge cases have test coverage.

---

## 📌 Optional

- Screenshots or UI examples: N/A — this is a CLI/host-adapter fix.
- [x] Edge cases considered:
  - A failed new-target install leaves the legacy instruction intact.
  - `--dry-run` performs no writes.
  - Explicit custom paths do not migrate default-home files.
  - Repeated install/remove operations remain idempotent.
- Follow-up tasks: none required for this bug fix.