### PR TITLE
docs: recommend `uv tool install` for memu-cli in install skill

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -31,7 +31,9 @@ personal machine.
 This puts `memu` and every host-adapter binary on `PATH`. If `pip` is not the
 right tool for this machine (managed Python, uv-only), use the equivalent —
 what matters is that the binaries below resolve from a bare, non-interactive
-shell.
+shell. With uv this means `uv tool install memu-cli`, **not** `uv pip install`:
+however it is installed, `memu-cli` is a cross-session bridging tool and must
+be callable everywhere, not scoped to one project venv.
 
 ## Step 2 — pick your host binary
 


### PR DESCRIPTION
## What

Clarifies the uv install path in the `install-memu` skill (`SKILL.md`, Step 1).

The step already required that the `memu-cli` binaries "resolve from a bare, non-interactive shell," but left "the equivalent" of `pip install` unspecified. For a uv user the obvious guess is `uv pip install`, which scopes the console scripts to a project venv — so the binaries won't resolve in the bare, non-interactive shell the scheduled bridging task runs in, nor in later agent sessions that don't share that venv.

This names `uv tool install memu-cli` as the correct uv equivalent and warns against `uv pip install`, emphasizing the core reason: `memu-cli` is a cross-session bridging tool and must be callable everywhere, not scoped to one project venv.

## Change

```
This puts `memu` and every host-adapter binary on `PATH`. If `pip` is not the
right tool for this machine (managed Python, uv-only), use the equivalent —
what matters is that the binaries below resolve from a bare, non-interactive
shell. With uv this means `uv tool install memu-cli`, **not** `uv pip install`:
however it is installed, `memu-cli` is a cross-session bridging tool and must
be callable everywhere, not scoped to one project venv.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)