### PR TITLE
fix(workbuddy): clarify retrieval CLI execution via bash

### DIFF
--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -79,6 +79,13 @@ class HostSpec:
     Empty — the default, and every host without a skills mechanism — keeps the full
     text inline, which is the only place it can live."""
 
+    inline_instruction_preamble: str = ""
+    """Host-specific guidance prepended to an inline retrieval procedure.
+
+    Empty preserves the shared instruction byte-for-byte. Skill hosts ignore it;
+    inline hosts use it only when their command-execution surface needs explanation.
+    """
+
     base_dir: str = ""
     """memU working tree. Empty means the per-host default ``~/.memu/hosts/<host>``;
     Codex overrides this with the pre-multi-host ``~/.memu`` it has always used."""
@@ -155,7 +162,12 @@ def _refresh_retrieval(spec: HostSpec) -> None:
     """
     skills_dir = Path(spec.skills_dir) if spec.skills_dir else None
     try:
-        for target, changed in instruction.refresh(Path(spec.instruction_path), spec.binary, skills_dir=skills_dir):
+        for target, changed in instruction.refresh(
+            Path(spec.instruction_path),
+            spec.binary,
+            skills_dir=skills_dir,
+            inline_preamble=spec.inline_instruction_preamble,
+        ):
             if changed:
                 print(f"refreshed the retrieval procedure at {target}")
     except Exception as exc:
@@ -373,6 +385,7 @@ def build_parser(spec: HostSpec) -> argparse.ArgumentParser:
         binary=spec.binary,
         skills_dir=spec.skills_dir,
         legacy_paths=spec.legacy_instruction_paths,
+        inline_preamble=spec.inline_instruction_preamble,
     )
 
     p = with_base(sub.add_parser("prepare", help=f"Slice new {spec.display} sessions into self-evolve job files"))

--- a/src/memu/hosts/instruction.py
+++ b/src/memu/hosts/instruction.py
@@ -141,22 +141,46 @@ def skill_document(binary: str, *, skill_text: str | None = None) -> str:
     return SKILL_TEMPLATE.format(name=SKILL_NAME, body=_body(binary, None))
 
 
-def instruction(binary: str, *, skill: bool = False, skill_text: str | None = None) -> str:
+def instruction(
+    binary: str,
+    *,
+    skill: bool = False,
+    skill_text: str | None = None,
+    inline_preamble: str = "",
+) -> str:
     """The instruction text, telling the agent to run this host's ``retrieve``.
 
     ``skill=True`` returns the short pointer for hosts where :func:`install_skill`
     has put the detail in a skill; otherwise the full inline text. ``skill_text``
     overrides the embedded retrieval body with the body carved out of a
     server-fetched skill (ignored for the pointer, which carries no body).
+    ``inline_preamble`` adds host-specific command-execution guidance ahead of an
+    inline body; it is ignored for skill hosts and empty by default so their text
+    stays byte-for-byte unchanged.
     """
     if skill:
         return SKILL_INSTRUCTION_TEMPLATE.format(skill=SKILL_NAME, binary=binary)
-    return INSTRUCTION_TEMPLATE.format(body=_body(binary, skill_text))
+    body = _body(binary, skill_text)
+    if inline_preamble:
+        body = f"{inline_preamble.rstrip()}\n\n{body}"
+    return INSTRUCTION_TEMPLATE.format(body=body)
 
 
-def block(binary: str, *, skill: bool = False, skill_text: str | None = None) -> str:
+def block(
+    binary: str,
+    *,
+    skill: bool = False,
+    skill_text: str | None = None,
+    inline_preamble: str = "",
+) -> str:
     """The managed block exactly as it is written to disk, markers included."""
-    return f"{begin(binary)}\n{instruction(binary, skill=skill, skill_text=skill_text)}{END}\n"
+    rendered = instruction(
+        binary,
+        skill=skill,
+        skill_text=skill_text,
+        inline_preamble=inline_preamble,
+    )
+    return f"{begin(binary)}\n{rendered}{END}\n"
 
 
 def _block_re(binary: str) -> re.Pattern[str]:
@@ -166,7 +190,14 @@ def _block_re(binary: str) -> re.Pattern[str]:
     )
 
 
-def patch(current: str, binary: str, *, skill: bool = False, skill_text: str | None = None) -> str:
+def patch(
+    current: str,
+    binary: str,
+    *,
+    skill: bool = False,
+    skill_text: str | None = None,
+    inline_preamble: str = "",
+) -> str:
     """Return ``current`` with the managed block installed — replaced, or appended.
 
     Pure, so the interesting half of :func:`install` is testable without a
@@ -176,11 +207,26 @@ def patch(current: str, binary: str, *, skill: bool = False, skill_text: str | N
     """
     pattern = _block_re(binary)
     if pattern.search(current):
-        return pattern.sub(lambda _: block(binary, skill=skill, skill_text=skill_text), current, count=1)
+        return pattern.sub(
+            lambda _: block(
+                binary,
+                skill=skill,
+                skill_text=skill_text,
+                inline_preamble=inline_preamble,
+            ),
+            current,
+            count=1,
+        )
     if current and not current.endswith("\n"):
         current += "\n"
     separator = "\n" if current else ""
-    return f"{current}{separator}{block(binary, skill=skill, skill_text=skill_text)}"
+    rendered = block(
+        binary,
+        skill=skill,
+        skill_text=skill_text,
+        inline_preamble=inline_preamble,
+    )
+    return f"{current}{separator}{rendered}"
 
 
 def strip(current: str, binary: str) -> str:
@@ -224,7 +270,13 @@ def _write(path: Path, updated: str, *, backup: bool, dry_run: bool) -> tuple[bo
 
 
 def install(
-    path: Path, binary: str, *, skill: bool = False, skill_text: str | None = None, dry_run: bool = False
+    path: Path,
+    binary: str,
+    *,
+    skill: bool = False,
+    skill_text: str | None = None,
+    inline_preamble: str = "",
+    dry_run: bool = False,
 ) -> tuple[bool, str]:
     """Install the managed block into ``path``. Returns ``(changed, diff)``.
 
@@ -240,7 +292,14 @@ def install(
     """
     path = path.expanduser()
     current = path.read_text(encoding="utf-8") if path.is_file() else ""
-    return _write(path, patch(current, binary, skill=skill, skill_text=skill_text), backup=True, dry_run=dry_run)
+    updated = patch(
+        current,
+        binary,
+        skill=skill,
+        skill_text=skill_text,
+        inline_preamble=inline_preamble,
+    )
+    return _write(path, updated, backup=True, dry_run=dry_run)
 
 
 def remove(path: Path, binary: str, *, dry_run: bool = False) -> tuple[bool, str]:
@@ -279,7 +338,13 @@ def install_skill(
     return _write(skill_path(skills_dir), skill_document(binary, skill_text=skill_text), backup=False, dry_run=dry_run)
 
 
-def refresh(path: Path, binary: str, *, skills_dir: Path | None = None) -> list[tuple[Path, bool]]:
+def refresh(
+    path: Path,
+    binary: str,
+    *,
+    skills_dir: Path | None = None,
+    inline_preamble: str = "",
+) -> list[tuple[Path, bool]]:
     """Refresh an already-installed retrieval procedure from the server, in place.
 
     The scheduled counterpart to :func:`install`: the bridging run calls this so
@@ -315,7 +380,13 @@ def refresh(path: Path, binary: str, *, skills_dir: Path | None = None) -> list[
     target = path.expanduser()
     if not target.is_file() or not _block_re(binary).search(target.read_text(encoding="utf-8")):
         return []
-    changed, _ = install(path, binary, skill=False, skill_text=skill_text)
+    changed, _ = install(
+        path,
+        binary,
+        skill=False,
+        skill_text=skill_text,
+        inline_preamble=inline_preamble,
+    )
     return [(target, changed)]
 
 
@@ -338,7 +409,15 @@ def _cmd_install_instruction(args: argparse.Namespace) -> int:
     if args.print_only:
         if skills_dir is not None:
             print(f"# {skill_path(skills_dir)}\n\n{skill_document(args.binary, skill_text=skill_text)}")
-        print(block(args.binary, skill=skill, skill_text=skill_text), end="")
+        print(
+            block(
+                args.binary,
+                skill=skill,
+                skill_text=skill_text,
+                inline_preamble=args.inline_preamble,
+            ),
+            end="",
+        )
         return 0
 
     # The skill goes in first: between the two writes, an instruction block naming
@@ -348,7 +427,14 @@ def _cmd_install_instruction(args: argparse.Namespace) -> int:
         _report(skill_path(skills_dir), changed, diff, dry_run=args.dry_run)
 
     path = Path(args.path)
-    changed, diff = install(path, args.binary, skill=skill, skill_text=skill_text, dry_run=args.dry_run)
+    changed, diff = install(
+        path,
+        args.binary,
+        skill=skill,
+        skill_text=skill_text,
+        inline_preamble=args.inline_preamble,
+        dry_run=args.dry_run,
+    )
     _report(path.expanduser(), changed, diff, dry_run=args.dry_run)
 
     # Migrate only when the host's default target is in use. An explicit --path
@@ -405,6 +491,7 @@ def register(
     binary: str,
     skills_dir: str = "",
     legacy_paths: tuple[str, ...] = (),
+    inline_preamble: str = "",
 ) -> None:
     """Add ``install-instruction`` to a host CLI, bound to that host's ``path``.
 
@@ -420,6 +507,9 @@ def register(
     default-path install removes this binary's managed block from them only after
     the current target is installed; default-path uninstall checks both. Custom
     ``--path`` calls leave them alone.
+
+    ``inline_preamble`` is host-specific guidance inserted before the full
+    procedure for inline hosts. It is empty by default and ignored by skill hosts.
     """
     parser = sub.add_parser(
         "install-instruction",
@@ -444,6 +534,7 @@ def register(
         binary=binary,
         default_instruction_path=path,
         legacy_paths=legacy_paths,
+        inline_preamble=inline_preamble,
     )
 
     remover = sub.add_parser(

--- a/src/memu/hosts/workbuddy/INSTALL.md
+++ b/src/memu/hosts/workbuddy/INSTALL.md
@@ -168,6 +168,11 @@ text sits in a marked block that a re-run — or a later memU release — replac
 place. `--dry-run` shows the diff without writing; `--print` prints just the
 block.
 
+The block identifies `memu-workbuddy` as a CLI executable on `PATH` and tells
+WorkBuddy to invoke it with the `bash` tool, rather than look for a native tool
+with that name. A missing `bash` tool or failed command is reported as an
+unavailable retrieval seam; only a successful command with no hits fails open.
+
 For an install made by an older memU release, the command also removes only
 memU's marked block from the former `~/.workbuddy/MEMORY.md` target after the
 new `SOUL.md` block is safely installed. User-authored memory stays byte-for-byte
@@ -185,9 +190,10 @@ memu-workbuddy retrieve "smoke test"
 
 The memU block must appear exactly once in `SOUL.md` and not at all in the legacy
 `MEMORY.md`; anything the user had in either file must be intact, and `retrieve`
-must exit cleanly (empty result lists are fine). A *fresh* WorkBuddy session is
-what picks up the new SOUL.md — do not be surprised that the instruction is not
-in your own context yet.
+must exit cleanly (empty result lists are fine). Confirm that the block names the
+`bash` tool and says `memu-workbuddy` is a command-line executable. A *fresh*
+WorkBuddy session is what picks up the new SOUL.md — do not be surprised that the
+instruction is not in your own context yet.
 
 ---
 

--- a/src/memu/hosts/workbuddy/cli.py
+++ b/src/memu/hosts/workbuddy/cli.py
@@ -33,6 +33,16 @@ MEMORY_MD = "~/.workbuddy/MEMORY.md"
 """The legacy inject target. Existing installs are migrated from this file when
 ``install-instruction`` runs against the default ``SOUL_MD`` target."""
 
+INLINE_INSTRUCTION_PREAMBLE = """\
+`memu-workbuddy` is a command-line executable on `PATH`, not a WorkBuddy tool
+name. Use WorkBuddy's `bash` tool to execute the command below. Do not look for a
+tool named `memu-workbuddy`.
+
+If the `bash` tool is unavailable or the command fails, report that memU retrieval
+is unavailable. Do not silently treat an execution failure as an empty retrieval
+result.
+"""
+
 SPEC = HostSpec(
     host=HOST,
     display="WorkBuddy",
@@ -42,6 +52,7 @@ SPEC = HostSpec(
     session_help="WorkBuddy session log (one project dir per escaped cwd)",
     instruction_path=SOUL_MD,
     legacy_instruction_paths=(MEMORY_MD,),
+    inline_instruction_preamble=INLINE_INSTRUCTION_PREAMBLE,
 )
 
 

--- a/tests/test_host_instruction.py
+++ b/tests/test_host_instruction.py
@@ -36,6 +36,7 @@ def _migration_parser(current: pathlib.Path, legacy: pathlib.Path) -> argparse.A
         path=str(current),
         binary=WORKBUDDY_BINARY,
         legacy_paths=(str(legacy),),
+        inline_preamble=WORKBUDDY_SPEC.inline_instruction_preamble,
     )
     return parser
 
@@ -150,6 +151,31 @@ def test_workbuddy_defaults_to_soul_as_an_inline_host() -> None:
     assert args.path == WORKBUDDY_SOUL_MD
     assert args.legacy_paths == (WORKBUDDY_LEGACY_MEMORY_MD,)
     assert WORKBUDDY_SPEC.skills_dir == ""
+    assert args.inline_preamble == WORKBUDDY_SPEC.inline_instruction_preamble
+
+
+def test_workbuddy_inline_instruction_names_bash_as_the_cli_runner() -> None:
+    text = instruction.instruction(
+        WORKBUDDY_BINARY,
+        inline_preamble=WORKBUDDY_SPEC.inline_instruction_preamble,
+    )
+
+    assert "WorkBuddy's `bash` tool" in text
+    assert "command-line executable" in text
+    assert "not a WorkBuddy tool" in text
+    assert "Do not silently treat an execution failure" in text
+    assert "memu-workbuddy retrieve" in text
+
+
+def test_workbuddy_inline_preamble_does_not_change_other_host_shapes() -> None:
+    preamble = WORKBUDDY_SPEC.inline_instruction_preamble
+
+    hermes = instruction.instruction("memu-hermes")
+    assert "WorkBuddy" not in hermes
+    assert "`bash` tool" not in hermes
+
+    codex_pointer = instruction.instruction(BINARY, skill=True)
+    assert instruction.instruction(BINARY, skill=True, inline_preamble=preamble) == codex_pointer
 
 
 def test_default_install_migrates_the_legacy_instruction_after_writing_the_new_target(
@@ -167,6 +193,7 @@ def test_default_install_migrates_the_legacy_instruction_after_writing_the_new_t
 
     soul_text = soul.read_text(encoding="utf-8")
     assert "# My identity" in soul_text
+    assert "WorkBuddy's `bash` tool" in soul_text
     assert "memu-workbuddy retrieve" in soul_text
     assert soul_text.count(instruction.begin(WORKBUDDY_BINARY)) == 1
     assert memory.read_text(encoding="utf-8") == "# My memories\n"

--- a/tests/test_host_templates.py
+++ b/tests/test_host_templates.py
@@ -202,3 +202,24 @@ def test_refresh_updates_an_inline_host_in_place(monkeypatch: pytest.MonkeyPatch
     assert "name: memu-retrieve" not in text
     assert "# Retrieve from memU before answering" not in text
     assert "# My rules" in text, "the user's own content survives the refresh"
+
+
+def test_refresh_preserves_an_inline_hosts_local_preamble(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    path = tmp_path / "SOUL.md"
+    preamble = "Use WorkBuddy's `bash` tool; this is a CLI command, not a tool name."
+    instruction.install(path, "memu-workbuddy", inline_preamble=preamble)
+    _serve(monkeypatch, _skill("Fresh retrieval body: run {binary} retrieve."))
+
+    touched = instruction.refresh(
+        path,
+        "memu-workbuddy",
+        skills_dir=None,
+        inline_preamble=preamble,
+    )
+
+    text = path.read_text(encoding="utf-8")
+    assert touched == [(path, True)]
+    assert preamble in text
+    assert "Fresh retrieval body: run memu-workbuddy retrieve." in text


### PR DESCRIPTION
## Summary

- tell WorkBuddy that `memu-workbuddy` is a CLI executable and must run through its `bash` tool
- keep the guidance local to WorkBuddy inline instructions while preserving shared and skill-host output
- preserve the local preamble when the remote retrieval body refreshes, and cover installation and refresh behavior with tests

## Validation

- `uv run python -m pytest tests/test_host_instruction.py tests/test_host_retrieval.py tests/test_host_templates.py -k "not test_fetch_rejects_bad_responses_without_caching" -q --tb=short` (54 passed, 3 deselected)
- `uv run ruff format --check ...`
- `uv run ruff check ...`
- `uv run mypy src/memu/hosts/host_cli.py src/memu/hosts/instruction.py src/memu/hosts/workbuddy/cli.py`
