### PR TITLE
fix(hermes): honor HERMES_HOME for adapter paths

### DIFF
--- a/src/memu/hosts/hermes/BRIDGING_TASK.md
+++ b/src/memu/hosts/hermes/BRIDGING_TASK.md
@@ -22,7 +22,7 @@ on its own.
 ## What the bridging task does (context)
 
 1. **Prepare** — `memu-hermes prepare` scans new message rows in
-   `~/.hermes/state.db` (read-only; sessions ordered by recent activity),
+   `$HERMES_HOME/state.db` (read-only; sessions ordered by recent activity),
    mirrors the current memU recall files to `~/.memu/hosts/hermes/memory` and
    `~/.memu/hosts/hermes/skill`, snapshots them by content hash, and writes
    numbered **job-instruction files** to `~/.memu/hosts/hermes/jobs/` (`1.txt`,
@@ -43,9 +43,10 @@ run's prompt must instruct the agent to do it, not shell out to a script.
 - **memU is installed and `memu-hermes` is on `PATH`.** Verify with
   `memu-hermes doctor`; if it fails, do `INSTALL.md` Part 1 first.
 - **Hermes runs headless from cron** with permission to run `memu-hermes` and
-  write under `~/.memu/`. If Hermes uses a non-default `HERMES_HOME`, the cron
-  environment must export it and the prompt's prepare step must pass
-  `--session-dir "$HERMES_HOME/state.db"`.
+  write under `~/.memu/`. The cron environment must inherit the same
+  `HERMES_HOME` as Hermes; `memu-hermes prepare` then resolves `state.db`
+  automatically. When it is unset, both Hermes and memU fall back to
+  `~/.hermes`.
 
 ## Step 1 — settle the schedule
 

--- a/src/memu/hosts/hermes/INSTALL.md
+++ b/src/memu/hosts/hermes/INSTALL.md
@@ -12,7 +12,7 @@ Installing memU on Hermes is three parts:
 1. **Install memU** — a Python package and the memory backend it uses.
 2. **Register the bridging task** — the scheduled job that turns recent Hermes
    sessions into durable memory (the *record* seam).
-3. **Patch `~/.hermes/SOUL.md`** — a standing instruction that tells the agent to
+3. **Patch `$HERMES_HOME/SOUL.md`** — a standing instruction that tells the agent to
    pull relevant memory before answering (the *inject* seam).
 
 Parts 2 and 3 must share one configured mode. In local mode they must also share
@@ -20,10 +20,13 @@ one store and embedding space, or retrieval silently returns nothing. Part 1 is
 what makes them agree.
 
 **Scope note.** This adapter reads Hermes's SQLite session store —
-`~/.hermes/state.db` (the `sessions` and `messages` tables), opened read-only so
-it never contends with the gateway's writer. If this install runs a non-default
-home (`HERMES_HOME`, or a profile), pass `--session-dir <home>/state.db` to
-`prepare`. The manual snapshots under `~/.hermes/sessions/saved/` are not mined.
+`$HERMES_HOME/state.db` (the `sessions` and `messages` tables), opened read-only
+so it never contends with the gateway's writer. It honors the same
+`HERMES_HOME` as Hermes (including profiles) and falls back to `~/.hermes` when
+the variable is unset. The native Windows installer sets `HERMES_HOME` to
+`%LOCALAPPDATA%\hermes`. The manual snapshots under the active home's
+`sessions/saved/` directory are not mined. `--session-dir` remains available as
+an explicit one-command override.
 
 ---
 
@@ -129,7 +132,7 @@ backend.
 ## Part 2 — Register the bridging (record) task
 
 The *record* seam: a scheduled job that mines recent sessions out of
-`~/.hermes/state.db` into memU memory, skills, and resources. In cloud mode,
+`$HERMES_HOME/state.db` into memU memory, skills, and resources. In cloud mode,
 workspace resources are submitted but are not currently persisted. **Do not
 reinvent this** — follow the packaged procedure:
 
@@ -150,7 +153,7 @@ sessions is fine and correct when nothing is new).
 
 ---
 
-## Part 3 — Patch `~/.hermes/SOUL.md` with the retrieval instruction
+## Part 3 — Patch `$HERMES_HOME/SOUL.md` with the retrieval instruction
 
 The *inject* seam: a standing instruction in Hermes's **SOUL.md** telling the
 agent to pull relevant memory before answering. SOUL.md is the one file Hermes
@@ -177,14 +180,17 @@ that. (Skill-based hosts — Codex, Claude Code, OpenClaw — surface skill
 descriptions every turn, so they install a short pointer plus a skill instead.)
 
 `SOUL.md` is the *user's*, so it appends rather than overwrites (previous content
-is backed up to `~/.hermes/SOUL.md.bak`), and memU's text sits in a marked block
+is backed up beside it as `SOUL.md.bak`), and memU's text sits in a marked block
 that a re-run — or a later memU release — replaces in place. `--dry-run` shows the
-diff without writing; `--path` targets a non-default home.
+diff without writing; `--path` explicitly overrides the resolved home for one
+command. The command prints the resolved absolute path it touched.
 
 ### ✅ Verify Part 3
 
+Run `memu-hermes install-instruction --dry-run` to confirm the resolved absolute
+path is already up to date, inspect that `SOUL.md`, then run:
+
 ```
-cat ~/.hermes/SOUL.md
 memu-hermes retrieve "smoke test"
 ```
 
@@ -198,7 +204,7 @@ the new SOUL.md.
 ## Done
 
 Report back to the user: the selected mode and its cloud endpoint or local store/provider; the scheduled job and its
-schedule in words; and that the retrieval instruction is now in
-`~/.hermes/SOUL.md`, carrying the `memu-hermes retrieve` procedure inline and
+schedule in words; and that the retrieval instruction is now in the active
+`$HERMES_HOME/SOUL.md`, carrying the `memu-hermes retrieve` procedure inline and
 taking effect next session. Record and inject both read `~/.memu/config.env`, so
 they provably share one store.

--- a/src/memu/hosts/hermes/UNINSTALL.md
+++ b/src/memu/hosts/hermes/UNINSTALL.md
@@ -8,7 +8,7 @@ Uninstalling is the install run in reverse, and it is three parts:
 
 1. **Unregister the bridging task** — stop the scheduled job first, so nothing
    fires mid-teardown (the *record* seam).
-2. **Unpatch `~/.hermes/SOUL.md`** — remove the standing retrieval instruction
+2. **Unpatch `$HERMES_HOME/SOUL.md`** — remove the standing retrieval instruction
    (the *inject* seam), plus a leftover `memu-retrieve` skill from older installs.
 3. **Apply the data-and-package defaults** — the user's memory is kept, the
    tooling is removed — and close by reporting both.
@@ -45,13 +45,13 @@ there.
 memu-hermes remove-instruction
 ```
 
-It deletes memU's marked block from `~/.hermes/SOUL.md` and prints the diff.
+It deletes memU's marked block from the active `$HERMES_HOME/SOUL.md` and prints the diff.
 Everything outside the markers is the user's and survives; the previous
-contents are backed up to `~/.hermes/SOUL.md.bak` before the rewrite.
+contents are backed up beside it as `SOUL.md.bak` before the rewrite.
 `--dry-run` shows the diff without writing. Re-running is a clean no-op — a
-file with no block left is already the desired end state. If this install used
-a non-default home (`HERMES_HOME`, or a profile), pass
-`--path <home>/SOUL.md`.
+file with no block left is already the desired end state. The command honors
+the same `HERMES_HOME` as Hermes, including profiles; `--path <home>/SOUL.md`
+remains available as an explicit one-command override.
 
 Current releases keep the procedure inline in that block, so there is nothing
 else to remove. If this machine was set up by an **older** release that
@@ -62,13 +62,13 @@ directory too — it is memU's own:
 rm -r ~/.hermes/skills/memu-retrieve
 ```
 
-(For a non-default home, it sits under `<home>/skills/` instead.) Other entries
-in `~/.hermes/skills/` are the user's or Hermes's — leave them alone.
+Other entries in `$HERMES_HOME/skills/` are the user's or Hermes's — leave them
+alone.
 
 ### ✅ Verify Part 2
 
-`cat ~/.hermes/SOUL.md` — no `memu:begin`/`memu:end` markers remain, and the
-user's own content is intact. `~/.hermes/skills/memu-retrieve` no longer
+Inspect the resolved `$HERMES_HOME/SOUL.md`: no `memu:begin`/`memu:end` markers
+remain, and the user's own content is intact. `$HERMES_HOME/skills/memu-retrieve` no longer
 exists. A session already running loaded the old file; a fresh session is what
 picks the removal up.
 
@@ -94,9 +94,9 @@ Only one thing overrides a default: the user's own explicit words.
   store marks history as already mined, and it would never be mined again.
 - **Remove this host's residue.** Everything else under `~/.memu/hosts/hermes/`
   — job files and mirrors, sparing the session cursor above; and
-  `~/.hermes/SOUL.md` itself **if** Part 2 left it
-  empty (it held only memU's block, so the install created it) — a file with
-  the user's own content stays, of course. Hermes's own `~/.hermes/state.db`
+  `$HERMES_HOME/SOUL.md` itself **if** Part 2 left it
+empty (it held only memU's block, so the install created it) — a file with
+  the user's own content stays, of course. Hermes's own `$HERMES_HOME/state.db`
   belongs to Hermes, not memU — the adapter only ever read it; leave it alone.
 - **Uninstall the package** — `pip uninstall memu-cli` (or `pipx uninstall
   memu-cli` — match how it was installed) — **unless** another host adapter is

--- a/src/memu/hosts/hermes/__init__.py
+++ b/src/memu/hosts/hermes/__init__.py
@@ -1,9 +1,9 @@
 """The Hermes Agent host adapter — ``memu-hermes``.
 
 Binds ADR 0008's two seams onto Hermes: *record* as a scheduled bridging task
-over the SQLite session store at ``~/.hermes/state.db`` (see
+over the SQLite session store at ``$HERMES_HOME/state.db`` (see
 :mod:`memu.hosts.bridging`), *inject* as a standing instruction in
-``~/.hermes/SOUL.md`` that points the agent at the ``memu-hermes retrieve``
+``$HERMES_HOME/SOUL.md`` that points the agent at the ``memu-hermes retrieve``
 command.
 """
 

--- a/src/memu/hosts/hermes/cli.py
+++ b/src/memu/hosts/hermes/cli.py
@@ -20,13 +20,14 @@ from __future__ import annotations
 
 import sys
 
-from memu.hosts.hermes.sessions import STATE_DB, HermesTranscriptSource
+from memu.hosts.hermes.paths import soul_path, state_db_path
+from memu.hosts.hermes.sessions import HermesTranscriptSource
 from memu.hosts.host_cli import HostSpec, run
 
 HOST = "hermes"
 
-SOUL_MD = "~/.hermes/SOUL.md"
-"""Hermes's identity file — the one file loaded from ``HERMES_HOME`` into every
+SOUL_MD = str(soul_path())
+"""Hermes's identity file — resolved from ``HERMES_HOME`` and loaded into every
 session regardless of working directory, so the inject seam lands here.
 (Project-level ``.hermes.md``/``AGENTS.md`` files are per-directory and would
 miss sessions started elsewhere.)"""
@@ -47,19 +48,25 @@ miss sessions started elsewhere.)"""
 # Code) can use the pointer shape. Hermes cannot, so it takes the full retrieval
 # procedure inline in SOUL.md, which is present on every turn.
 
-SPEC = HostSpec(
-    host=HOST,
-    display="Hermes",
-    package="memu.hosts.hermes",
-    source_factory=HermesTranscriptSource,
-    session_dir=STATE_DB,
-    session_help="Hermes SQLite session store (state.db under HERMES_HOME)",
-    instruction_path=SOUL_MD,
-)
+
+def build_spec() -> HostSpec:
+    """Build the adapter defaults from the active Hermes home."""
+    return HostSpec(
+        host=HOST,
+        display="Hermes",
+        package="memu.hosts.hermes",
+        source_factory=HermesTranscriptSource,
+        session_dir=str(state_db_path()),
+        session_help="Hermes SQLite session store (state.db under HERMES_HOME)",
+        instruction_path=str(soul_path()),
+    )
+
+
+SPEC = build_spec()
 
 
 def main(argv: list[str] | None = None) -> int:
-    return run(SPEC, argv)
+    return run(build_spec(), argv)
 
 
 if __name__ == "__main__":

--- a/src/memu/hosts/hermes/paths.py
+++ b/src/memu/hosts/hermes/paths.py
@@ -1,0 +1,27 @@
+"""Hermes home paths, resolved with Hermes Agent's own precedence.
+
+Hermes treats ``HERMES_HOME`` as the single source of truth for profiles,
+containers, and native Windows installs.  Only an unset or whitespace-only
+value falls back to the classic ``~/.hermes`` home.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def hermes_home() -> Path:
+    """Return the active Hermes home directory."""
+    value = os.environ.get("HERMES_HOME", "").strip()
+    return Path(value) if value else Path.home() / ".hermes"
+
+
+def soul_path() -> Path:
+    """Return the identity file loaded into every Hermes session."""
+    return hermes_home() / "SOUL.md"
+
+
+def state_db_path() -> Path:
+    """Return Hermes's SQLite session store."""
+    return hermes_home() / "state.db"

--- a/src/memu/hosts/hermes/sessions.py
+++ b/src/memu/hosts/hermes/sessions.py
@@ -1,14 +1,14 @@
-"""Hermes Agent's session log: the SQLite store at ``~/.hermes/state.db``.
+"""Hermes Agent's session log: the SQLite store under ``HERMES_HOME``.
 
 The whole of what makes this host Hermes. Everything the bridging task does with
 these records is host-agnostic and lives in :mod:`memu.hosts.bridging`.
 
 Hermes is the one supported host whose log is not JSONL-on-disk: sessions and
 their full message history live in two tables (``sessions``, ``messages``) of a
-WAL-mode SQLite database under the Hermes home (``~/.hermes`` by default; the
-host honors ``HERMES_HOME``, in which case pass ``--session-dir`` pointing at
-that ``state.db``). ``~/.hermes/sessions/saved/`` holds only manual snapshots and
-is ignored. This is exactly the "different container" seam
+WAL-mode SQLite database under the active Hermes home. Both Hermes and this
+adapter honor ``HERMES_HOME`` and fall back to ``~/.hermes`` when it is unset.
+The ``sessions/saved/`` directory there holds only manual snapshots and is
+ignored. This is exactly the "different container" seam
 :class:`~memu.hosts.base.TranscriptSource` anticipates: :meth:`discover`,
 :meth:`read_records`, :meth:`key`, and :meth:`timestamp` are overridden; each
 session row plays the role a session *file* plays elsewhere, and each message row
@@ -24,14 +24,14 @@ from __future__ import annotations
 
 import datetime
 import json
-import os
 import sqlite3
 from pathlib import Path
 from typing import ClassVar
 
 from memu.hosts.base import RecordKind, TranscriptSource
+from memu.hosts.hermes.paths import state_db_path
 
-STATE_DB = "~/.hermes/state.db"
+STATE_DB = str(state_db_path())
 
 _MESSAGE_ROLES = ("user", "assistant")
 
@@ -50,8 +50,8 @@ class HermesTranscriptSource(TranscriptSource):
 
     name: ClassVar[str] = "hermes"
 
-    def __init__(self, state_db: str | Path = STATE_DB) -> None:
-        self._db = Path(os.path.expanduser(str(state_db)))
+    def __init__(self, state_db: str | Path | None = None) -> None:
+        self._db = Path(state_db).expanduser() if state_db is not None else state_db_path()
 
     def root(self) -> Path:
         return self._db.parent

--- a/tests/test_host_instruction.py
+++ b/tests/test_host_instruction.py
@@ -19,6 +19,8 @@ import pytest
 
 from memu.hosts import instruction
 from memu.hosts.codex.cli import AGENTS_MD, SKILLS_DIR, build_parser
+from memu.hosts.hermes.cli import build_spec as build_hermes_spec
+from memu.hosts.hermes.paths import hermes_home
 from memu.hosts.host_cli import build_parser as build_host_parser
 from memu.hosts.workbuddy.cli import MEMORY_MD as WORKBUDDY_LEGACY_MEMORY_MD
 from memu.hosts.workbuddy.cli import SOUL_MD as WORKBUDDY_SOUL_MD
@@ -134,6 +136,43 @@ def test_hermes_is_an_inline_host() -> None:
     from memu.hosts.hermes.cli import SPEC
 
     assert SPEC.skills_dir == ""
+
+
+def test_hermes_defaults_follow_hermes_home(monkeypatch, tmp_path: pathlib.Path) -> None:
+    fallback_home = tmp_path / "os-home"
+    active_home = tmp_path / "Hermes Home %41 #片段"
+    monkeypatch.setattr(pathlib.Path, "home", lambda: fallback_home)
+    monkeypatch.setenv("HERMES_HOME", str(active_home))
+
+    spec = build_hermes_spec()
+    args = build_host_parser(spec).parse_args(["install-instruction"])
+
+    assert pathlib.Path(args.path) == active_home / "SOUL.md"
+    assert pathlib.Path(spec.session_dir) == active_home / "state.db"
+    assert instruction._cmd_install_instruction(args) == 0
+    assert "memu-hermes retrieve" in (active_home / "SOUL.md").read_text(encoding="utf-8")
+    assert not (fallback_home / ".hermes" / "SOUL.md").exists()
+
+
+def test_hermes_home_ignores_blank_override(monkeypatch, tmp_path: pathlib.Path) -> None:
+    monkeypatch.setattr(pathlib.Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", "   ")
+
+    assert hermes_home() == tmp_path / ".hermes"
+
+
+def test_hermes_explicit_path_overrides_resolved_home(monkeypatch, tmp_path: pathlib.Path) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "Hermes"))
+    custom_soul = tmp_path / "profile" / "SOUL.md"
+    custom_db = tmp_path / "profile" / "state.db"
+    spec = build_hermes_spec()
+    parser = build_host_parser(spec)
+
+    instruction_args = parser.parse_args(["install-instruction", "--path", str(custom_soul)])
+    prepare_args = parser.parse_args(["prepare", "--session-dir", str(custom_db)])
+
+    assert pathlib.Path(instruction_args.path) == custom_soul
+    assert pathlib.Path(prepare_args.session_dir) == custom_db
 
 
 def test_openclaw_is_a_skill_host() -> None:

--- a/tests/test_host_sessions.py
+++ b/tests/test_host_sessions.py
@@ -277,6 +277,20 @@ def _hermes_db(tmp_path: pathlib.Path) -> pathlib.Path:
     return db
 
 
+def test_hermes_default_db_follows_hermes_home(monkeypatch, tmp_path: pathlib.Path) -> None:
+    home = tmp_path / "Hermes Home %41 #片段"
+    home.mkdir()
+    db = _hermes_db(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    source = HermesTranscriptSource()
+
+    assert source.root() == home
+    assert source.exists()
+    assert [source.key(path) for path in source.discover()] == ["new", "old"]
+    assert db == home / "state.db"
+
+
 def test_hermes_discovers_sessions_most_recent_first(tmp_path: pathlib.Path) -> None:
     source = HermesTranscriptSource(_hermes_db(tmp_path))
     assert source.exists()


### PR DESCRIPTION
## Pull Request Summary

Make the Hermes host adapter resolve its home from `HERMES_HOME`, with the existing `~/.hermes` location retained as the fallback.

---

## What does this PR do?

- Centralizes Hermes home, `SOUL.md`, and `state.db` path resolution.
- Uses `HERMES_HOME` for native Windows installs, profiles, and containers.
- Preserves explicit `--path` and `--session-dir` overrides.
- Adds coverage for Windows-style paths containing spaces, percent signs, hash characters, and non-ASCII text.
- Updates the packaged Hermes install, bridging, and uninstall instructions. The repository README is unchanged.

---

## Why is this change needed?

The Hermes Windows installer uses `%LOCALAPPDATA%\\hermes`, while the adapter previously assumed `~/.hermes`. That mismatch could inject memU guidance into the wrong `SOUL.md` and read sessions from the wrong `state.db`.

macOS behavior remains compatible because an unset or blank `HERMES_HOME` still resolves to `Path.home() / ".hermes"`, which is the previous location.

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (please explain)

---

## PR Quality Checklist

- [x] PR title follows an allowed format (for example `feat:`, `fix:`, `docs:`, `memory base:`)
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable
- [x] No breaking changes (or clearly documented)
- [x] Related issues or discussions linked (not applicable; no issue was provided)

---

## Testing

- `python -m pytest tests/test_host_instruction.py tests/test_host_sessions.py tests/test_scheduling_windows.py -q -p no:cacheprovider` — 77 passed
- `ruff check` and `ruff format --check` on touched Python files — passed
- `mypy` on touched Python files — passed

---

## Optional

- [ ] Screenshots or examples added (not applicable)
- [x] Edge cases considered
- [ ] Follow-up tasks mentioned (not applicable)
