### PR TITLE
feat(inject): route a bare "uninstall memU" to the packaged guide

### DIFF
--- a/src/memu/hosts/instruction.py
+++ b/src/memu/hosts/instruction.py
@@ -66,6 +66,20 @@ plus a summary. Work from the summaries; open a `path` only when you need what i
 leaves out.
 """
 
+# "Uninstall memU" arrives with no file to point at: the user won't say "read
+# SKILL.md and follow its uninstall section", they'll just say the words, and an
+# agent with no routing in context improvises — deleting too much or too little.
+# This one sentence is that routing, and it must sit in the *instruction file*
+# (both variants), not in the retrieval body or the skill: the body is replaced
+# wholesale by :func:`refresh` from the server's copy, so anything riding inside
+# it would be washed out on the next scheduled run. Outside the ``{body}`` slot
+# it survives refresh, upgrades with the managed block, and — because
+# ``remove-instruction`` takes the whole block — removes itself with the seam.
+UNINSTALL_POINTER = """\
+If the user asks to uninstall or remove memU, do not improvise: run
+`{binary} docs uninstall` and follow the guide it prints, top to bottom.
+"""
+
 # The body is a ``{body}`` slot rather than baked in, so the same document can be
 # rendered with either the embedded :data:`RETRIEVAL_BODY` or the body carved out
 # of the server's current skill (:mod:`memu.hosts.templates`) — see :func:`_body`,
@@ -75,14 +89,16 @@ INSTRUCTION_TEMPLATE = """\
 
 Before answering:
 
-{body}"""
+{body}
+{uninstall}"""
 
 SKILL_INSTRUCTION_TEMPLATE = """\
 ## memU — retrieve before answering
 
 Before answering, use the `{skill}` skill to pull any relevant memory into
 context. It fails open: if nothing comes back, answer normally.
-"""
+
+{uninstall}"""
 
 SKILL_TEMPLATE = """\
 ---
@@ -149,9 +165,10 @@ def instruction(binary: str, *, skill: bool = False, skill_text: str | None = No
     overrides the embedded retrieval body with the body carved out of a
     server-fetched skill (ignored for the pointer, which carries no body).
     """
+    uninstall = UNINSTALL_POINTER.format(binary=binary)
     if skill:
-        return SKILL_INSTRUCTION_TEMPLATE.format(skill=SKILL_NAME, binary=binary)
-    return INSTRUCTION_TEMPLATE.format(body=_body(binary, skill_text))
+        return SKILL_INSTRUCTION_TEMPLATE.format(skill=SKILL_NAME, binary=binary, uninstall=uninstall)
+    return INSTRUCTION_TEMPLATE.format(body=_body(binary, skill_text), uninstall=uninstall)
 
 
 def block(binary: str, *, skill: bool = False, skill_text: str | None = None) -> str:

--- a/tests/test_host_instruction.py
+++ b/tests/test_host_instruction.py
@@ -246,6 +246,39 @@ def test_instruction_names_the_llm_free_retrieval() -> None:
     assert "`memu retrieve" not in instruction.instruction(BINARY)
 
 
+def test_both_variants_route_an_uninstall_to_the_packaged_guide() -> None:
+    """A user says "uninstall memU", not "read SKILL.md and follow its uninstall
+    section" — so the routing to `docs uninstall` must already sit in the one
+    thing guaranteed to be in context: the instruction block, in both shapes."""
+    inline = instruction.instruction(BINARY)
+    pointer = instruction.instruction(BINARY, skill=True)
+    assert "memu-codex docs uninstall" in inline
+    assert "memu-codex docs uninstall" in pointer
+
+
+def test_uninstall_routing_survives_a_server_refreshed_body() -> None:
+    """`refresh` replaces the retrieval body wholesale from the server's skill —
+    the uninstall pointer lives outside the ``{body}`` slot precisely so a
+    scheduled refresh cannot wash it out."""
+    skill_text = "---\nname: memu-retrieve\n---\n\n# Retrieve\n\nServer body: run {binary} retrieve.\n"
+    text = instruction.instruction(BINARY, skill_text=skill_text)
+    assert "Server body" in text, "the refreshed body must actually be in use"
+    assert "memu-codex docs uninstall" in text
+
+
+def test_uninstall_routing_leaves_with_the_block(tmp_path: pathlib.Path) -> None:
+    """After an uninstall the pointer must not linger, naming a binary that is
+    about to be gone — `remove-instruction` takes the whole block, pointer included."""
+    path = tmp_path / "AGENTS.md"
+    path.write_text("# My rules\n", encoding="utf-8")
+    instruction.install(path, BINARY)
+    assert "docs uninstall" in path.read_text(encoding="utf-8")
+
+    instruction.remove(path, BINARY)
+
+    assert "docs uninstall" not in path.read_text(encoding="utf-8")
+
+
 def test_remove_restores_user_content_byte_for_byte(tmp_path: pathlib.Path) -> None:
     """The uninstall promise: an install/remove round-trip is invisible."""
     original = "# My rules\n\nAlways use tabs.\n"


### PR DESCRIPTION
## Problem

The uninstall flow assumes the user points the agent at a guide ("read SKILL.md and follow its uninstall section"). Real users don't do that — they just say **"uninstall memU"**. An agent with no routing in its context improvises: it deletes too much (the store, the user's own crontab lines) or too little (leaves the bridging task firing against a removed package).

## Fix

Put the routing in the one thing guaranteed to be in every session's context on an integrated host: the managed instruction block, in both shapes. Two sentences:

> If the user asks to uninstall or remove memU, do not improvise: run
> `<binary> docs uninstall` and follow the guide it prints, top to bottom.

Why this channel and not, say, a seeded memory:

- **Deterministic, not probabilistic.** The inject seam puts it in context on every turn — no dependence on a retrieval happening, matching, and ranking into top-k at exactly the moment things may already be broken.
- **Upgrades for free.** It rides the managed block, so an upgrade is a re-run (`install-instruction`), same as everything else in the block.
- **Removes itself.** `remove-instruction` takes the whole block, so after an uninstall no sentence lingers naming a binary that is gone.
- **Version-proof by indirection.** It points at `docs uninstall`, which prints the guide shipped in the *currently installed* package — no second copy of uninstall steps to keep in sync.

## Placement detail

The pointer lives **outside the `{body}` slot** deliberately: `refresh` replaces the retrieval body wholesale from the server's skill document, so anything riding inside the body would be washed out on the next scheduled run. There's a test pinning exactly that property.

## Tests

Four new tests in `test_host_instruction.py`:
- both block variants (inline and skill-pointer) carry the routing
- the routing **survives a server-refreshed body**
- `remove-instruction` takes the pointer with the block
- (existing idempotence/upgrade tests cover the migration story unchanged)

Full suite: 208 passed.

---

## 问题

现有卸载流程假设用户会给 agent 指路（「读 SKILL.md 并按其中的卸载章节操作」）。真实用户不会这么说——他们只会说**「卸载 memU」**。上下文里没有任何路由信息的 agent 就会自由发挥：要么删多了（store、用户自己的 crontab 条目），要么删少了（bridging task 还在定时触发一个已被删除的包）。

## 修复

把路由放进已集成 host 上唯一保证每个 session 都在上下文里的东西：managed instruction block，两种形态都加。就两句话：

> If the user asks to uninstall or remove memU, do not improvise: run
> `<binary> docs uninstall` and follow the guide it prints, top to bottom.

为什么选这个通道，而不是（比如）内置一条 memory：

- **确定性，而非概率性。** inject seam 保证它每个 turn 都在上下文里——不依赖「检索恰好发生、恰好命中、恰好排进 top-k」，尤其卸载时刻往往正是检索链路已经出问题的时刻。
- **升级免费。** 它随 managed block 走，升级就是 re-run（`install-instruction`），和 block 里其他内容一样。
- **自我移除。** `remove-instruction` 摘掉整个 block，卸载完成后不会留下一句指向已删 binary 的残句。
- **靠间接引用做到版本无关。** 它指向 `docs uninstall`，打印的是**当前已安装包**内置的指南——不存在需要同步维护的第二份卸载步骤。

## 放置位置的细节

指针刻意放在 **`{body}` 槽位之外**：`refresh` 会用服务端的 skill 文档整体替换检索正文，任何写在 body 里的内容都会在下一次定时刷新时被冲掉。有一个测试专门钉住这条性质。

## 测试

`test_host_instruction.py` 新增 4 个测试：
- 两种 block 变体（inline 和 skill 指针）都带路由
- 路由**在服务端刷新 body 后仍然存活**
- `remove-instruction` 摘 block 时把指针一起带走
- （既有的幂等/升级测试不变，覆盖存量用户的迁移路径）

全量测试：208 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
