### PR TITLE
feat(memory): paginate list_all_recall_files with a keyset cursor (ADR 0014)

### DIFF
--- a/docs/adr/0014-paginated-list-all-recall-files.md
+++ b/docs/adr/0014-paginated-list-all-recall-files.md
@@ -1,0 +1,176 @@
+ADR 0014: Paginated `list_all_recall_files`
+
+- Status: Proposed
+- Date: 2026-07-26
+- Builds on: ADR 0012 (cloud-backed agentic backend), ADR 0007 (three memory
+  lines / tracks), ADR 0003 (user scope in the data model)
+- Scope: making `list_all_recall_files` return one bounded page per call across
+  both the local and cloud backends, and having the only two callers reassemble
+  the full set by following a cursor. It does not change `progressive_retrieve`,
+  `commit_results`, or the `where` vocabulary.
+
+## Context
+
+`list_all_recall_files` returns every recall file in scope in a single
+response. Today `AgenticMixin.list_all_recall_files` calls
+`recall_file_repo.list_recall_files(where)`, which loads the whole result set,
+and both callers consume all of it at once:
+
+- bridging `prepare` mirrors the entire store to disk;
+- the `list-files` CLI prints the whole list.
+
+As a scope's memory/skill set grows, that single response grows without bound:
+one large DB read, one large serialization, one large HTTP body. We want a
+bounded page size.
+
+Two facts about the topology constrain the design:
+
+1. **There is one implementation, not two.** The hosted service does not have
+   its own query code for this operation — `memu-service` runs open-source
+   memU's `AgenticMixin` unchanged (`MemuAgenticHost(AgenticMixin)`) over its
+   own storage adapter, and the HTTP route returns the mixin's dict untouched
+   ("the wire shape is memU's by construction"). So the paginated *response
+   shape* must be born in the mixin; the cloud client and the server route
+   cannot synthesize a shape the mixin does not produce.
+
+2. **Both execution paths must stay byte-for-byte identical.** `local` runs the
+   mixin in process; `cloud` runs the same mixin behind one HTTP roundtrip
+   (ADR 0012). Pagination — page size, ordering, cursor encoding — therefore
+   belongs to the mixin and its repositories, not to any one transport.
+
+## Decision
+
+### Paginate at the source, keyed on `(track, name, id)`
+
+`AgenticMixin.list_all_recall_files` gains `cursor` and `limit` parameters and
+returns `{"recall_files": [...], "next_cursor": <token-or-null>}`. A `null`
+`next_cursor` means the last page. The page is produced by a new repository
+method (below), ordered by the composite key **`(track, name, id)`**.
+
+Why `(track, name)` is the ordering key — the crucial decision:
+
+- **It is the domain's own identity, so it is unique by construction, not by
+  accident.** A recall file is keyed by `name` within its `track`
+  (`memory`/`skill`) — see `commit_results`. Pagination always runs inside a
+  fixed `(user_id, agent_id)` scope, so within one paging sequence `(track,
+  name)` is unique. Uniqueness is the one hard requirement for correct paging:
+  with no ties, no page can skip or duplicate a row, which is exactly what a
+  caller reassembling the full set needs.
+- **It is immutable under the write path.** There is no in-place rename; a
+  "rename" is delete-then-create. A row therefore never changes its sort
+  position mid-pagination, which is what keyset resumption relies on.
+- **It produces a meaningful order for free** — stable alphabetical `list-files`
+  output, and a debuggable cursor — where the primary-key alternative (a random
+  UUID, `RecallFile.id`) would order arbitrarily and carry no business meaning.
+
+`id` is appended as a final tiebreaker (`ORDER BY track, name, id`). `(track,
+name)` is already unique today, so this is defense-in-depth: it makes the total
+order unconditional if the uniqueness invariant is ever relaxed (a migration
+window, soft-deleted duplicates) at zero cost.
+
+### Keyset, not offset
+
+The cursor encodes the last row's `(track, name, id)` and each page resumes with
+`(track, name, id) > (cursor)`. Offset pagination drifts under the concurrent
+commits that `prepare` races against: a delete positioned before the offset
+shifts every later row up and silently skips one. Keyset over an immutable
+unique key does not drift. The cursor is an opaque token (base64 of the tuple)
+so callers cannot depend on its internals.
+
+### Page at the repository, not in memory
+
+The page is a bounded repository query
+(`WHERE scope AND (track,name,id) > cursor ORDER BY track,name,id LIMIT n+1`),
+added as a new method rather than by slicing the existing full-fetch in the
+mixin. In-memory slicing would re-read and re-sort the entire table on every
+page — on the multi-tenant server, N page calls become N full scans, which is
+worse than the single read we set out to shrink. A keyset query touches only one
+page's worth of rows per call. (The in-memory backend "queries" a sorted list,
+so paging there is a trivial slice — but the method signature is uniform.)
+
+The new method is additive:
+
+```
+list_recall_files_page(where, *, after, limit)
+    -> (ordered list[RecallFile], next_after | None)
+```
+
+The existing `list_recall_files(where) -> dict[str, RecallFile]` is left
+untouched: its other callers — the `_collect_files` file roll-up and the
+per-track lookup in `_commit_recall_files` — genuinely need the full,
+unordered set, and must not be forced through a cursor.
+
+### One page per call at the transport; callers reassemble
+
+`CloudMemoryClient.list_all_recall_files` forwards `cursor`/`limit` as query
+parameters and passes the paginated body through unchanged — one page per call,
+no client-side loop. Reassembly lives in the callers, where it composes with
+work they already do per item:
+
+- bridging `prepare` follows `next_cursor`, writing each page to disk as it
+  arrives — no change to its per-file mirror logic, and the whole store is never
+  held in memory at once;
+- the `list-files` CLI follows `next_cursor` to gather the full list before
+  printing (its contract is "show everything").
+
+`limit` defaults to a fixed page size (`DEFAULT_PAGE_LIMIT`); callers do not set
+it.
+
+## Server-side changes (hippocampus-server)
+
+The mixin change flows to the server through the pinned memU git dependency; the
+service's own code changes only to thread the two new parameters through and to
+implement the paged query on its storage adapter:
+
+1. **HTTP route** (`app/interfaces/http/api/memory_files.py`, `GET
+   /api/v4/memory`): accept `cursor: str | None` and `limit: int` as `Query`
+   parameters (bound `limit` with `ge=1, le=<max>`) and forward them. The return
+   value is still the mixin's dict, passed through untouched, so `next_cursor`
+   reaches the wire for free.
+2. **Engine** (`app/infrastructure/memu/engine.py`,
+   `MemuAgenticEngine.list_all_recall_files`): accept `cursor`/`limit` and
+   forward them into `host.list_all_recall_files(where=where, cursor=cursor,
+   limit=limit)`. No shape work — the result already passes through `_run`
+   unchanged.
+3. **Storage adapter** (`MemuV4Store`'s recall-file repository): implement
+   `list_recall_files_page` with the same keyset predicate and
+   `ORDER BY track, name, id` over the multi-tenant schema. This is the one place
+   the server supplies its own query code (it satisfies memU's repository
+   protocol), and it must order identically to memU's own repositories or the
+   two execution paths diverge. An index covering `(scope…, track, name, id)`
+   keeps each page seek-only.
+
+## Consequences
+
+Positive:
+
+- Response, serialization, and DB-read size per call are bounded by `limit`
+  regardless of how large a scope grows.
+- Local and cloud paths remain identical: same ordering, same cursor, same page
+  shape, because pagination lives in the shared mixin + repository contract.
+- `prepare` never materializes the whole store in memory; it streams pages to
+  disk.
+- The ordering key is the domain identity, so correctness (no skips/dups) does
+  not depend on an incidental property.
+
+Costs:
+
+- The repository protocol gains a method that every backend must implement
+  (SQLite, in-memory, Postgres here; `MemuV4Store` on the server). A backend
+  that forgets it, or orders it differently, breaks paging silently.
+- `list_all_recall_files` is no longer a single call; both callers carry a
+  cursor loop, and any future caller must remember to follow `next_cursor`
+  rather than reading one page and stopping.
+- The cursor's meaning (`(track, name, id)` keyset) is now part of the
+  cross-repo contract; changing the sort key later invalidates in-flight cursors.
+
+## Out of scope
+
+- Paginating `progressive_retrieve` (already bounded by `top_k`) or
+  `commit_results`.
+- Widening the `where` vocabulary (ADR 0012 keeps cloud reads to exact
+  `user_id`/`agent_id`).
+- A stateful/snapshot cursor that hides concurrent inserts appearing on a later
+  page; keyset gives read-committed semantics, which is sufficient for `prepare`
+  (a missed just-created file is picked up on the next run).
+- Total-count or `has_more`-beyond-`next_cursor` metadata.

--- a/src/memu/agentic_backend.py
+++ b/src/memu/agentic_backend.py
@@ -14,7 +14,17 @@ class AgenticMemoryBackend(Protocol):
     async def list_all_recall_files(
         self,
         where: dict[str, Any] | None = None,
-    ) -> dict[str, Any]: ...
+        *,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        """One keyset page of recall files with an opaque ``next_cursor`` (ADR 0014).
+
+        ``next_cursor`` is ``None`` on the last page; callers follow it to
+        reassemble the full set. Both backends order identically, so the two
+        execution paths stay byte-for-byte the same.
+        """
+        ...
 
     async def progressive_retrieve(
         self,

--- a/src/memu/app/agentic.py
+++ b/src/memu/app/agentic.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import json
 from collections.abc import Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
@@ -11,6 +13,26 @@ if TYPE_CHECKING:
     from memu.app.settings import ProgressiveRetrieveConfig
     from memu.database.interfaces import Database
     from memu.database.models import RecallFile, Resource
+
+# Default recall-file page size for ``list_all_recall_files`` (ADR 0014). Callers
+# follow ``next_cursor`` to reassemble the full set; the page size only bounds the
+# per-call read/serialization/response, not the total returned.
+DEFAULT_PAGE_LIMIT = 50
+
+
+def _encode_cursor(after: tuple[str, str, str] | None) -> str | None:
+    """Opaque token for a ``(track, name, id)`` keyset position (``None`` = end)."""
+    if after is None:
+        return None
+    return base64.urlsafe_b64encode(json.dumps(list(after)).encode()).decode()
+
+
+def _decode_cursor(cursor: str | None) -> tuple[str, str, str] | None:
+    """Inverse of :func:`_encode_cursor`; a blank/absent cursor starts at the top."""
+    if not cursor:
+        return None
+    track, name, _id = json.loads(base64.urlsafe_b64decode(cursor.encode()))
+    return (track, name, _id)
 
 
 async def _embed_one(embed_client: Any, text: str) -> list[float]:
@@ -38,17 +60,27 @@ class AgenticMixin:
     async def list_all_recall_files(
         self,
         where: dict[str, Any] | None = None,
+        *,
+        cursor: str | None = None,
+        limit: int = DEFAULT_PAGE_LIMIT,
     ) -> dict[str, Any]:
-        """List RecallFiles across every track.
+        """List one keyset page of RecallFiles across every track (ADR 0014).
 
         No ``track`` filter is forced (ADR 0006), so skill-track files are
-        included alongside memory-track ones; the repository is queried directly.
+        included alongside memory-track ones. The page is ordered by
+        ``(track, name, id)`` and returned with ``next_cursor``; a ``None``
+        ``next_cursor`` marks the last page. Callers follow the cursor to walk
+        the full set — ordering on the domain identity ``(track, name)`` (unique
+        within a scope, immutable under commit) is what makes that walk skip- and
+        duplicate-free.
         """
         store = self._get_database()
         where_filters = self._normalize_where(where)
-        recall_files = store.recall_file_repo.list_recall_files(where_filters)
-        recall_files_list = [self._model_dump_without_embeddings(recall_file) for recall_file in recall_files.values()]
-        return {"recall_files": recall_files_list}
+        recall_files, next_after = store.recall_file_repo.list_recall_files_page(
+            where_filters, after=_decode_cursor(cursor), limit=limit
+        )
+        recall_files_list = [self._model_dump_without_embeddings(recall_file) for recall_file in recall_files]
+        return {"recall_files": recall_files_list, "next_cursor": _encode_cursor(next_after)}
 
     async def progressive_retrieve(
         self,

--- a/src/memu/cli.py
+++ b/src/memu/cli.py
@@ -93,11 +93,19 @@ async def _cmd_retrieve(args: argparse.Namespace) -> int:
 
 async def _cmd_list_files(args: argparse.Namespace) -> int:
     backend = _build_backend(args)
-    result = await backend.list_all_recall_files()
+    # "list-files" shows everything, so follow next_cursor across pages (ADR 0014)
+    # and gather the full set before printing.
+    files: list[dict[str, Any]] = []
+    cursor: str | None = None
+    while True:
+        result = await backend.list_all_recall_files(cursor=cursor)
+        files.extend(result.get("recall_files", []))
+        cursor = result.get("next_cursor")
+        if not cursor:
+            break
     if args.json:
-        _print_json(result)
+        _print_json({"recall_files": files})
         return 0
-    files = result.get("recall_files", [])
     print(f"{len(files)} recall file(s)")
     for f in files:
         print(f"  - {f.get('track')}/{f.get('name')}: {f.get('description') or ''}")

--- a/src/memu/cloud.py
+++ b/src/memu/cloud.py
@@ -116,8 +116,18 @@ class CloudMemoryClient:
     async def list_all_recall_files(
         self,
         where: dict[str, Any] | None = None,
+        *,
+        cursor: str | None = None,
+        limit: int | None = None,
     ) -> dict[str, Any]:
-        return await self._request("GET", "", params=self._scope(where))
+        # One page per call: the server paginates (ADR 0014) and the caller
+        # follows ``next_cursor``. The cursor is opaque here — forwarded as-is.
+        params = self._scope(where)
+        if cursor:
+            params["cursor"] = cursor
+        if limit is not None:
+            params["limit"] = str(limit)
+        return await self._request("GET", "", params=params)
 
     async def progressive_retrieve(
         self,

--- a/src/memu/database/inmemory/repositories/recall_file_repo.py
+++ b/src/memu/database/inmemory/repositories/recall_file_repo.py
@@ -23,6 +23,23 @@ class InMemoryRecallFileRepository(RecallFileRepoProtocol):
             return dict(self.recall_files)
         return {rid: recall_file for rid, recall_file in self.recall_files.items() if matches_where(recall_file, where)}
 
+    def list_recall_files_page(
+        self,
+        where: Mapping[str, Any] | None,
+        *,
+        after: tuple[str, str, str] | None,
+        limit: int,
+    ) -> tuple[list[RecallFile], tuple[str, str, str] | None]:
+        """One keyset page ordered by ``(track, name, id)`` (ADR 0014)."""
+        matches = [f for f in self.recall_files.values() if not where or matches_where(f, where)]
+        matches.sort(key=lambda f: (f.track, f.name, f.id))
+        if after is not None:
+            matches = [f for f in matches if (f.track, f.name, f.id) > after]
+        page = matches[:limit]
+        has_more = len(matches) > limit
+        next_after = (page[-1].track, page[-1].name, page[-1].id) if has_more else None
+        return page, next_after
+
     def clear_recall_files(self, where: Mapping[str, Any] | None = None) -> dict[str, RecallFile]:
         if not where:
             matches = self.recall_files.copy()

--- a/src/memu/database/postgres/repositories/recall_file_repo.py
+++ b/src/memu/database/postgres/repositories/recall_file_repo.py
@@ -37,6 +37,36 @@ class PostgresRecallFileRepo(PostgresRepoBase, RecallFileRepo):
                 result[recall_file.id] = recall_file
         return result
 
+    def list_recall_files_page(
+        self,
+        where: Mapping[str, Any] | None,
+        *,
+        after: tuple[str, str, str] | None,
+        limit: int,
+    ) -> tuple[list[RecallFile], tuple[str, str, str] | None]:
+        """One keyset page ordered by ``(track, name, id)`` (ADR 0014)."""
+        from sqlalchemy import tuple_
+        from sqlmodel import select
+
+        model = self._sqla_models.RecallFile
+        filters = self._build_filters(model, where)
+        with self._sessions.session() as session:
+            stmt = select(model).where(*filters)
+            if after is not None:
+                # Row-value keyset: resume strictly after the last row seen.
+                stmt = stmt.where(tuple_(model.track, model.name, model.id) > after)
+            # One extra row reveals whether a further page exists; trimmed below.
+            stmt = stmt.order_by(model.track, model.name, model.id).limit(limit + 1)
+            rows = session.scalars(stmt).all()
+            has_more = len(rows) > limit
+            rows = rows[:limit]
+            files: list[RecallFile] = []
+            for row in rows:
+                row.embedding = self._normalize_embedding(row.embedding)
+                files.append(self._cache_recall_file(row))
+        next_after = (files[-1].track, files[-1].name, files[-1].id) if has_more else None
+        return files, next_after
+
     def clear_recall_files(self, where: Mapping[str, Any] | None = None) -> dict[str, RecallFile]:
         from sqlmodel import delete, select
 

--- a/src/memu/database/repositories/recall_file.py
+++ b/src/memu/database/repositories/recall_file.py
@@ -14,6 +14,23 @@ class RecallFileRepo(Protocol):
 
     def list_recall_files(self, where: Mapping[str, Any] | None = None) -> dict[str, RecallFile]: ...
 
+    def list_recall_files_page(
+        self,
+        where: Mapping[str, Any] | None,
+        *,
+        after: tuple[str, str, str] | None,
+        limit: int,
+    ) -> tuple[list[RecallFile], tuple[str, str, str] | None]:
+        """One keyset page ordered by ``(track, name, id)``, plus the next cursor.
+
+        Returns the ordered page and the ``(track, name, id)`` of its last row
+        when more rows remain, or ``None`` on the final page. Distinct from
+        :meth:`list_recall_files`, which returns the whole unordered mapping its
+        roll-up and commit callers need — this one is the paginated read behind
+        ``list_all_recall_files`` (see ADR 0014).
+        """
+        ...
+
     def clear_recall_files(self, where: Mapping[str, Any] | None = None) -> dict[str, RecallFile]: ...
 
     def get_or_create_recall_file(

--- a/src/memu/database/sqlite/repositories/recall_file_repo.py
+++ b/src/memu/database/sqlite/repositories/recall_file_repo.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
+from sqlalchemy import tuple_
 from sqlmodel import delete, select
 
 from memu.database.models import RecallFile
@@ -66,21 +67,54 @@ class SQLiteRecallFileRepo(SQLiteRepoBase, RecallFileRepo):
 
         result: dict[str, RecallFile] = {}
         for row in rows:
-            recall_file = RecallFile(
-                id=row.id,
-                name=row.name,
-                description=row.description,
-                embedding=self._normalize_embedding(row.embedding),
-                content=row.content,
-                track=row.track,
-                created_at=row.created_at,
-                updated_at=row.updated_at,
-                **self._scope_kwargs_from(row),
-            )
+            recall_file = self._row_to_recall_file(row)
             result[row.id] = recall_file
-            self.recall_files[row.id] = recall_file
 
         return result
+
+    def list_recall_files_page(
+        self,
+        where: Mapping[str, Any] | None,
+        *,
+        after: tuple[str, str, str] | None,
+        limit: int,
+    ) -> tuple[list[RecallFile], tuple[str, str, str] | None]:
+        """One keyset page ordered by ``(track, name, id)`` (ADR 0014)."""
+        model = self._recall_file_model
+        with self._sessions.session() as session:
+            stmt = select(model)
+            filters = self._build_filters(model, where)
+            if filters:
+                stmt = stmt.where(*filters)
+            if after is not None:
+                # Row-value keyset: resume strictly after the last row seen.
+                stmt = stmt.where(tuple_(model.track, model.name, model.id) > after)
+            # Fetch one extra to learn whether a further page exists without a
+            # second round-trip; it is trimmed off before returning.
+            stmt = stmt.order_by(model.track, model.name, model.id).limit(limit + 1)
+            rows = session.exec(stmt).all()
+
+        has_more = len(rows) > limit
+        rows = rows[:limit]
+        files = [self._row_to_recall_file(row) for row in rows]
+        next_after = (rows[-1].track, rows[-1].name, rows[-1].id) if has_more else None
+        return files, next_after
+
+    def _row_to_recall_file(self, row: Any) -> RecallFile:
+        """Map a stored row to a cached :class:`RecallFile` (embedding normalized)."""
+        recall_file = RecallFile(
+            id=row.id,
+            name=row.name,
+            description=row.description,
+            embedding=self._normalize_embedding(row.embedding),
+            content=row.content,
+            track=row.track,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+            **self._scope_kwargs_from(row),
+        )
+        self.recall_files[row.id] = recall_file
+        return recall_file
 
     def clear_recall_files(self, where: Mapping[str, Any] | None = None) -> dict[str, RecallFile]:
         """Clear recall files matching the where clause.

--- a/src/memu/hosts/bridging/pipeline.py
+++ b/src/memu/hosts/bridging/pipeline.py
@@ -53,13 +53,21 @@ async def prepare(
     # "state as of the last commit". Re-snapshotting on every prepare would
     # absorb files a crashed run wrote but never committed, making them
     # undiffable — and therefore uncommittable — forever.
+    # list_all_recall_files returns one keyset page per call (ADR 0014); follow
+    # next_cursor to mirror every file, writing each page to disk as it arrives
+    # so the whole store is never held in memory at once.
     backend = build_agentic_memory_backend_from_env()
-    result = await backend.list_all_recall_files()
-    for recall_file in result["recall_files"]:
-        subdir = TRACK_DIRS.get(recall_file.get("track"))
-        if subdir is None:
-            continue
-        write_recall_file(layout.base, subdir, recall_file)
+    cursor: str | None = None
+    while True:
+        result = await backend.list_all_recall_files(cursor=cursor)
+        for recall_file in result["recall_files"]:
+            subdir = TRACK_DIRS.get(recall_file.get("track"))
+            if subdir is None:
+                continue
+            write_recall_file(layout.base, subdir, recall_file)
+        cursor = result.get("next_cursor")
+        if not cursor:
+            break
     if not layout.memory_manifest.exists():
         snapshot_tracked(layout.base, layout.track_dirs, layout.memory_manifest)
 

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -74,6 +74,37 @@ async def test_commit_then_list_covers_both_tracks(service: MemoryService) -> No
     assert by_track == [("memory", "Profile"), ("skill", "deploy-checklist")]
 
 
+async def test_list_all_recall_files_paginates_by_track_name_id(service: MemoryService) -> None:
+    # Commit more files than the page size, spread across both tracks.
+    limit = 3
+    committed = await service.commit_results(
+        recall_files=[
+            {"name": f"m{i:02d}", "track": "memory", "description": "d", "content": f"line {i}"} for i in range(4)
+        ]
+        + [{"name": f"s{i:02d}", "track": "skill", "description": "d", "content": f"step {i}"} for i in range(4)],
+    )
+    assert len(committed["recall_files"]) == 8
+
+    # Walk every page by following next_cursor, as prepare/CLI do.
+    seen: list[tuple[str, str]] = []
+    pages = 0
+    cursor: str | None = None
+    while True:
+        page = await service.list_all_recall_files(cursor=cursor, limit=limit)
+        assert len(page["recall_files"]) <= limit
+        seen.extend((f["track"], f["name"]) for f in page["recall_files"])
+        pages += 1
+        cursor = page["next_cursor"]
+        if not cursor:
+            break
+
+    # Every file exactly once (no skips/dups), in (track, name) order, and the
+    # final page correctly signalled the end.
+    expected = sorted([("memory", f"m{i:02d}") for i in range(4)] + [("skill", f"s{i:02d}") for i in range(4)])
+    assert seen == expected
+    assert pages == 3  # 8 files / page size 3 -> 3,3,2
+
+
 async def test_progressive_retrieve_ranks_all_three_layers(service: MemoryService) -> None:
     await _seed(service)
     result = await service.progressive_retrieve("coffee")

--- a/tests/test_bridging_promotion.py
+++ b/tests/test_bridging_promotion.py
@@ -39,8 +39,10 @@ class FakeService:
     def __init__(self) -> None:
         self.committed: list[dict[str, Any]] = []
 
-    async def list_all_recall_files(self) -> dict[str, Any]:
-        return {"recall_files": []}
+    async def list_all_recall_files(
+        self, where: Any = None, *, cursor: str | None = None, limit: int = 100
+    ) -> dict[str, Any]:
+        return {"recall_files": [], "next_cursor": None}
 
     async def commit_results(self, recall_files: Any, resource: Any) -> dict[str, Any]:
         self.committed.append({"recall_files": recall_files, "resource": resource})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -93,9 +93,11 @@ def test_retrieve_and_list_files_use_selected_backend(
             calls.append(("retrieve", query))
             return {"segments": [], "files": [], "resources": []}
 
-        async def list_all_recall_files(self) -> dict[str, Any]:
-            calls.append(("list", None))
-            return {"categories": []}
+        async def list_all_recall_files(
+            self, where: Any = None, *, cursor: str | None = None, limit: int = 100
+        ) -> dict[str, Any]:
+            calls.append(("list", cursor))
+            return {"recall_files": [], "next_cursor": None}
 
     backend = Backend()
     monkeypatch.setattr(cli, "build_agentic_memory_backend_from_env", lambda **kwargs: backend)

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -55,6 +55,25 @@ async def test_list_uses_v4_base_auth_and_explicit_default_scope() -> None:
     assert request.headers["Authorization"] == "Bearer project-key"
 
 
+async def test_list_forwards_cursor_and_limit_and_passes_page_through() -> None:
+    seen: list[httpx.Request] = []
+    page = {"recall_files": [{"name": "m01", "track": "memory"}], "next_cursor": "next-token"}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json=page)
+
+    result = await _client(handler).list_all_recall_files(cursor="cur-token", limit=25)
+
+    # One page per call: the client forwards the opaque cursor and page size and
+    # passes the server's page (next_cursor and all) straight back (ADR 0014).
+    assert result == page
+    params = dict(seen[0].url.params)
+    assert params["cursor"] == "cur-token"
+    assert params["limit"] == "25"
+    assert params["user_id"] == "default"
+
+
 async def test_search_maps_scope_and_passes_response_through() -> None:
     response_payload = {
         "segments": [{"id": "s1", "score": 0.9}],


### PR DESCRIPTION
## What & why

`list_all_recall_files` returned **every** recall file in a single response, so as a scope's memory/skill set grows the response grows without bound: one large DB read, one large serialization, one large HTTP body. This makes it return **one bounded page per call**, ordered by the domain identity `(track, name, id)` and carrying an opaque `next_cursor`. Callers follow the cursor to reassemble the full set.

Design decisions (full rationale in [ADR 0014](docs/adr/0014-paginated-list-all-recall-files.md)):

- **Keyset on `(track, name)`, not offset.** A recall file is keyed by `name` within its `track`, so within a fixed `(user_id, agent_id)` scope `(track, name)` is unique and immutable (a "rename" is delete-then-create). That makes the cursor walk skip- and duplicate-free even against the concurrent commits `prepare` races — where offset paging would drift and silently skip a row. `id` is a defensive final tiebreaker.
- **Paged at the repository, not sliced in memory.** Each page is a bounded `WHERE scope AND (track,name,id) > cursor ORDER BY track,name,id LIMIT n+1` query, so the server never re-scans the whole table per page.
- **The mixin is the single origin.** The hosted service runs this same `AgenticMixin` unchanged and passes its dict through, so the paginated shape is born here; the cloud client and server route only thread `cursor`/`limit` through.

## Changes

- New `RecallFileRepo.list_recall_files_page` across **sqlite / postgres / inmemory**; the existing full-fetch `list_recall_files` is left untouched for its roll-up and commit callers.
- `AgenticMixin`, the `AgenticMemoryBackend` protocol, and `CloudMemoryClient` gain `cursor`/`limit` and return `next_cursor` (cloud forwards one page, passthrough).
- Bridging `prepare` streams each page to disk; the `list-files` CLI follows the cursor before printing.
- Tests: mixin cursor walk over multiple pages (inmemory **and** sqlite), and cloud forward/passthrough.

## Follow-up (separate repo)

Server-side changes in **hippocampus-server** (route + engine param plumbing, and `MemuV4Store.list_recall_files_page` with identical ordering) are documented in ADR 0014 and land separately. memU must merge + bump the pin before the server can call with `cursor`/`limit`.

## Test plan

- [x] `uv run pytest -q` — 197 passed
- [x] `uv run mypy` — clean (128 files)
- [x] `uv run ruff check src tests` — clean
- [x] sqlite pagination test exercises the row-value keyset comparison against a real DB end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)