### PR TITLE
docs: separate cloud and self-hosted setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,11 @@ memU is a lightweight, agent-driven memory system that gives users a shared LLM 
 
 memU works with Codex, Claude Code, Cursor, OpenClaw, Hermes, WorkBuddy, and more. See [Host adapters](#host-adapters-memory-for-desktop-coding-agents).
 
-Choose Cloud or Local, then send the corresponding message to your agent.
-
-### Cloud
-
 **Cross-device · Free · Unlimited · [View online](https://memu.so)**
 
-> Read [https://memu.pro/SKILL.md](https://memu.pro/SKILL.md) and follow it to install memU.
+Get your API key from [memu.so](https://memu.so), then send this message to your agent:
 
-### Local / self-hosted
-
-**Private · Single-device · Embedding key required**
-
-> Read [https://raw.githubusercontent.com/NevaMind-AI/MemU/main/SKILL.md](https://raw.githubusercontent.com/NevaMind-AI/MemU/main/SKILL.md) and follow it to install memU.
+> Read [https://memu.pro/SKILL.md](https://memu.pro/SKILL.md), follow its instructions to install and configure memU, API Key is memu_•••••••••(get Api Key from memu.so).
 
 ## How it works
 
@@ -59,9 +51,17 @@ Once the scheduled bridging task is installed, memU can turn useful agent histor
 
 The judgment and synthesis stay inside the agent. `MemoryService` makes no LLM or chat calls; it stores, embeds, and retrieves the skill Markdown the agent prepared.
 
+## Self-hosted
+
+**Private · Single-device · Embedding key required**
+
+To run memU locally with your own storage and embedding provider, send this message to your agent:
+
+> Read [https://raw.githubusercontent.com/NevaMind-AI/MemU/main/SKILL.md](https://raw.githubusercontent.com/NevaMind-AI/MemU/main/SKILL.md) and follow it to install memU.
+
 ## Host adapters: memory for desktop coding agents
 
-memU runs as a sidecar to a desktop agent (ADR 0008/0009/0010), one binary per host. Each binds two seams:
+memU runs as a sidecar to a desktop agent, one binary per host. Each binds two seams:
 
 - **record** — a scheduled bridging task slices new session logs into self-contained job files; the agent itself distills them into memory/skill Markdown; `commit` submits whatever the agent left on disk back through `commit_results`.
 - **inject** — a standing instruction in the host's instruction file tells the agent to run `<binary> retrieve` (→ `progressive_retrieve`) before answering.
@@ -81,7 +81,7 @@ For agents without a dedicated binary, `memu-agent detect` probes the machine an
 All hosts share one configured memory backend via `~/.memu/config.env` — local
 or MemU Cloud. What one host's sessions taught memU, another host retrieves.
 
-Installation is the one-message setup at the top of this README. [SKILL.md](SKILL.md) is the routing skill it hands your agent: install the package, identify which host you are (falling back to `memu-agent detect` for anything without a dedicated adapter), print that host's packaged install guide (`<binary> docs install`), and follow it — configure the memory backend, register the scheduled bridging task, patch the instruction file, each step behind a verify gate — then report which seams (memorization / retrieval) are now active.
+Installation is the one-message setup in [Quick start](#quick-start) or [Self-hosted](#self-hosted). [SKILL.md](SKILL.md) is the routing skill it hands your agent: install the package, identify which host you are (falling back to `memu-agent detect` for anything without a dedicated adapter), print that host's packaged install guide (`<binary> docs install`), and follow it — configure the memory backend, register the scheduled bridging task, patch the instruction file, each step behind a verify gate — then report which seams (memorization / retrieval) are now active.
 
 Afterwards `<binary> doctor` proves the whole loop resolves: config, selected
 mode, and a live retrieval.


### PR DESCRIPTION
## What changed

- keep Quick start focused on the memU Cloud skill
- direct users to memu.so for their Cloud API key and show the expected key format
- move the local installation instruction into a dedicated Self-hosted section
- update the later installation reference to link to both setup sections
- simplify the host-adapter introduction while retaining the current WorkBuddy instruction path from main

## Why

Cloud onboarding should be the primary quick-start path, while self-hosted setup remains easy to find without competing with the default flow.

## Impact

README readers get a clearer Cloud-first installation path and explicit API-key guidance. Runtime behavior is unchanged.

## Validation

- `git diff --check`
- compared the branch with latest `main`: one commit, one modified file (`README.md`)
