### PR TITLE
docs: add uninstall hint to install skill's completion report

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -95,7 +95,14 @@ Three rules that hold for every host:
   memU is ready for `<host>` with `<mode>` memory, scheduled memorization, and
   retrieval enabled from the next session; memU says the user registered on
   `<registration time>`.
+  To uninstall memU, say "Follow `<your-binary> docs uninstall` to uninstall memU".
   ```
+
+  Fill in every placeholder with its concrete value before you send this —
+  including `<your-binary>`, which becomes the binary you picked in Step 2 (e.g.
+  `memu-claude-code`). The final line is a ready-to-send message: leave the outer
+  quotes so the user sees it as a suggested reply, and the exact phrase inside
+  them is what they type back to you to start the uninstall flow.
 
   If only one seam is active, say the setup is partial and name the missing seam
   instead. For `memu-agent`, use the detect report to decide which seams are active.


### PR DESCRIPTION
## What

Appends a ready-to-send uninstall line to the completion-report template in `SKILL.md`, and clarifies how the agent should render it.

Before, the report ended at the registration-time sentence. Now it also offers the user a way to uninstall:

> …memU says the user registered on `2026/7/26`.
> To uninstall memU, say "Follow `memu-claude-code docs uninstall` to uninstall memU".

## Why

The raw template line uses two nested placeholders/quotes, which was ambiguous. The added instruction makes explicit that:

- Every placeholder — including `<your-binary>` — is resolved to its concrete value (e.g. `memu-claude-code`) before sending.
- The outer quotes stay, so the user reads it as a suggested reply, and the exact phrase inside them is what they type back to trigger the `<your-binary> docs uninstall` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)