### PR TITLE
feat(seed): plant SKILL.md as a skill-track memory at setup time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/memu"]
 
+# The root SKILL.md doubles as the seed skill (memu.hosts.seed): setup plants it
+# in the user's store so a bare "uninstall memU" can retrieve the packaged guide.
+[tool.hatch.build.targets.wheel.force-include]
+"SKILL.md" = "memu/SKILL.md"
+
 [dependency-groups]
 dev = [
     {include-group = "lint"},

--- a/src/memu/hosts/bridging/recall_files.py
+++ b/src/memu/hosts/bridging/recall_files.py
@@ -69,7 +69,16 @@ def read_recall_file(path: Path, track: str) -> dict[str, Any]:
     tagging it with the ``track`` its directory represents (the file itself does
     not store the track). Mirrors the fields ``list_all_recall_files`` returns.
     """
-    text = path.read_text(encoding="utf-8")
+    return parse_recall_text(path.read_text(encoding="utf-8"), track)
+
+
+def parse_recall_text(text: str, track: str) -> dict[str, Any]:
+    """The parsing half of :func:`read_recall_file`, for text not yet on disk.
+
+    Split out so a caller holding a front-mattered document from elsewhere (a
+    packaged skill being seeded, a server-fetched template) can parse it with the
+    same convention the mirror uses, rather than growing a second parser.
+    """
     name = ""
     description = ""
     content = text

--- a/src/memu/hosts/claude_code/INSTALL.md
+++ b/src/memu/hosts/claude_code/INSTALL.md
@@ -171,6 +171,18 @@ memu-claude-code doctor
 It prints the resolved mode plus its endpoint or local store/provider, and runs a smoke-test retrieval. It
 must exit cleanly. **Zero hits is the expected result** on a new store.
 
+With `doctor` green, plant the packaged install/uninstall skill into the store:
+
+```
+memu-claude-code seed-skills
+```
+
+This stores `SKILL.md` as a `skill`-track recall file, so a later bare
+"uninstall memU" — said without pointing at any guide — can surface the packaged
+instructions through retrieval, on any host sharing this store. Rerunning is an
+upsert, never a duplicate; if the store already carries it from another host's
+install, this refreshes it to this package's copy.
+
 ---
 
 ## Part 2 — Register the bridging (record) task

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -301,6 +301,22 @@ async def _cmd_doctor(spec: HostSpec, args: argparse.Namespace) -> int:
     return 0
 
 
+async def _cmd_seed_skills(spec: HostSpec, args: argparse.Namespace) -> int:
+    """Plant the packaged install/uninstall skill into the store (see :mod:`memu.hosts.seed`).
+
+    A setup-time step: run once after ``doctor`` is green, so a later bare
+    "uninstall memU" can surface the packaged guide through retrieval on any
+    host sharing this store. Rerunning is an upsert, never a duplicate.
+    """
+    from memu.hosts import seed as seed_module
+
+    mirror, result = await seed_module.seed(_layout(spec, args).base)
+    committed = result.get("recall_files", [])
+    print(f"mirror  {mirror}")
+    print(f"store   upserted {len(committed)} skill file(s)")
+    return 0
+
+
 async def _cmd_docs(spec: HostSpec, args: argparse.Namespace) -> int:
     # Server-first, then last-good cache, then the embedded floor — the same
     # self-updating shape ADR 0013 gives the instruction templates, applied to the
@@ -397,6 +413,14 @@ def build_parser(spec: HostSpec) -> argparse.ArgumentParser:
 
     p = sub.add_parser("doctor", help="Verify MEMU_* config resolves and the selected memory backend is reachable")
     p.set_defaults(handler=bind(_cmd_doctor))
+
+    p = with_base(
+        sub.add_parser(
+            "seed-skills",
+            help="Plant the packaged install/uninstall skill into the store (setup-time; rerun-safe upsert)",
+        )
+    )
+    p.set_defaults(handler=bind(_cmd_seed_skills))
 
     p = sub.add_parser("docs", help="Print a packaged agent-facing guide")
     p.add_argument(

--- a/src/memu/hosts/seed.py
+++ b/src/memu/hosts/seed.py
@@ -1,0 +1,74 @@
+"""Seed the packaged install/uninstall skill into the user's store at setup time.
+
+A user who wants memU gone says "uninstall memU" — not "read SKILL.md and follow
+its uninstall section". An agent whose context holds no route to the packaged
+guide improvises, and an improvised teardown deletes too much (the store) or too
+little (the bridging task). Retrieval is a channel that can carry that route: if
+the root ``SKILL.md`` sits in the store as a ``skill``-track recall file, a bare
+"uninstall memU" can surface it on *any* host sharing the store — including hosts
+whose instruction file was never patched, or was hand-edited since.
+
+So setup plants it once. The seed is the packaged ``SKILL.md`` verbatim: its
+frontmatter is already the recall-file convention (``name``/``description``), its
+description already names the triggers ("install, set up, integrate, remove, or
+uninstall memU"), and that description is exactly what gets embedded — the
+retrieval surface. Committing through ``commit_results`` makes reseeding an
+upsert: a later install refreshes the stored copy instead of stacking a twin.
+
+The mirror under ``~/.memu/skill/`` is written too, for the same reason bridging
+mirrors everything: the agent's working medium is markdown on disk, and a seeded
+file the self-evolve loop cannot see is a file it would recreate or contradict.
+"""
+
+from __future__ import annotations
+
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+
+from memu.hosts.bridging.layout import TRACK_DIRS
+from memu.hosts.bridging.recall_files import parse_recall_text, write_recall_file
+
+SEED_TRACK = "skill"
+
+
+def seed_document() -> str:
+    """The packaged root ``SKILL.md``, falling back to the repo checkout.
+
+    The wheel force-includes the repo-root ``SKILL.md`` as ``memu/SKILL.md`` (see
+    ``pyproject.toml``); an editable/dev checkout has no such copy, so fall back
+    to the file three levels up from this module. One source document either way
+    — never a second copy that can drift.
+    """
+    packaged = files("memu") / "SKILL.md"
+    if packaged.is_file():
+        return packaged.read_text(encoding="utf-8")
+    return (Path(__file__).resolve().parents[3] / "SKILL.md").read_text(encoding="utf-8")
+
+
+def seed_recall_file() -> dict[str, Any]:
+    """``SKILL.md`` parsed into the shape ``commit_results`` expects.
+
+    The document's own frontmatter supplies ``name`` and ``description`` — the
+    description is what gets embedded, and it already carries the uninstall
+    trigger words. No rewriting here: the skill's author owns the retrieval
+    surface, not the seeder.
+    """
+    return parse_recall_text(seed_document(), track=SEED_TRACK)
+
+
+async def seed(base_dir: Path) -> tuple[Path, dict[str, Any]]:
+    """Plant the skill: mirror it under ``base_dir`` and upsert it into the store.
+
+    Returns ``(mirror_path, commit result)``. Deliberately store-first in spirit
+    but mirror-first in order: the mirror write is local and cannot half-fail,
+    while the commit needs the backend — if that raises, the caller reruns this
+    whole command and the mirror write is an idempotent overwrite.
+    """
+    from memu.env import build_agentic_memory_backend_from_env
+
+    recall_file = seed_recall_file()
+    mirror = write_recall_file(base_dir, TRACK_DIRS[SEED_TRACK], recall_file)
+    backend = build_agentic_memory_backend_from_env()
+    result: dict[str, Any] = await backend.commit_results(recall_files=[recall_file])
+    return mirror, result

--- a/tests/test_host_seed.py
+++ b/tests/test_host_seed.py
@@ -1,0 +1,78 @@
+"""The seed skill: does setup plant the uninstall route where retrieval can find it?
+
+A bare "uninstall memU" carries no pointer to the packaged guide; the seeded
+``SKILL.md`` in the skill track is what retrieval surfaces instead. These pin the
+seam's three properties: the seed is the packaged document verbatim (its own
+frontmatter is the retrieval surface), planting writes both the mirror and the
+store, and replanting is an upsert rather than a twin.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+import pytest
+
+from memu.hosts import seed
+from memu.hosts.bridging.recall_files import read_recall_file
+from memu.hosts.codex.cli import build_parser
+
+
+def test_seed_is_the_packaged_skill_with_its_own_frontmatter() -> None:
+    """The document's author owns the retrieval surface — the seeder rewrites nothing."""
+    recall_file = seed.seed_recall_file()
+
+    assert recall_file["name"] == "install-memu"
+    assert recall_file["track"] == "skill"
+    assert "uninstall" in recall_file["description"].lower(), (
+        "the description is what gets embedded — without the trigger word, a bare 'uninstall memU' cannot match"
+    )
+    assert "## Uninstall" in recall_file["content"]
+
+
+class _FakeBackend:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def commit_results(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return {"recall_files": kwargs.get("recall_files") or []}
+
+
+@pytest.fixture
+def backend(monkeypatch: pytest.MonkeyPatch) -> _FakeBackend:
+    import memu.env
+
+    fake = _FakeBackend()
+    monkeypatch.setattr(memu.env, "build_agentic_memory_backend_from_env", lambda **_: fake)
+    return fake
+
+
+async def test_seed_writes_the_mirror_and_commits_to_the_store(
+    backend: _FakeBackend, tmp_path: pathlib.Path
+) -> None:
+    mirror, result = await seed.seed(tmp_path)
+
+    assert mirror == tmp_path / "skill" / "install-memu.md"
+    assert read_recall_file(mirror, "skill") == seed.seed_recall_file(), (
+        "the mirror must round-trip to the exact recall file the store received"
+    )
+    assert backend.calls == [{"recall_files": [seed.seed_recall_file()]}]
+    assert result["recall_files"], "the caller reports what the store accepted"
+
+
+async def test_reseeding_overwrites_in_place(backend: _FakeBackend, tmp_path: pathlib.Path) -> None:
+    """A second install (same host or another sharing the store) refreshes, never stacks."""
+    first, _ = await seed.seed(tmp_path)
+    second, _ = await seed.seed(tmp_path)
+
+    assert first == second
+    assert [p.name for p in (tmp_path / "skill").iterdir()] == ["install-memu.md"]
+    assert len(backend.calls) == 2, "each run re-commits — commit_results upserts by (track, name)"
+
+
+def test_cli_registers_seed_skills() -> None:
+    args = build_parser().parse_args(["seed-skills"])
+    assert callable(args.handler)
+    assert args.base_dir, "seed needs the working tree to place the mirror"

--- a/tests/test_host_seed.py
+++ b/tests/test_host_seed.py
@@ -49,9 +49,7 @@ def backend(monkeypatch: pytest.MonkeyPatch) -> _FakeBackend:
     return fake
 
 
-async def test_seed_writes_the_mirror_and_commits_to_the_store(
-    backend: _FakeBackend, tmp_path: pathlib.Path
-) -> None:
+async def test_seed_writes_the_mirror_and_commits_to_the_store(backend: _FakeBackend, tmp_path: pathlib.Path) -> None:
     mirror, result = await seed.seed(tmp_path)
 
     assert mirror == tmp_path / "skill" / "install-memu.md"


### PR DESCRIPTION
## What this is

The redundancy layer for the bare-"uninstall memU" problem, complementary to #583 — same problem, different delivery channel.

#583 puts the routing in the **push** channel: the managed instruction block, unconditionally in context on every turn of an integrated host. This PR puts the packaged guide in the **pull** channel: setup plants the root `SKILL.md` into the store as a `skill`-track recall file, so a bare "uninstall memU" can surface it *through retrieval* — including on hosts whose instruction file was never patched, was hand-edited since, or belongs to an existing install that hasn't re-run `install-instruction` yet (the staleness gap #583 has on skill hosts). The two layers' failure modes are disjoint by construction.

## How it works

- New module `memu/hosts/seed.py`: reads the packaged `SKILL.md` **verbatim** and commits it via `commit_results`. No rewriting: the document's own frontmatter is already the recall-file convention, and its `description` — the embedded retrieval surface — already carries the trigger words ("install, set up, integrate, remove, or uninstall memU"). The skill's author owns the retrieval surface, not the seeder.
- Committing through `commit_results` makes reseeding an **upsert** by `(track, name)` — a second install (same host or another sharing the store) refreshes the stored copy instead of stacking a twin.
- The `~/.memu/skill/` mirror is written too: the self-evolve loop works against markdown on disk, and a seeded file it cannot see is a file it would recreate or contradict.
- New host command `memu-<host> seed-skills` (all seven hosts get it), invoked in the install flow right after the `doctor` gate — the closest thing local mode has to "registration complete". Wired into `claude_code/INSTALL.md` as the reference host; the other six guides follow once the direction is settled.
- The wheel force-includes the repo-root `SKILL.md` as `memu/SKILL.md`; dev checkouts fall back to the repo-root copy. One source document, never a second copy that can drift.
- Small refactor: `read_recall_file` splits out `parse_recall_text`, so the seed parses with the mirror's own convention instead of growing a second parser.

## Open questions (deliberately not resolved here — this PR is write-side only)

This PR makes the seed **exist** in the store; whether it gets **found** reliably is a retrieval-side question with three open decisions. None of them block the write side, and this PR is compatible with every outcome:

1. **Hard rule or not** — should a query containing "memU" force-include this file in retrieval results? Deterministic for gates 2–3 (semantic match + top-k), and it ships with the package so upgrades activate it everywhere at once. But it special-cases vendor content inside a neutral engine, false-positives on every memU-development query, and still can't fix gate 1 (the agent must run retrieve at all — only the inject seam reaches that). Leaning no until the data says otherwise.
2. **Track semantics vs. recall stability** — `skill` track is semantically correct (this is a procedure), and that's where this PR puts it. But skill-track recall is currently less stable than memory-track. We deliberately did **not** mislabel it into `memory` to game the ranking — that fixes a ranking problem by corrupting data.
3. **Per-track quota balancing** — a guaranteed minimum of skill-track results in top-k. This is the *general* fix: it serves every self-evolved skill, not just this seeded one, and once it lands the hard rule is likely unnecessary. Tracked as its own work item.

Known limitation, inherent to the design and left visible on purpose: the seeded copy is frozen at install time (refreshed only on reseed), retrieval is probabilistic until (3) lands, and an uninstalled machine keeps the seed in its retained store. This layer is a net, not a guarantee — the guarantee is #583.

## Tests

Four in `test_host_seed.py`: the seed is the packaged document with its own frontmatter (including the embedded trigger words); planting writes mirror and store with an exact round-trip; reseeding overwrites in place; the CLI registers the command. Full suite: 209 passed. Wheel build verified to contain `memu/SKILL.md`.

---

## 这是什么

裸说「卸载 memU」问题的**冗余层**,与 #583 互补——同一个问题,不同的投放通道。

#583 把路由放进**推送**通道:managed instruction block,在已集成 host 的每个 turn 无条件在上下文里。本 PR 把包内指南放进**拉取**通道:安装时把根目录 `SKILL.md` 作为 `skill` track 的 recall file 种进 store,这样裸说的「卸载 memU」可以**通过检索**召回它——包括指令文件从未打过补丁的 host、之后被手动编辑过的 host、以及还没 re-run `install-instruction` 的存量安装(#583 在 skill host 上的真空期)。两层的失效条件在构造上互斥。

## 工作方式

- 新模块 `memu/hosts/seed.py`:读包内 `SKILL.md` **原样**,通过 `commit_results` 提交。不做任何改写:文档自己的 frontmatter 本来就是 recall file 的格式约定,它的 `description`——被 embed 的检索面——已自带触发词("install, set up, integrate, remove, or uninstall memU")。检索面归 skill 的作者所有,不归 seeder。
- 走 `commit_results` 提交,重复 seed 是按 `(track, name)` 的 **upsert**——第二次安装(同 host 或共享 store 的另一个 host)只会刷新存储副本,不会堆出第二份。
- 同时写 `~/.memu/skill/` 镜像:self-evolve 循环的工作介质是磁盘上的 markdown,一个它看不见的 seed 文件,是一个它会重造或与之矛盾的文件。
- 新 host 命令 `memu-<host> seed-skills`(七个 host 全部获得),挂在安装流程 `doctor` gate 通过之后——本地模式里最接近「注册完成」的时刻。以 `claude_code/INSTALL.md` 为参考实现接线;方向确定后再铺其余六个指南。
- wheel 通过 force-include 把仓库根目录的 `SKILL.md` 打包为 `memu/SKILL.md`;dev checkout 回退读仓库根副本。单一真相源,不存在会漂移的第二份。
- 小重构:`read_recall_file` 拆出 `parse_recall_text`,seed 复用镜像自己的解析约定,不长第二个 parser。

## 待决问题(本 PR 刻意不解决——这里只做写入侧)

本 PR 让 seed 在 store 里**存在**;它能否被**稳定找到**是检索侧的问题,有三个待决事项。它们都不阻塞写入侧,且本 PR 与任何结论兼容:

1. **硬规则上不上**——query 含 "memU" 时是否强制把这个 file 加进检索结果?它对第二、三关(语义命中 + top-k 排序)是确定性的,且随包分发、升级即全面生效。但它在 neutral 引擎里为厂商内容开特例,对所有 memU 开发类查询误触发,而且修不了第一关(agent 得先跑 retrieve——那一关只有 inject seam 够得着)。倾向先不上,等数据说话。
2. **track 语义 vs 召回稳定性**——`skill` track 语义正确(这就是一个 procedure),本 PR 也放在那里。但 skill track 目前召回不如 memory track 稳。我们刻意**没有**为了博排序把它错标进 `memory`——那是用污染数据的方式修排序问题。
3. **per-track 配平**——top-k 里保证 skill track 的最小名额。这是**通用**修法:它服务所有 self-evolve 萃取出的 skill,不只这一个 seed;配平落地后,硬规则大概率不再需要。作为独立工作项跟踪。

设计固有、刻意保持可见的已知限制:seed 副本冻结在安装时刻(只在重新 seed 时刷新)、在 (3) 落地前检索是概率性的、卸载后保留的 store 里 seed 仍在。这一层是兜底网,不是保证——保证是 #583。

## 测试

`test_host_seed.py` 共 4 个:seed 是带自身 frontmatter 的包内文档原样(含被 embed 的触发词);种植同时写镜像和 store 且精确 round-trip;重复 seed 原地覆盖;CLI 已注册该命令。全量测试:209 通过。wheel 构建验证含 `memu/SKILL.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
