### PR TITLE
fix(hermes): isolate Windows Python environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,21 @@ jobs:
 
       - name: Run tests
         run: uv run make test
+
+  windows-console-script:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv & set Python
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+          enable-cache: true
+          cache-python: true
+
+      - name: Sync dependencies
+        run: uv sync --frozen
+
+      - name: Test the installed Hermes console executable
+        run: uv run python -m pytest tests/test_hermes_bootstrap.py

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ or MemU Cloud. What one host's sessions taught memU, another host retrieves.
 
 Installation is the one-message setup at the top of this README. [SKILL.md](SKILL.md) is the routing skill it hands your agent: install the package, identify which host you are (falling back to `memu-agent detect` for anything without a dedicated adapter), print that host's packaged install guide (`<binary> docs install`), and follow it — configure the memory backend, register the scheduled bridging task, patch the instruction file, each step behind a verify gate — then report which seams (memorization / retrieval) are now active.
 
+On Windows, `memu-hermes` isolates `PYTHONPATH`, `PYTHONHOME`, and
+`VIRTUAL_ENV` inherited from Hermes before it imports memU. This prevents the
+host's Python dependencies from overriding the environment where memU was
+installed; macOS and Linux keep the existing in-process launch behavior.
+
 Afterwards `<binary> doctor` proves the whole loop resolves: config, selected
 mode, and a live retrieval.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/memu"]
+packages = ["src/memu", "src/memu_hermes_bootstrap"]
 
 [dependency-groups]
 dev = [
@@ -65,7 +65,7 @@ memu-codex = "memu.hosts.codex.cli:main"
 memu-claude-code = "memu.hosts.claude_code.cli:main"
 memu-cursor = "memu.hosts.cursor.cli:main"
 memu-openclaw = "memu.hosts.openclaw.cli:main"
-memu-hermes = "memu.hosts.hermes.cli:main"
+memu-hermes = "memu_hermes_bootstrap.hermes:main"
 memu-workbuddy = "memu.hosts.workbuddy.cli:main"
 # The generic adapter: any agent without a dedicated binary. `memu-agent
 # detect` finds the session log and instruction file, then reports which of

--- a/src/memu/hosts/hermes/INSTALL.md
+++ b/src/memu/hosts/hermes/INSTALL.md
@@ -37,6 +37,11 @@ This puts `memu` and **`memu-hermes`** on `PATH`. Confirm: `memu-hermes --help`.
 If it is not found, fix `PATH` now — the scheduled task in Part 2 runs from a
 bare, non-interactive environment.
 
+On Windows, `memu-hermes` automatically removes `PYTHONPATH`, `PYTHONHOME`, and
+`VIRTUAL_ENV` inherited from Hermes before loading memU. It keeps `PATH`, all
+`MEMU_*` settings, proxy configuration, and the console script's own Python
+interpreter. macOS and Linux retain the existing in-process launch behavior.
+
 ### 1.2 Configure the memory backend
 
 If `~/.memu/config.env` already exists from another memU host, reuse it as is

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -272,6 +272,10 @@ async def _cmd_doctor(spec: HostSpec, args: argparse.Namespace) -> int:
     """
     from memu.env import CONFIG_ENV, cloud_base_url, embedding_provider, env, memory_mode
 
+    isolated = os.environ.get("MEMU_HERMES_ISOLATED_ENV")
+    if spec.host == "hermes" and isolated and os.environ.get("MEMU_DEBUG") == "1":
+        print(f"note: isolated Hermes host Python environment ({isolated})", file=sys.stderr)
+
     try:
         mode = memory_mode()
         result = await retrieval.retrieve("smoke test")

--- a/src/memu_hermes_bootstrap/__init__.py
+++ b/src/memu_hermes_bootstrap/__init__.py
@@ -1,0 +1,1 @@
+"""Dependency-free launch shim for the Hermes host environment."""

--- a/src/memu_hermes_bootstrap/hermes.py
+++ b/src/memu_hermes_bootstrap/hermes.py
@@ -1,0 +1,52 @@
+"""Start ``memu-hermes`` without inheriting Hermes's Python environment.
+
+Hermes launches shell tools from its own Python environment on Windows. Its
+``PYTHONPATH`` can therefore put Hermes's dependencies ahead of the interpreter
+that owns the ``memu-hermes`` console script. Keep this module independent of
+``memu`` and third-party packages so it can restart the real CLI before either
+is imported.
+
+The isolation is Windows-only. On POSIX, delegate in-process so existing
+macOS/Linux environment, signal, and process semantics stay unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+ISOLATED_ENV_MARKER = "MEMU_HERMES_ISOLATED_ENV"
+_HOST_PYTHON_ENV = ("PYTHONPATH", "PYTHONHOME", "VIRTUAL_ENV")
+
+
+def _windows_main() -> int:
+    env = os.environ.copy()
+    removed = [name for name in _HOST_PYTHON_ENV if name in env]
+    for name in removed:
+        env.pop(name)
+    if removed:
+        # Pass names only: paths can contain user-specific or sensitive data.
+        env[ISOLATED_ENV_MARKER] = ",".join(removed)
+
+    command = [
+        sys.executable,
+        "-E",
+        "-P",
+        "-m",
+        "memu.hosts.hermes.cli",
+        *sys.argv[1:],
+    ]
+    try:
+        return subprocess.call(command, env=env)  # noqa: S603
+    except KeyboardInterrupt:
+        return 130
+
+
+def main() -> int:
+    if os.name == "nt":
+        return _windows_main()
+
+    from memu.hosts.hermes.cli import main as hermes_main
+
+    return hermes_main()

--- a/tests/test_hermes_bootstrap.py
+++ b/tests/test_hermes_bootstrap.py
@@ -1,0 +1,173 @@
+"""Hermes's console-script boundary isolates its embedded Python on Windows."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from memu.hosts import host_cli
+from memu.hosts.hermes.cli import SPEC
+from memu_hermes_bootstrap import hermes as bootstrap
+
+
+def test_non_windows_delegates_in_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    from memu.hosts.hermes import cli
+
+    monkeypatch.setattr(bootstrap.os, "name", "posix")
+    monkeypatch.setattr(cli, "main", lambda: 23)
+
+    def unexpected_call(*args: Any, **kwargs: Any) -> int:
+        raise AssertionError
+
+    monkeypatch.setattr(bootstrap.subprocess, "call", unexpected_call)
+
+    assert bootstrap.main() == 23
+
+
+def test_windows_restarts_with_clean_import_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_call(command: list[str], *, env: dict[str, str]) -> int:
+        captured["command"] = command
+        captured["env"] = env
+        return 17
+
+    monkeypatch.setattr(bootstrap.os, "name", "nt")
+    monkeypatch.setattr(bootstrap.sys, "executable", r"C:\Python313\python.exe")
+    monkeypatch.setattr(bootstrap.sys, "argv", ["memu-hermes", "retrieve", "tea and cake"])
+    monkeypatch.setattr(bootstrap.subprocess, "call", fake_call)
+    monkeypatch.setenv("PYTHONPATH", r"C:\hermes;C:\hermes\venv\Lib\site-packages")
+    monkeypatch.setenv("PYTHONHOME", r"C:\hermes\venv")
+    monkeypatch.setenv("VIRTUAL_ENV", r"C:\hermes\venv")
+    monkeypatch.setenv("MEMU_DB", r"C:\memory\memu.sqlite3")
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example")
+
+    assert bootstrap.main() == 17
+    assert captured["command"] == [
+        r"C:\Python313\python.exe",
+        "-E",
+        "-P",
+        "-m",
+        "memu.hosts.hermes.cli",
+        "retrieve",
+        "tea and cake",
+    ]
+    child_env = captured["env"]
+    assert "PYTHONPATH" not in child_env
+    assert "PYTHONHOME" not in child_env
+    assert "VIRTUAL_ENV" not in child_env
+    assert child_env[bootstrap.ISOLATED_ENV_MARKER] == "PYTHONPATH,PYTHONHOME,VIRTUAL_ENV"
+    assert child_env["MEMU_DB"] == r"C:\memory\memu.sqlite3"
+    assert child_env["HTTPS_PROXY"] == "http://proxy.example"
+
+
+def test_windows_ctrl_c_returns_shell_interrupt_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bootstrap.os, "name", "nt")
+
+    def interrupted(*args: Any, **kwargs: Any) -> int:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(bootstrap.subprocess, "call", interrupted)
+
+    assert bootstrap.main() == 130
+
+
+def test_doctor_debug_reports_isolated_variable_names(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    async def successful_retrieve(query: str) -> dict[str, list[Any]]:
+        return {"segments": [], "files": [], "resources": []}
+
+    monkeypatch.setattr(host_cli.retrieval, "retrieve", successful_retrieve)
+    monkeypatch.setenv("MEMU_MEMORY_MODE", "local")
+    monkeypatch.setenv("MEMU_DB", ":memory:")
+    monkeypatch.setenv("MEMU_DEBUG", "1")
+    monkeypatch.setenv(bootstrap.ISOLATED_ENV_MARKER, "PYTHONPATH,VIRTUAL_ENV")
+
+    assert host_cli.run(SPEC, ["doctor"]) == 0
+    assert "isolated Hermes host Python environment (PYTHONPATH,VIRTUAL_ENV)" in capsys.readouterr().err
+
+
+class _CloudHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        self.rfile.read(int(self.headers.get("Content-Length", "0")))
+        body = b'{"segments": [], "files": [], "resources": []}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        pass
+
+
+def _console_script() -> Path:
+    suffix = ".exe" if sys.platform == "win32" else ""
+    return Path(sys.executable).with_name(f"memu-hermes{suffix}")
+
+
+def test_installed_console_script_survives_hermes_pythonpath(tmp_path: Path) -> None:
+    script = _console_script()
+    assert script.is_file(), f"installed console script not found: {script}"
+
+    env = os.environ.copy()
+    env["MEMU_DOCS_BASE_URL"] = ""
+    env["MEMU_TEMPLATE_BASE_URL"] = ""
+    env["MEMU_MEMORY_MODE"] = "cloud"
+    env["MEMU_CLOUD_API_KEY"] = "test-key"
+    env["MEMU_DEBUG"] = "1"
+    env["NO_PROXY"] = "127.0.0.1,localhost"
+    env["no_proxy"] = "127.0.0.1,localhost"
+
+    if sys.platform == "win32":
+        hermes_site = tmp_path / "hermes-venv" / "Lib" / "site-packages"
+        hermes_site.mkdir(parents=True)
+        (hermes_site / "pydantic.py").write_text(
+            'raise RuntimeError("poisoned Hermes pydantic was imported")\n', encoding="utf-8"
+        )
+        env["PYTHONPATH"] = str(hermes_site)
+        env["VIRTUAL_ENV"] = str(tmp_path / "hermes-venv")
+
+    docs = subprocess.run(  # noqa: S603
+        [str(script), "docs", "install"],
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+    )
+    assert docs.returncode == 0, docs.stderr
+    assert "Install memU for Hermes Agent" in docs.stdout
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _CloudHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        env["MEMU_CLOUD_BASE_URL"] = f"http://127.0.0.1:{server.server_port}/api/v4/memory/"
+        doctor = subprocess.run(  # noqa: S603
+            [str(script), "doctor"],
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert doctor.returncode == 0, doctor.stderr
+    assert "retrieval ok" in doctor.stdout
+    if sys.platform == "win32":
+        assert "isolated Hermes host Python environment (PYTHONPATH,VIRTUAL_ENV)" in doctor.stderr


### PR DESCRIPTION
## Pull Request Summary

Fix Windows `memu-hermes` retrieval failures caused by Hermes's inherited Python environment shadowing memU dependencies.

---

## What does this PR do?

- Routes the `memu-hermes` console script through a dependency-free top-level bootstrap.
- On Windows, removes inherited `PYTHONPATH`, `PYTHONHOME`, and `VIRTUAL_ENV`, then restarts the real CLI with the same interpreter using `-E -P`.
- Preserves the existing in-process launch behavior on macOS and Linux.
- Adds a debug-only doctor note listing which variable names were isolated, without exposing their values.
- Adds Windows CI coverage against the generated `memu-hermes.exe` with a deliberately poisoned pydantic on `PYTHONPATH`.
- Documents the Windows isolation behavior.

---

## Why is this change needed?

Hermes can invoke shell tools with its own venv on `PYTHONPATH`. The previous entry point imported `memu.hosts.hermes.cli` directly, which executes `memu/__init__.py` and imports pydantic before CLI code can sanitize the environment. A mismatched Hermes pydantic therefore prevents retrieval and doctor from starting.

The bootstrap intentionally lives outside `memu.*` so no memU or third-party module is imported before the clean restart.

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / cleanup
- [ ] Other

---

## PR Quality Checklist

- [x] PR title follows an allowed format
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable
- [x] No breaking changes
- [ ] Related issues or discussions linked

---

## Validation

- `uv run python -m pytest tests/test_hermes_bootstrap.py -q` — 5 passed
- Real installed Windows `memu-hermes.exe` passed `docs` and `doctor` with a poisoned Hermes pydantic on `PYTHONPATH`
- `uv run pre-commit run -a`
- `uv run mypy`
- `uv run deptry src`
- Built wheel contains `memu_hermes_bootstrap` and the expected console entry point

A full local Windows run passed 209 tests; one pre-existing oversized parametrized template case exceeds Windows's 32,767-character environment-variable limit when pytest writes `PYTEST_CURRENT_TEST`. The existing Linux full-suite job is unchanged, and the new Windows job runs the launcher-focused regression.

---

## Optional

- [ ] Screenshots or examples added (not applicable)
- [x] Edge cases considered
- [ ] Follow-up tasks mentioned