### PR TITLE
fix(bridging): clear job/session working files on commit; skip empty resource job

### DIFF
--- a/src/memu/hosts/bridging/pipeline.py
+++ b/src/memu/hosts/bridging/pipeline.py
@@ -90,13 +90,18 @@ async def prepare(
         memory_template=templates.resolve(templates.MEMORY_JOB, MEMORY_JOB_TEMPLATE),
         skill_template=templates.resolve(templates.SKILL_JOB, SKILL_JOB_TEMPLATE),
     )
-    prepare_resource_job(
-        job_dir=layout.jobs,
-        verify_command=verify_command,
-        resource_file=layout.resources,
-        job_index=2 * num_sessions + 1,
-        template=templates.resolve(templates.RESOURCE_JOB, RESOURCE_JOB_TEMPLATE),
-    )
+    # The resource job describes files the skill jobs logged as touched. With no
+    # sessions there are no skill jobs, so the touched-file log stays empty and
+    # there is nothing to describe — skipping keeps a no-new-session run a true
+    # no-op instead of a pointless agent pass over an empty log.
+    if num_sessions:
+        prepare_resource_job(
+            job_dir=layout.jobs,
+            verify_command=verify_command,
+            resource_file=layout.resources,
+            job_index=2 * num_sessions + 1,
+            template=templates.resolve(templates.RESOURCE_JOB, RESOURCE_JOB_TEMPLATE),
+        )
     return num_sessions
 
 
@@ -123,4 +128,17 @@ async def commit(layout: Layout) -> dict[str, Any]:
     pending = layout.session_manifest_pending
     if pending.exists():
         os.replace(pending, layout.session_manifest)
+
+    # The run is durable, so clear this run's ephemeral working files: the job
+    # instructions, the session slices they mine, and the touched-file log.
+    # Done strictly last — after the store accepted the submission and the
+    # cursor/snapshot advanced — so a crash anywhere earlier leaves jobs/ and
+    # sessions/ intact and the next run's LEFTOVERS step recovers them. Without
+    # this, a *successful* run's jobs survive too, and every following run
+    # re-mines already-committed sessions before prepare wipes them.
+    for stale in layout.jobs.glob("*.txt"):
+        stale.unlink()
+    for stale in layout.sessions.glob("*.jsonl"):
+        stale.unlink()
+    layout.resource_log.unlink(missing_ok=True)
     return result

--- a/tests/test_bridging_promotion.py
+++ b/tests/test_bridging_promotion.py
@@ -113,6 +113,36 @@ async def test_files_from_a_died_run_stay_committable(rig) -> None:
     assert "orphan" in submitted
 
 
+async def test_commit_clears_this_runs_working_files(rig) -> None:
+    """A durable commit wipes the ephemeral working dirs, so the next run's
+    LEFTOVERS step re-processes nothing that was already committed."""
+    source, layout, _ = rig
+
+    await prepare(source, layout, verify_command="x verify-resources")
+    assert list(layout.jobs.glob("*.txt")), "prepare should have written job files"
+    assert list(layout.sessions.glob("*.jsonl")), "prepare should have written session slices"
+
+    await commit(layout)
+
+    assert list(layout.jobs.glob("*.txt")) == [], "commit must clear the job instructions"
+    assert list(layout.sessions.glob("*.jsonl")) == [], "commit must clear the session slices"
+    assert not layout.resource_log.exists(), "commit must clear the touched-file log"
+
+
+async def test_prepare_skips_the_resource_job_when_no_new_sessions(rig) -> None:
+    """No sessions means no skill jobs to populate the touched-file log, so the
+    resource-describe job has nothing to do and is not written at all."""
+    source, layout, _ = rig
+
+    await prepare(source, layout, verify_command="x verify-resources")
+    await commit(layout)  # spend the batch
+
+    n = await prepare(source, layout, verify_command="x verify-resources")
+
+    assert n == 0
+    assert list(layout.jobs.glob("*.txt")) == [], "a no-new-session prepare writes no jobs at all"
+
+
 async def test_snapshot_is_retaken_at_commit_so_reruns_are_clean(rig) -> None:
     source, layout, service = rig
 


### PR DESCRIPTION
## Problem

`commit` never removed the `jobs/` and `sessions/` working files it consumed, so a **successful** run left them on disk. The next run's LEFTOVERS step then re-mined already-committed sessions before `prepare` wiped them:

- Redundant agent work on **every** scheduled run (not just after a crash).
- Because `prepare` always wrote the resource-describe job (`job_index = 2*num_sessions + 1`, unguarded), even a no-new-session run left a leftover to re-process.
- Leftovers stopped meaning "a run crashed," contradicting the bridging task docs (`BRIDGING_TASK.md`, `scheduling/prompt.py`), which describe them as *"unfinished work from an earlier run (a crash, or the install itself)."*

## Changes

- **`commit` clears the run's ephemeral working files** — `jobs/*.txt`, `sessions/*.jsonl`, and `.resource.tmp` — but only *after* the store accepts the submission and the cursor/snapshot advance. Done strictly last, so a crash anywhere earlier still leaves the files for the existing LEFTOVERS recovery path. The one residual window (store accepts, process dies before cleanup) degrades to today's behavior: one no-op re-run, self-healing next cycle.
- **`prepare` skips the resource job when `num_sessions == 0`.** With zero sessions there are no skill jobs to populate the touched-file log, so the job had nothing to describe. A no-new-session run is now a true no-op.

Net effect: the steady-state loop becomes `commit` → empty `jobs/` → LEFTOVERS finds nothing → `prepare` writes nothing → no self-evolve → no-op `commit`. Leftovers now only ever come from a crash or install, matching the docs.

## Tests

Two new tests in `test_bridging_promotion.py`:
- `test_commit_clears_this_runs_working_files` — a durable commit wipes `jobs/`, `sessions/`, and the touched-file log.
- `test_prepare_skips_the_resource_job_when_no_new_sessions` — a no-new-session `prepare` writes no jobs at all.

Full `test_bridging_promotion.py` (7) plus `test_cli` / `test_host_instruction` / `test_host_sessions` (58) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)