### PR TITLE
fix(hosts): never inline the bridging prompt in crontab — cron truncates ~1KB lines

### DIFF
--- a/src/memu/hosts/claude_code/BRIDGING_TASK.md
+++ b/src/memu/hosts/claude_code/BRIDGING_TASK.md
@@ -66,9 +66,52 @@ hour**, cron `0 * * * *` (local time). Confirm before creating.
 
 ## Step 2 — register the scheduled run
 
+**Never inline the pipeline prompt in the crontab entry.** The quoted prompt is
+~1.2 KB, and cron truncates a crontab line at roughly 1 KB before handing it to
+`/bin/sh` — the shell receives a command cut off mid-quote and every tick dies
+instantly with `unexpected EOF while looking for matching "'"`, mailed to
+`/var/mail/$USER` and visible nowhere else; `claude` never starts. Field data:
+two hosts' inlined entries on one macOS machine failed exactly this way on every
+tick, while the short script-invoking entry beside them kept working. This is
+the Unix sibling of the Windows `schtasks /TR` limit (memU#539), and the fix is
+the same shape: **the prompt lives in a file; the crontab line stays short.**
+
+1. Write the pipeline prompt to
+   `~/.memu/hosts/claude-code/pipeline-prompt.txt`, this content **verbatim**
+   as a single line:
+
+   ```
+   Run the memU bridging pipeline. Do the four steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. LEFTOVERS. If ~/.memu/hosts/claude-code/jobs/ already contains job files, they are unfinished work from an earlier run (a crash, or the install itself) — process them exactly as step 3 describes, then run:  memu-claude-code commit  — and only then continue.  2. PREPARE. Run this exact command with bash:  memu-claude-code prepare  — it regenerates ~/.memu/hosts/claude-code/jobs/. If the command exits non-zero, stop and report the error.  3. SELF-EVOLVE. List ~/.memu/hosts/claude-code/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 4. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  4. COMMIT. Run this exact command with bash:  memu-claude-code commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran (leftovers included) and what was committed.
+   ```
+
+2. Write `~/.memu/hosts/claude-code/bridge.sh` and `chmod +x` it:
+
+   ```sh
+   #!/bin/sh
+   # memU bridging for Claude Code — invoked by cron.
+   # The pipeline prompt lives in pipeline-prompt.txt because cron truncates
+   # crontab lines around 1 KB (see BRIDGING_TASK.md).
+   DIR="$HOME/.memu/hosts/claude-code"
+   # Single-instance lock: an hourly tick can fire while a long backlog run is
+   # still going; a second run would race it on jobs/ and double-commit.
+   # mkdir is atomic; a stale lock older than 3h is reclaimed.
+   LOCK="$DIR/.bridge.lock"
+   if ! mkdir "$LOCK" 2>/dev/null; then
+     if [ -n "$(find "$LOCK" -maxdepth 0 -mmin +180 2>/dev/null)" ]; then
+       rmdir "$LOCK" 2>/dev/null
+       mkdir "$LOCK" 2>/dev/null || exit 0
+     else
+       echo "$(date '+%F %T') skipped: another bridging run is in progress" >> "$DIR/bridging.log"
+       exit 0
+     fi
+   fi
+   trap 'rmdir "$LOCK" 2>/dev/null' EXIT INT TERM
+   claude -p "$(cat "$DIR/pipeline-prompt.txt")" >> "$DIR/bridging.log" 2>&1
+   ```
+
 **The crontab's first line is a `PATH`.** cron runs with a bare
-`/usr/bin:/bin`; the binaries this entry needs (pipx and npm installs land in
-`~/.local/bin` and `/opt/homebrew/bin`) are not there, and the entry dies on
+`/usr/bin:/bin`; the binaries the pipeline needs (pipx and npm installs land in
+`~/.local/bin` and `/opt/homebrew/bin`) are not there, and the run dies on
 `command not found` before the pipeline starts. Derive it at registration time
 and write it **above** the entry:
 
@@ -77,18 +120,22 @@ PATH=$(dirname "$(command -v memu-claude-code)"):$(dirname "$(command -v claude)
 ```
 
 The machine-specific fact lives in the crontab, where machine facts belong —
-the pipeline prompt itself stays verbatim.
+the pipeline prompt itself stays verbatim in its file.
 
-Create a system cron entry — the default, macOS included (use launchd only if
-the user explicitly asks for it) — that runs Claude Code headless with the
-pipeline prompt:
+Then the cron entry — the default, macOS included (use launchd only if the user
+explicitly asks for it) — is one short line (cron does not expand `~` in the
+command field, but it does run the line through `/bin/sh`, so `$HOME` works; a
+literal absolute path is equally fine):
 
 ```
-0 * * * * claude -p 'Run the memU bridging pipeline. Do the four steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. LEFTOVERS. If ~/.memu/hosts/claude-code/jobs/ already contains job files, they are unfinished work from an earlier run (a crash, or the install itself) — process them exactly as step 3 describes, then run:  memu-claude-code commit  — and only then continue.  2. PREPARE. Run this exact command with bash:  memu-claude-code prepare  — it regenerates ~/.memu/hosts/claude-code/jobs/. If the command exits non-zero, stop and report the error.  3. SELF-EVOLVE. List ~/.memu/hosts/claude-code/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 4. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  4. COMMIT. Run this exact command with bash:  memu-claude-code commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran (leftovers included) and what was committed.'
+0 * * * * $HOME/.memu/hosts/claude-code/bridge.sh
 ```
 
-The prompt block is fixed; only the cron expression is the user's choice. Nothing
-in it is machine-specific — the pipeline is invoked through `PATH` commands.
+The prompt block is fixed; only the cron expression is the user's choice.
+Nothing machine-specific leaks into the prompt — the pipeline is invoked
+through `PATH` commands. As a side benefit the run's output now lands in
+`~/.memu/hosts/claude-code/bridging.log` (an inlined entry discarded it), so a
+failed tick leaves a diagnosable trace instead of only a cron mail.
 
 ## Step 3 — confirm
 
@@ -99,11 +146,12 @@ count:
   *failing* is exactly why the entry needs its `PATH` line; with that line in
   place the command must resolve from the directories it names.
 - The hard check: trigger one run through cron itself (temporarily set the
-  schedule a minute ahead, or run the entry's command line by hand with
-  `env -i PATH=... /bin/sh -c`), then verify **filesystem traces** — the session
-  cursor and `jobs/` timestamps moved — rather than trusting the run's own
-  summary. Field data, twice over: scheduled runs in bare environments have
-  reported "completed successfully" on a command-not-found.
+  schedule a minute ahead, or run `bridge.sh` by hand with
+  `env -i PATH=... HOME="$HOME" /bin/sh -c`), then verify **filesystem
+  traces** — the session cursor and `jobs/` timestamps moved, and
+  `~/.memu/hosts/claude-code/bridging.log` grew — rather than trusting the
+  run's own summary. Field data, twice over: scheduled runs in bare
+  environments have reported "completed successfully" on a command-not-found.
 
 Report back: where the schedule was registered (crontab/launchd), and the cron in
 words (e.g. "hourly at :00 local time"). Mention that the first run only has

--- a/src/memu/hosts/claude_code/BRIDGING_TASK.md
+++ b/src/memu/hosts/claude_code/BRIDGING_TASK.md
@@ -77,7 +77,7 @@ the Unix sibling of the Windows `schtasks /TR` limit (memU#539), and the fix is
 the same shape: **the prompt lives in a file; the crontab line stays short.**
 
 1. Write the pipeline prompt to
-   `~/.memu/hosts/claude-code/pipeline-prompt.txt`, this content **verbatim**
+   `~/.memu/hosts/claude-code/bridge-prompt.txt`, this content **verbatim**
    as a single line:
 
    ```
@@ -89,24 +89,28 @@ the same shape: **the prompt lives in a file; the crontab line stays short.**
    ```sh
    #!/bin/sh
    # memU bridging for Claude Code — invoked by cron.
-   # The pipeline prompt lives in pipeline-prompt.txt because cron truncates
+   # The pipeline prompt lives in bridge-prompt.txt because cron truncates
    # crontab lines around 1 KB (see BRIDGING_TASK.md).
    DIR="$HOME/.memu/hosts/claude-code"
    # Single-instance lock: an hourly tick can fire while a long backlog run is
    # still going; a second run would race it on jobs/ and double-commit.
-   # mkdir is atomic; a stale lock older than 3h is reclaimed.
+   # mkdir is atomic; a stale lock older than 3h is reclaimed. Tradeoff: a
+   # legitimate run longer than 3h loses its lock to the next tick and can
+   # double-run — accepted deliberately, because the alternative (no reclaim)
+   # lets one crashed run wedge the schedule forever. Do not "fix" one side
+   # without weighing the other.
    LOCK="$DIR/.bridge.lock"
    if ! mkdir "$LOCK" 2>/dev/null; then
      if [ -n "$(find "$LOCK" -maxdepth 0 -mmin +180 2>/dev/null)" ]; then
        rmdir "$LOCK" 2>/dev/null
        mkdir "$LOCK" 2>/dev/null || exit 0
      else
-       echo "$(date '+%F %T') skipped: another bridging run is in progress" >> "$DIR/bridging.log"
+       echo "$(date '+%F %T') skipped: another bridging run is in progress" >> "$DIR/bridge.log"
        exit 0
      fi
    fi
    trap 'rmdir "$LOCK" 2>/dev/null' EXIT INT TERM
-   claude -p "$(cat "$DIR/pipeline-prompt.txt")" >> "$DIR/bridging.log" 2>&1
+   claude -p "$(cat "$DIR/bridge-prompt.txt")" >> "$DIR/bridge.log" 2>&1
    ```
 
 **The crontab's first line is a `PATH`.** cron runs with a bare
@@ -134,7 +138,7 @@ literal absolute path is equally fine):
 The prompt block is fixed; only the cron expression is the user's choice.
 Nothing machine-specific leaks into the prompt — the pipeline is invoked
 through `PATH` commands. As a side benefit the run's output now lands in
-`~/.memu/hosts/claude-code/bridging.log` (an inlined entry discarded it), so a
+`~/.memu/hosts/claude-code/bridge.log` (an inlined entry discarded it), so a
 failed tick leaves a diagnosable trace instead of only a cron mail.
 
 ## Step 3 — confirm
@@ -149,7 +153,7 @@ count:
   schedule a minute ahead, or run `bridge.sh` by hand with
   `env -i PATH=... HOME="$HOME" /bin/sh -c`), then verify **filesystem
   traces** — the session cursor and `jobs/` timestamps moved, and
-  `~/.memu/hosts/claude-code/bridging.log` grew — rather than trusting the
+  `~/.memu/hosts/claude-code/bridge.log` grew — rather than trusting the
   run's own summary. Field data, twice over: scheduled runs in bare
   environments have reported "completed successfully" on a command-not-found.
 

--- a/src/memu/hosts/claude_code/INSTALL.md
+++ b/src/memu/hosts/claude_code/INSTALL.md
@@ -47,7 +47,7 @@ command -v claude || echo "claude NOT FOUND (landing dir: $(ls ~/.local/bin/clau
 command -v memu-claude-code || echo "memu NOT FOUND - do Part 1"
 [ -f ~/.claude/.credentials.json ] && echo "cred file: yes" || echo "cred file: no"
 crontab -l 2>/dev/null | grep -qE 'ANTHROPIC|CLAUDE_CODE' && echo "cron env: set" || echo "cron env: none"
-crontab -l 2>/dev/null | grep -q 'memU bridging pipeline' && echo "cron entry: yes" || echo "cron entry: no"
+crontab -l 2>/dev/null | grep -qE 'hosts/claude-code/bridge\.sh|memU bridging pipeline' && echo "cron entry: yes" || echo "cron entry: no"
 grep -q memu ~/.claude/CLAUDE.md 2>/dev/null && echo "inject: yes" || echo "inject: no"
 ```
 

--- a/src/memu/hosts/claude_code/UNINSTALL.md
+++ b/src/memu/hosts/claude_code/UNINSTALL.md
@@ -39,7 +39,7 @@ and stays.
   If the memU line was the only reason a `PATH=` line was added, that line may
   go too — but only if nothing else in the crontab needs it. If nothing at all
   remains, `crontab -r` removes the now-empty crontab cleanly. The `bridge.sh`,
-  `pipeline-prompt.txt`, and `bridging.log` files live under
+  `bridge-prompt.txt`, and `bridge.log` files live under
   `~/.memu/hosts/claude-code/` and go with the host residue in Part 3.
 - **launchd** — `launchctl bootout gui/$(id -u)/<label>` and delete the plist
   under `~/Library/LaunchAgents`.

--- a/src/memu/hosts/claude_code/UNINSTALL.md
+++ b/src/memu/hosts/claude_code/UNINSTALL.md
@@ -28,14 +28,19 @@ instruction file exactly as they are.
 
 Find the scheduled entry that runs the memU bridging pipeline — a cron entry
 (or launchd job, if that is what the user chose at install time) invoking
-`claude -p 'Run the memU bridging pipeline. …'` — and delete **only that
-entry**. Everything else in the user's crontab is theirs and stays.
+`~/.memu/hosts/claude-code/bridge.sh` (or, on installs predating the prompt-file
+layout, inlining `claude -p 'Run the memU bridging pipeline. …'` directly) —
+and delete **only that entry**. Everything else in the user's crontab is theirs
+and stays.
 
 - **cron** — `crontab -l` to find the line, then rewrite the crontab without
-  it, e.g. `crontab -l | grep -v 'memU bridging pipeline' | crontab -`. If the
-  memU line was the only reason a `PATH=` line was added, that line may go too —
-  but only if nothing else in the crontab needs it. If nothing at all remains,
-  `crontab -r` removes the now-empty crontab cleanly.
+  it, e.g.
+  `crontab -l | grep -vE 'hosts/claude-code/bridge\.sh|memU bridging pipeline' | crontab -`.
+  If the memU line was the only reason a `PATH=` line was added, that line may
+  go too — but only if nothing else in the crontab needs it. If nothing at all
+  remains, `crontab -r` removes the now-empty crontab cleanly. The `bridge.sh`,
+  `pipeline-prompt.txt`, and `bridging.log` files live under
+  `~/.memu/hosts/claude-code/` and go with the host residue in Part 3.
 - **launchd** — `launchctl bootout gui/$(id -u)/<label>` and delete the plist
   under `~/Library/LaunchAgents`.
 - **Windows (Task Scheduler)** — the task was registered by the helper, so remove

--- a/src/memu/hosts/cursor/BRIDGING_TASK.md
+++ b/src/memu/hosts/cursor/BRIDGING_TASK.md
@@ -72,7 +72,13 @@ the same shape: **the prompt lives in a file; the crontab line stays short.**
    Run the memU bridging pipeline. Do the four steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. LEFTOVERS. If ~/.memu/hosts/cursor/jobs/ already contains job files, they are unfinished work from an earlier run (a crash, or the install itself) — process them exactly as step 3 describes, then run:  memu-cursor commit  — and only then continue.  2. PREPARE. Run this exact command with bash:  memu-cursor prepare  — it regenerates ~/.memu/hosts/cursor/jobs/. If the command exits non-zero, stop and report the error.  3. SELF-EVOLVE. List ~/.memu/hosts/cursor/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 4. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  4. COMMIT. Run this exact command with bash:  memu-cursor commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran (leftovers included) and what was committed.
    ```
 
-2. Write `~/.memu/hosts/cursor/bridge.sh` and `chmod +x` it:
+2. Write `~/.memu/hosts/cursor/bridge.sh` and `chmod +x` it. Note the
+   **`--trust` flag and the `cd` into the host working tree**: `cursor-agent`
+   refuses headless runs in an untrusted directory ("Workspace Trust
+   Required", exit 1 — field-verified on Windows in memU#571, and the wall is
+   in headless running itself, so it applies to cron too). The trust lands on
+   memU's own tree, never on whatever directory cron happens to start in.
+   Never `--yolo` — that is the blanket permission-skip this guide rejects:
 
    ```sh
    #!/bin/sh
@@ -94,7 +100,10 @@ the same shape: **the prompt lives in a file; the crontab line stays short.**
      fi
    fi
    trap 'rmdir "$LOCK" 2>/dev/null' EXIT INT TERM
-   cursor-agent -p "$(cat "$DIR/pipeline-prompt.txt")" >> "$DIR/bridging.log" 2>&1
+   # --trust scopes workspace trust to $DIR (memU's own tree), which is also
+   # the working directory — headless cursor-agent dies without it.
+   cd "$DIR" || exit 1
+   cursor-agent --trust -p "$(cat "$DIR/pipeline-prompt.txt")" >> "$DIR/bridging.log" 2>&1
    ```
 
 **The crontab's first line is a `PATH`.** cron runs with a bare

--- a/src/memu/hosts/cursor/BRIDGING_TASK.md
+++ b/src/memu/hosts/cursor/BRIDGING_TASK.md
@@ -57,9 +57,49 @@ hour**, cron `0 * * * *` (local time). Confirm before creating.
 
 ## Step 2 — register the scheduled run
 
+**Never inline the pipeline prompt in the crontab entry.** The quoted prompt is
+~1.2 KB, and cron truncates a crontab line at roughly 1 KB before handing it to
+`/bin/sh` — the shell receives a command cut off mid-quote and every tick dies
+instantly with `unexpected EOF while looking for matching "'"`, mailed to
+`/var/mail/$USER` and visible nowhere else; `cursor-agent` never starts. This is
+the Unix sibling of the Windows `schtasks /TR` limit (memU#539), and the fix is
+the same shape: **the prompt lives in a file; the crontab line stays short.**
+
+1. Write the pipeline prompt to `~/.memu/hosts/cursor/pipeline-prompt.txt`,
+   this content **verbatim** as a single line:
+
+   ```
+   Run the memU bridging pipeline. Do the four steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. LEFTOVERS. If ~/.memu/hosts/cursor/jobs/ already contains job files, they are unfinished work from an earlier run (a crash, or the install itself) — process them exactly as step 3 describes, then run:  memu-cursor commit  — and only then continue.  2. PREPARE. Run this exact command with bash:  memu-cursor prepare  — it regenerates ~/.memu/hosts/cursor/jobs/. If the command exits non-zero, stop and report the error.  3. SELF-EVOLVE. List ~/.memu/hosts/cursor/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 4. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  4. COMMIT. Run this exact command with bash:  memu-cursor commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran (leftovers included) and what was committed.
+   ```
+
+2. Write `~/.memu/hosts/cursor/bridge.sh` and `chmod +x` it:
+
+   ```sh
+   #!/bin/sh
+   # memU bridging for Cursor — invoked by cron.
+   # The pipeline prompt lives in pipeline-prompt.txt because cron truncates
+   # crontab lines around 1 KB (see BRIDGING_TASK.md).
+   DIR="$HOME/.memu/hosts/cursor"
+   # Single-instance lock: an hourly tick can fire while a long backlog run is
+   # still going; a second run would race it on jobs/ and double-commit.
+   # mkdir is atomic; a stale lock older than 3h is reclaimed.
+   LOCK="$DIR/.bridge.lock"
+   if ! mkdir "$LOCK" 2>/dev/null; then
+     if [ -n "$(find "$LOCK" -maxdepth 0 -mmin +180 2>/dev/null)" ]; then
+       rmdir "$LOCK" 2>/dev/null
+       mkdir "$LOCK" 2>/dev/null || exit 0
+     else
+       echo "$(date '+%F %T') skipped: another bridging run is in progress" >> "$DIR/bridging.log"
+       exit 0
+     fi
+   fi
+   trap 'rmdir "$LOCK" 2>/dev/null' EXIT INT TERM
+   cursor-agent -p "$(cat "$DIR/pipeline-prompt.txt")" >> "$DIR/bridging.log" 2>&1
+   ```
+
 **The crontab's first line is a `PATH`.** cron runs with a bare
-`/usr/bin:/bin`; the binaries this entry needs (pipx and npm installs land in
-`~/.local/bin` and `/opt/homebrew/bin`) are not there, and the entry dies on
+`/usr/bin:/bin`; the binaries the pipeline needs (pipx and npm installs land in
+`~/.local/bin` and `/opt/homebrew/bin`) are not there, and the run dies on
 `command not found` before the pipeline starts. Derive it at registration time
 and write it **above** the entry:
 
@@ -68,17 +108,22 @@ PATH=$(dirname "$(command -v memu-cursor)"):$(dirname "$(command -v cursor-agent
 ```
 
 The machine-specific fact lives in the crontab, where machine facts belong —
-the pipeline prompt itself stays verbatim.
+the pipeline prompt itself stays verbatim in its file.
 
-Create a system cron entry — the default, macOS included (use launchd only if
-the user explicitly asks for it) — running:
+Then the cron entry — the default, macOS included (use launchd only if the user
+explicitly asks for it) — is one short line (cron does not expand `~` in the
+command field, but it does run the line through `/bin/sh`, so `$HOME` works; a
+literal absolute path is equally fine):
 
 ```
-0 * * * * cursor-agent -p 'Run the memU bridging pipeline. Do the four steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. LEFTOVERS. If ~/.memu/hosts/cursor/jobs/ already contains job files, they are unfinished work from an earlier run (a crash, or the install itself) — process them exactly as step 3 describes, then run:  memu-cursor commit  — and only then continue.  2. PREPARE. Run this exact command with bash:  memu-cursor prepare  — it regenerates ~/.memu/hosts/cursor/jobs/. If the command exits non-zero, stop and report the error.  3. SELF-EVOLVE. List ~/.memu/hosts/cursor/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 4. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  4. COMMIT. Run this exact command with bash:  memu-cursor commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran (leftovers included) and what was committed.'
+0 * * * * $HOME/.memu/hosts/cursor/bridge.sh
 ```
 
-The prompt block is fixed; only the cron expression is the user's choice. Nothing
-in it is machine-specific — the pipeline is invoked through `PATH` commands.
+The prompt block is fixed; only the cron expression is the user's choice.
+Nothing machine-specific leaks into the prompt — the pipeline is invoked
+through `PATH` commands. As a side benefit the run's output now lands in
+`~/.memu/hosts/cursor/bridging.log` (an inlined entry discarded it), so a
+failed tick leaves a diagnosable trace instead of only a cron mail.
 
 ## Step 3 — confirm
 
@@ -89,11 +134,12 @@ count:
   *failing* is exactly why the entry needs its `PATH` line; with that line in
   place the command must resolve from the directories it names.
 - The hard check: trigger one run through cron itself (temporarily set the
-  schedule a minute ahead, or run the entry's command line by hand with
-  `env -i PATH=... /bin/sh -c`), then verify **filesystem traces** — the session
-  cursor and `jobs/` timestamps moved — rather than trusting the run's own
-  summary. Field data, twice over: scheduled runs in bare environments have
-  reported "completed successfully" on a command-not-found.
+  schedule a minute ahead, or run `bridge.sh` by hand with
+  `env -i PATH=... HOME="$HOME" /bin/sh -c`), then verify **filesystem
+  traces** — the session cursor and `jobs/` timestamps moved, and
+  `~/.memu/hosts/cursor/bridging.log` grew — rather than trusting the run's
+  own summary. Field data, twice over: scheduled runs in bare environments
+  have reported "completed successfully" on a command-not-found.
 
 Report back: where the schedule was registered, and the cron in words. Mention
 that the first run only has work to do once there are new Cursor agent sessions

--- a/src/memu/hosts/cursor/BRIDGING_TASK.md
+++ b/src/memu/hosts/cursor/BRIDGING_TASK.md
@@ -65,7 +65,7 @@ instantly with `unexpected EOF while looking for matching "'"`, mailed to
 the Unix sibling of the Windows `schtasks /TR` limit (memU#539), and the fix is
 the same shape: **the prompt lives in a file; the crontab line stays short.**
 
-1. Write the pipeline prompt to `~/.memu/hosts/cursor/pipeline-prompt.txt`,
+1. Write the pipeline prompt to `~/.memu/hosts/cursor/bridge-prompt.txt`,
    this content **verbatim** as a single line:
 
    ```
@@ -83,19 +83,23 @@ the same shape: **the prompt lives in a file; the crontab line stays short.**
    ```sh
    #!/bin/sh
    # memU bridging for Cursor — invoked by cron.
-   # The pipeline prompt lives in pipeline-prompt.txt because cron truncates
+   # The pipeline prompt lives in bridge-prompt.txt because cron truncates
    # crontab lines around 1 KB (see BRIDGING_TASK.md).
    DIR="$HOME/.memu/hosts/cursor"
    # Single-instance lock: an hourly tick can fire while a long backlog run is
    # still going; a second run would race it on jobs/ and double-commit.
-   # mkdir is atomic; a stale lock older than 3h is reclaimed.
+   # mkdir is atomic; a stale lock older than 3h is reclaimed. Tradeoff: a
+   # legitimate run longer than 3h loses its lock to the next tick and can
+   # double-run — accepted deliberately, because the alternative (no reclaim)
+   # lets one crashed run wedge the schedule forever. Do not "fix" one side
+   # without weighing the other.
    LOCK="$DIR/.bridge.lock"
    if ! mkdir "$LOCK" 2>/dev/null; then
      if [ -n "$(find "$LOCK" -maxdepth 0 -mmin +180 2>/dev/null)" ]; then
        rmdir "$LOCK" 2>/dev/null
        mkdir "$LOCK" 2>/dev/null || exit 0
      else
-       echo "$(date '+%F %T') skipped: another bridging run is in progress" >> "$DIR/bridging.log"
+       echo "$(date '+%F %T') skipped: another bridging run is in progress" >> "$DIR/bridge.log"
        exit 0
      fi
    fi
@@ -103,7 +107,7 @@ the same shape: **the prompt lives in a file; the crontab line stays short.**
    # --trust scopes workspace trust to $DIR (memU's own tree), which is also
    # the working directory — headless cursor-agent dies without it.
    cd "$DIR" || exit 1
-   cursor-agent --trust -p "$(cat "$DIR/pipeline-prompt.txt")" >> "$DIR/bridging.log" 2>&1
+   cursor-agent --trust -p "$(cat "$DIR/bridge-prompt.txt")" >> "$DIR/bridge.log" 2>&1
    ```
 
 **The crontab's first line is a `PATH`.** cron runs with a bare
@@ -131,7 +135,7 @@ literal absolute path is equally fine):
 The prompt block is fixed; only the cron expression is the user's choice.
 Nothing machine-specific leaks into the prompt — the pipeline is invoked
 through `PATH` commands. As a side benefit the run's output now lands in
-`~/.memu/hosts/cursor/bridging.log` (an inlined entry discarded it), so a
+`~/.memu/hosts/cursor/bridge.log` (an inlined entry discarded it), so a
 failed tick leaves a diagnosable trace instead of only a cron mail.
 
 ## Step 3 — confirm
@@ -146,7 +150,7 @@ count:
   schedule a minute ahead, or run `bridge.sh` by hand with
   `env -i PATH=... HOME="$HOME" /bin/sh -c`), then verify **filesystem
   traces** — the session cursor and `jobs/` timestamps moved, and
-  `~/.memu/hosts/cursor/bridging.log` grew — rather than trusting the run's
+  `~/.memu/hosts/cursor/bridge.log` grew — rather than trusting the run's
   own summary. Field data, twice over: scheduled runs in bare environments
   have reported "completed successfully" on a command-not-found.
 

--- a/src/memu/hosts/cursor/UNINSTALL.md
+++ b/src/memu/hosts/cursor/UNINSTALL.md
@@ -27,12 +27,16 @@ file exactly as they are.
 ## Part 1 — Unregister the bridging (record) task
 
 Find the cron entry that runs the memU bridging pipeline — it invokes
-`cursor-agent -p 'Run the memU bridging pipeline. …'` — and delete **only that
-line**. Everything else in the user's crontab is theirs and stays, e.g.
-`crontab -l | grep -v 'memU bridging pipeline' | crontab -`. If the memU line
-was the only reason a `PATH=` line was added, that line may go too — but only
-if nothing else in the crontab needs it. If nothing at all remains,
-`crontab -r` removes the now-empty crontab cleanly.
+`~/.memu/hosts/cursor/bridge.sh` (or, on installs predating the prompt-file
+layout, inlines `cursor-agent -p 'Run the memU bridging pipeline. …'`
+directly) — and delete **only that line**. Everything else in the user's
+crontab is theirs and stays, e.g.
+`crontab -l | grep -vE 'hosts/cursor/bridge\.sh|memU bridging pipeline' | crontab -`.
+If the memU line was the only reason a `PATH=` line was added, that line may go
+too — but only if nothing else in the crontab needs it. If nothing at all
+remains, `crontab -r` removes the now-empty crontab cleanly. The `bridge.sh`,
+`pipeline-prompt.txt`, and `bridging.log` files live under
+`~/.memu/hosts/cursor/` and go with the host residue in the later cleanup part.
 
 ### ✅ Verify Part 1
 

--- a/src/memu/hosts/cursor/UNINSTALL.md
+++ b/src/memu/hosts/cursor/UNINSTALL.md
@@ -35,7 +35,7 @@ crontab is theirs and stays, e.g.
 If the memU line was the only reason a `PATH=` line was added, that line may go
 too — but only if nothing else in the crontab needs it. If nothing at all
 remains, `crontab -r` removes the now-empty crontab cleanly. The `bridge.sh`,
-`pipeline-prompt.txt`, and `bridging.log` files live under
+`bridge-prompt.txt`, and `bridge.log` files live under
 `~/.memu/hosts/cursor/` and go with the host residue in the later cleanup part.
 
 ### ✅ Verify Part 1

--- a/src/memu/hosts/generic/BRIDGING_TASK.md
+++ b/src/memu/hosts/generic/BRIDGING_TASK.md
@@ -69,8 +69,25 @@ The machine-specific fact lives in the crontab, where machine facts belong —
 the pipeline prompt itself stays verbatim.
 
 Default to a system cron entry invoking the agent headless; use the agent's
-own scheduler instead only if the user prefers it. The recurring prompt, with `<SESSION_DIR>` filled
-in, **verbatim**:
+own scheduler instead only if the user prefers it.
+
+**Never inline the pipeline prompt in the crontab entry.** The quoted prompt
+is over 1 KB, and cron truncates a crontab line at roughly 1 KB before handing
+it to `/bin/sh` — the shell receives a command cut off mid-quote and every
+tick dies instantly with `unexpected EOF while looking for matching "'"`,
+mailed to `/var/mail/$USER` and visible nowhere else; the agent never starts
+(field data: inlined entries for two hosts failed exactly this way on every
+tick). This is the Unix sibling of the Windows `schtasks /TR` limit
+(memU#539), and the fix is the same shape: write the prompt **verbatim** to
+`~/.memu/hosts/agent/pipeline-prompt.txt`, wrap the headless invocation in a
+small `~/.memu/hosts/agent/bridge.sh` (`<agent-cli> <headless-flag> "$(cat
+~/.memu/hosts/agent/pipeline-prompt.txt)" >> ~/.memu/hosts/agent/bridging.log
+2>&1`, ideally with an atomic `mkdir`-based lock so an hourly tick can't race
+a still-running backlog run — see the claude-code host's `BRIDGING_TASK.md`
+for the full script), and keep the crontab line to just
+`0 * * * * $HOME/.memu/hosts/agent/bridge.sh`.
+
+The recurring prompt, with `<SESSION_DIR>` filled in, **verbatim**:
 
 ```
 Run the memU bridging pipeline. Do the four steps strictly in order; do not

--- a/src/memu/hosts/generic/BRIDGING_TASK.md
+++ b/src/memu/hosts/generic/BRIDGING_TASK.md
@@ -79,13 +79,16 @@ mailed to `/var/mail/$USER` and visible nowhere else; the agent never starts
 (field data: inlined entries for two hosts failed exactly this way on every
 tick). This is the Unix sibling of the Windows `schtasks /TR` limit
 (memU#539), and the fix is the same shape: write the prompt **verbatim** to
-`~/.memu/hosts/agent/pipeline-prompt.txt`, wrap the headless invocation in a
+`~/.memu/hosts/agent/bridge-prompt.txt`, wrap the headless invocation in a
 small `~/.memu/hosts/agent/bridge.sh` (`<agent-cli> <headless-flag> "$(cat
-~/.memu/hosts/agent/pipeline-prompt.txt)" >> ~/.memu/hosts/agent/bridging.log
+~/.memu/hosts/agent/bridge-prompt.txt)" >> ~/.memu/hosts/agent/bridge.log
 2>&1`, ideally with an atomic `mkdir`-based lock so an hourly tick can't race
 a still-running backlog run — see the claude-code host's `BRIDGING_TASK.md`
-for the full script), and keep the crontab line to just
-`0 * * * * $HOME/.memu/hosts/agent/bridge.sh`.
+for the full script), and keep the crontab entry to one short line:
+
+```
+0 * * * * $HOME/.memu/hosts/agent/bridge.sh
+```
 
 The recurring prompt, with `<SESSION_DIR>` filled in, **verbatim**:
 

--- a/src/memu/hosts/generic/UNINSTALL.md
+++ b/src/memu/hosts/generic/UNINSTALL.md
@@ -40,7 +40,7 @@ running `memu-agent prepare --session-dir …`, the job files, then
 for cron:
 `crontab -l | grep -vE 'hosts/agent/bridge\.sh|memU bridging pipeline' | crontab -`.
 If nothing at all remains, `crontab -r` removes the now-empty crontab cleanly.
-The `bridge.sh`, `pipeline-prompt.txt`, and `bridging.log` files live under
+The `bridge.sh`, `bridge-prompt.txt`, and `bridge.log` files live under
 `~/.memu/hosts/agent/` and go with the host residue in the later cleanup part.
 
 ### ✅ Verify Part 1

--- a/src/memu/hosts/generic/UNINSTALL.md
+++ b/src/memu/hosts/generic/UNINSTALL.md
@@ -32,11 +32,16 @@ and its instruction file exactly as they are.
 
 Find where the bridging run was scheduled at install time — the agent's own
 scheduler if it has one, otherwise a system cron entry — and delete **that
-entry only**. Its prompt is recognizable: the three-step block running
-`memu-agent prepare --session-dir …`, the job files, then `memu-agent commit`.
-Everything else in the scheduler is the user's and stays; for cron:
-`crontab -l | grep -v 'memU bridging pipeline' | crontab -`. If nothing at all
-remains, `crontab -r` removes the now-empty crontab cleanly.
+entry only**. A cron entry invokes `~/.memu/hosts/agent/bridge.sh` (or, on
+installs predating the prompt-file layout, inlines the pipeline prompt
+directly); a native-scheduler prompt is recognizable as the three-step block
+running `memu-agent prepare --session-dir …`, the job files, then
+`memu-agent commit`. Everything else in the scheduler is the user's and stays;
+for cron:
+`crontab -l | grep -vE 'hosts/agent/bridge\.sh|memU bridging pipeline' | crontab -`.
+If nothing at all remains, `crontab -r` removes the now-empty crontab cleanly.
+The `bridge.sh`, `pipeline-prompt.txt`, and `bridging.log` files live under
+`~/.memu/hosts/agent/` and go with the host residue in the later cleanup part.
 
 ### ✅ Verify Part 1
 

--- a/src/memu/hosts/hermes/BRIDGING_TASK.md
+++ b/src/memu/hosts/hermes/BRIDGING_TASK.md
@@ -54,9 +54,15 @@ hour**, cron `0 * * * *` (local time). Confirm before creating.
 
 ## Step 2 — register the scheduled run
 
-Prefer Hermes's own native `cronjob` tool when available — it already runs in
-the correct headless environment; give it the prompt from step 1 below and skip
-the crontab machinery. The rest of this step is the raw-crontab fallback.
+**Hermes's own native `cronjob` tool is the recommended path — use it whenever
+it is available.** It runs in the correct headless environment and takes the
+prompt as *data* (like Codex/OpenClaw schedulers do), sidestepping the crontab
+machinery and its line-length wall entirely: give it the prompt from step 1
+below and you are done. The raw-crontab route that follows is a **fallback
+only**, for setups where the native tool is unavailable — and treat it with
+suspicion proportional to its history: no install is known to have ever run
+successfully through it (the previous revision of this guide shipped a flag
+that does not exist in the Hermes CLI, and nobody hit it in the field).
 
 **Never inline the pipeline prompt in the crontab entry.** The quoted prompt is
 ~1.2 KB, and cron truncates a crontab line at roughly 1 KB before handing it to
@@ -67,7 +73,7 @@ an inlined Hermes entry failed exactly this way on every tick). This is the
 Unix sibling of the Windows `schtasks /TR` limit (memU#539), and the fix is the
 same shape: **the prompt lives in a file; the crontab line stays short.**
 
-1. Write the pipeline prompt to `~/.memu/hosts/hermes/pipeline-prompt.txt`,
+1. Write the pipeline prompt to `~/.memu/hosts/hermes/bridge-prompt.txt`,
    this content **verbatim** as a single line:
 
    ```
@@ -82,24 +88,28 @@ same shape: **the prompt lives in a file; the crontab line stays short.**
    ```sh
    #!/bin/sh
    # memU bridging for Hermes — invoked by cron.
-   # The pipeline prompt lives in pipeline-prompt.txt because cron truncates
+   # The pipeline prompt lives in bridge-prompt.txt because cron truncates
    # crontab lines around 1 KB (see BRIDGING_TASK.md).
    DIR="$HOME/.memu/hosts/hermes"
    # Single-instance lock: an hourly tick can fire while a long backlog run is
    # still going; a second run would race it on jobs/ and double-commit.
-   # mkdir is atomic; a stale lock older than 3h is reclaimed.
+   # mkdir is atomic; a stale lock older than 3h is reclaimed. Tradeoff: a
+   # legitimate run longer than 3h loses its lock to the next tick and can
+   # double-run — accepted deliberately, because the alternative (no reclaim)
+   # lets one crashed run wedge the schedule forever. Do not "fix" one side
+   # without weighing the other.
    LOCK="$DIR/.bridge.lock"
    if ! mkdir "$LOCK" 2>/dev/null; then
      if [ -n "$(find "$LOCK" -maxdepth 0 -mmin +180 2>/dev/null)" ]; then
        rmdir "$LOCK" 2>/dev/null
        mkdir "$LOCK" 2>/dev/null || exit 0
      else
-       echo "$(date '+%F %T') skipped: another bridging run is in progress" >> "$DIR/bridging.log"
+       echo "$(date '+%F %T') skipped: another bridging run is in progress" >> "$DIR/bridge.log"
        exit 0
      fi
    fi
    trap 'rmdir "$LOCK" 2>/dev/null' EXIT INT TERM
-   hermes -z "$(cat "$DIR/pipeline-prompt.txt")" >> "$DIR/bridging.log" 2>&1
+   hermes -z "$(cat "$DIR/bridge-prompt.txt")" >> "$DIR/bridge.log" 2>&1
    ```
 
 **The crontab's first line is a `PATH`.** cron runs with a bare
@@ -126,7 +136,7 @@ absolute path is equally fine):
 The prompt block is fixed; only the cron expression is the user's choice.
 Nothing machine-specific leaks into the prompt — the pipeline is invoked
 through `PATH` commands. As a side benefit the run's output now lands in
-`~/.memu/hosts/hermes/bridging.log` (an inlined entry discarded it), so a
+`~/.memu/hosts/hermes/bridge.log` (an inlined entry discarded it), so a
 failed tick leaves a diagnosable trace instead of only a cron mail.
 
 ## Step 3 — confirm
@@ -141,7 +151,7 @@ count:
   schedule a minute ahead, or run `bridge.sh` by hand with
   `env -i PATH=... HOME="$HOME" /bin/sh -c`), then verify **filesystem
   traces** — the session cursor and `jobs/` timestamps moved, and
-  `~/.memu/hosts/hermes/bridging.log` grew — rather than trusting the run's
+  `~/.memu/hosts/hermes/bridge.log` grew — rather than trusting the run's
   own summary. Field data, twice over: scheduled runs in bare environments
   have reported "completed successfully" on a command-not-found.
 

--- a/src/memu/hosts/hermes/BRIDGING_TASK.md
+++ b/src/memu/hosts/hermes/BRIDGING_TASK.md
@@ -54,9 +54,57 @@ hour**, cron `0 * * * *` (local time). Confirm before creating.
 
 ## Step 2 — register the scheduled run
 
+Prefer Hermes's own native `cronjob` tool when available — it already runs in
+the correct headless environment; give it the prompt from step 1 below and skip
+the crontab machinery. The rest of this step is the raw-crontab fallback.
+
+**Never inline the pipeline prompt in the crontab entry.** The quoted prompt is
+~1.2 KB, and cron truncates a crontab line at roughly 1 KB before handing it to
+`/bin/sh` — the shell receives a command cut off mid-quote and every tick dies
+instantly with `unexpected EOF while looking for matching "'"`, mailed to
+`/var/mail/$USER` and visible nowhere else; `hermes` never starts (field data:
+an inlined Hermes entry failed exactly this way on every tick). This is the
+Unix sibling of the Windows `schtasks /TR` limit (memU#539), and the fix is the
+same shape: **the prompt lives in a file; the crontab line stays short.**
+
+1. Write the pipeline prompt to `~/.memu/hosts/hermes/pipeline-prompt.txt`,
+   this content **verbatim** as a single line:
+
+   ```
+   Run the memU bridging pipeline. Do the four steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. LEFTOVERS. If ~/.memu/hosts/hermes/jobs/ already contains job files, they are unfinished work from an earlier run (a crash, or the install itself) — process them exactly as step 3 describes, then run:  memu-hermes commit  — and only then continue.  2. PREPARE. Run this exact command with the shell tool:  memu-hermes prepare  — it regenerates ~/.memu/hosts/hermes/jobs/. If the command exits non-zero, stop and report the error.  3. SELF-EVOLVE. List ~/.memu/hosts/hermes/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 4. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  4. COMMIT. Run this exact command with the shell tool:  memu-hermes commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran (leftovers included) and what was committed.
+   ```
+
+2. Write `~/.memu/hosts/hermes/bridge.sh` and `chmod +x` it. Note the headless
+   flag: **Hermes's one-shot flag is `-z`/`--oneshot`, not `-p`** — copying
+   another host's bridge script without fixing this flag has broken installs
+   in the field:
+
+   ```sh
+   #!/bin/sh
+   # memU bridging for Hermes — invoked by cron.
+   # The pipeline prompt lives in pipeline-prompt.txt because cron truncates
+   # crontab lines around 1 KB (see BRIDGING_TASK.md).
+   DIR="$HOME/.memu/hosts/hermes"
+   # Single-instance lock: an hourly tick can fire while a long backlog run is
+   # still going; a second run would race it on jobs/ and double-commit.
+   # mkdir is atomic; a stale lock older than 3h is reclaimed.
+   LOCK="$DIR/.bridge.lock"
+   if ! mkdir "$LOCK" 2>/dev/null; then
+     if [ -n "$(find "$LOCK" -maxdepth 0 -mmin +180 2>/dev/null)" ]; then
+       rmdir "$LOCK" 2>/dev/null
+       mkdir "$LOCK" 2>/dev/null || exit 0
+     else
+       echo "$(date '+%F %T') skipped: another bridging run is in progress" >> "$DIR/bridging.log"
+       exit 0
+     fi
+   fi
+   trap 'rmdir "$LOCK" 2>/dev/null' EXIT INT TERM
+   hermes -z "$(cat "$DIR/pipeline-prompt.txt")" >> "$DIR/bridging.log" 2>&1
+   ```
+
 **The crontab's first line is a `PATH`.** cron runs with a bare
-`/usr/bin:/bin`; the binaries this entry needs (pipx and npm installs land in
-`~/.local/bin` and `/opt/homebrew/bin`) are not there, and the entry dies on
+`/usr/bin:/bin`; the binaries the pipeline needs (pipx and npm installs land in
+`~/.local/bin` and `/opt/homebrew/bin`) are not there, and the run dies on
 `command not found` before the pipeline starts. Derive it at registration time
 and write it **above** the entry:
 
@@ -65,17 +113,21 @@ PATH=$(dirname "$(command -v memu-hermes)"):$(dirname "$(command -v hermes)"):/u
 ```
 
 The machine-specific fact lives in the crontab, where machine facts belong —
-the pipeline prompt itself stays verbatim.
+the pipeline prompt itself stays verbatim in its file.
 
-Create a system cron entry that runs Hermes headless with the pipeline prompt:
+Then the cron entry is one short line (cron does not expand `~` in the command
+field, but it does run the line through `/bin/sh`, so `$HOME` works; a literal
+absolute path is equally fine):
 
 ```
-0 * * * * hermes -p 'Run the memU bridging pipeline. Do the four steps strictly in order; do not skip a step even if the previous one looks like it produced nothing.  1. LEFTOVERS. If ~/.memu/hosts/hermes/jobs/ already contains job files, they are unfinished work from an earlier run (a crash, or the install itself) — process them exactly as step 3 describes, then run:  memu-hermes commit  — and only then continue.  2. PREPARE. Run this exact command with the shell tool:  memu-hermes prepare  — it regenerates ~/.memu/hosts/hermes/jobs/. If the command exits non-zero, stop and report the error.  3. SELF-EVOLVE. List ~/.memu/hosts/hermes/jobs/*.txt and process them in ascending numeric order (1.txt, then 2.txt, …). The count changes every run — always glob and sort. If there are no job files, skip to step 4. For each job file: read it and follow its instructions to the letter. Each job is self-contained and already carries the concrete paths it needs. Emitting no files for a job is a valid outcome; do not invent content.  4. COMMIT. Run this exact command with the shell tool:  memu-hermes commit  — it commits whatever the jobs created or changed. If it exits non-zero, report the error.  Finish with a one-line summary: how many jobs ran (leftovers included) and what was committed.'
+0 * * * * $HOME/.memu/hosts/hermes/bridge.sh
 ```
 
-(Adjust the headless invocation to the Hermes CLI the user runs, but keep the
-prompt block verbatim.) Nothing in it is machine-specific — the pipeline is
-invoked through `PATH` commands.
+The prompt block is fixed; only the cron expression is the user's choice.
+Nothing machine-specific leaks into the prompt — the pipeline is invoked
+through `PATH` commands. As a side benefit the run's output now lands in
+`~/.memu/hosts/hermes/bridging.log` (an inlined entry discarded it), so a
+failed tick leaves a diagnosable trace instead of only a cron mail.
 
 ## Step 3 — confirm
 
@@ -86,11 +138,12 @@ count:
   *failing* is exactly why the entry needs its `PATH` line; with that line in
   place the command must resolve from the directories it names.
 - The hard check: trigger one run through cron itself (temporarily set the
-  schedule a minute ahead, or run the entry's command line by hand with
-  `env -i PATH=... /bin/sh -c`), then verify **filesystem traces** — the session
-  cursor and `jobs/` timestamps moved — rather than trusting the run's own
-  summary. Field data, twice over: scheduled runs in bare environments have
-  reported "completed successfully" on a command-not-found.
+  schedule a minute ahead, or run `bridge.sh` by hand with
+  `env -i PATH=... HOME="$HOME" /bin/sh -c`), then verify **filesystem
+  traces** — the session cursor and `jobs/` timestamps moved, and
+  `~/.memu/hosts/hermes/bridging.log` grew — rather than trusting the run's
+  own summary. Field data, twice over: scheduled runs in bare environments
+  have reported "completed successfully" on a command-not-found.
 
 Report back: where the schedule was registered, and the cron in words. Mention
 that the first run only has work to do once there are new Hermes sessions since

--- a/src/memu/hosts/hermes/UNINSTALL.md
+++ b/src/memu/hosts/hermes/UNINSTALL.md
@@ -26,13 +26,17 @@ file exactly as they are.
 
 ## Part 1 — Unregister the bridging (record) task
 
-Find the cron entry that runs the memU bridging pipeline — it invokes Hermes
-headless with the three-step prepare / self-evolve / commit prompt — and
+Find the cron entry that runs the memU bridging pipeline — it invokes
+`~/.memu/hosts/hermes/bridge.sh` (or, on installs predating the prompt-file
+layout, invokes Hermes headless with the inlined three-step prompt) — and
 delete **only that line**. Everything else in the user's crontab is theirs and
-stays, e.g. `crontab -l | grep -v 'memU bridging pipeline' | crontab -`. If
-the memU line was the only reason a `PATH=` line was added, that line may go
+stays, e.g.
+`crontab -l | grep -vE 'hosts/hermes/bridge\.sh|memU bridging pipeline' | crontab -`.
+If the memU line was the only reason a `PATH=` line was added, that line may go
 too — but only if nothing else in the crontab needs it. If nothing at all
-remains, `crontab -r` removes the now-empty crontab cleanly.
+remains, `crontab -r` removes the now-empty crontab cleanly. The `bridge.sh`,
+`pipeline-prompt.txt`, and `bridging.log` files live under
+`~/.memu/hosts/hermes/` and go with the host residue in the later cleanup part.
 
 ### ✅ Verify Part 1
 

--- a/src/memu/hosts/hermes/UNINSTALL.md
+++ b/src/memu/hosts/hermes/UNINSTALL.md
@@ -35,7 +35,7 @@ stays, e.g.
 If the memU line was the only reason a `PATH=` line was added, that line may go
 too — but only if nothing else in the crontab needs it. If nothing at all
 remains, `crontab -r` removes the now-empty crontab cleanly. The `bridge.sh`,
-`pipeline-prompt.txt`, and `bridging.log` files live under
+`bridge-prompt.txt`, and `bridge.log` files live under
 `~/.memu/hosts/hermes/` and go with the host residue in the later cleanup part.
 
 ### ✅ Verify Part 1

--- a/src/memu/hosts/scheduling/prompt.py
+++ b/src/memu/hosts/scheduling/prompt.py
@@ -1,16 +1,18 @@
 """The bridging pipeline prompt, as data.
 
 The scheduled bridging task is a headless agent run whose prompt is the four-step
-prepare -> self-evolve -> commit pipeline. On Unix that prompt is pasted verbatim
-into the crontab (see each host's ``BRIDGING_TASK.md``). The Windows ``schedule``
-helper can't push a ~1000-character quoted string through Task Scheduler, so it
-writes the prompt to a file the wrapper reads — which means the prompt has to
-exist as a value here, not only inside the guide.
+prepare -> self-evolve -> commit pipeline. Neither scheduler can carry the
+~1200-character quoted prompt on its command line — cron truncates crontab lines
+around 1 KB, and Task Scheduler's ``/TR`` splits on the first space — so on both
+platforms the prompt lives in a file the scheduled wrapper reads (Unix:
+``pipeline-prompt.txt`` + ``bridge.sh``, see each host's ``BRIDGING_TASK.md``;
+Windows: the ``schedule`` helper writes it) — which means the prompt has to exist
+as a value here, not only inside the guide.
 
 Parameterized by :class:`~memu.hosts.host_cli.HostSpec` (working tree + binary) so
 one text serves every host. It mirrors the canonical prompt in each host's
-``BRIDGING_TASK.md`` cron block; if you change one, change both. (A test asserting
-the two agree is a good follow-up — today they are kept in sync by hand.)
+``BRIDGING_TASK.md`` prompt-file block; if you change one, change both — a test
+in ``test_scheduling_windows.py`` asserts the two agree.
 """
 
 from __future__ import annotations

--- a/src/memu/hosts/scheduling/prompt.py
+++ b/src/memu/hosts/scheduling/prompt.py
@@ -5,7 +5,7 @@ prepare -> self-evolve -> commit pipeline. Neither scheduler can carry the
 ~1200-character quoted prompt on its command line — cron truncates crontab lines
 around 1 KB, and Task Scheduler's ``/TR`` splits on the first space — so on both
 platforms the prompt lives in a file the scheduled wrapper reads (Unix:
-``pipeline-prompt.txt`` + ``bridge.sh``, see each host's ``BRIDGING_TASK.md``;
+``bridge-prompt.txt`` + ``bridge.sh``, see each host's ``BRIDGING_TASK.md``;
 Windows: the ``schedule`` helper writes it) — which means the prompt has to exist
 as a value here, not only inside the guide.
 

--- a/tests/test_scheduling_windows.py
+++ b/tests/test_scheduling_windows.py
@@ -185,7 +185,7 @@ def test_builders_escape_single_quotes_in_paths() -> None:
 
 
 def test_pipeline_prompt_matches_the_bridging_doc() -> None:
-    # The prompt exists twice — this code builder and the doc's pipeline-prompt.txt
+    # The prompt exists twice — this code builder and the doc's bridge-prompt.txt
     # block (the single-line fence the Unix registration step writes to disk) — and
     # they must stay verbatim. Lock it here: drift fails a test, not silently later.
     from importlib.resources import files
@@ -199,7 +199,7 @@ def test_pipeline_prompt_matches_the_bridging_doc() -> None:
 
 def test_cursor_pipeline_prompt_matches_the_bridging_doc() -> None:
     # Wiring cursor makes bridging_pipeline_prompt(CURSOR) live on Windows; lock its
-    # guide's pipeline-prompt.txt block to the canon the same way claude's is locked.
+    # guide's bridge-prompt.txt block to the canon the same way claude's is locked.
     from importlib.resources import files
 
     doc = (files("memu.hosts.cursor") / "BRIDGING_TASK.md").read_text(encoding="utf-8")
@@ -207,6 +207,22 @@ def test_cursor_pipeline_prompt_matches_the_bridging_doc() -> None:
         line.strip() for line in doc.splitlines() if line.strip().startswith("Run the memU bridging pipeline.")
     )
     assert doc_prompt == prompt.bridging_pipeline_prompt(CURSOR)
+
+
+@pytest.mark.parametrize("pkg", ["claude_code", "cursor", "hermes", "generic"])
+def test_bridging_doc_cron_entries_stay_short(pkg: str) -> None:
+    # The bug class behind memU#591: an inlined pipeline prompt pushed the guide's
+    # crontab entry past cron's ~1KB line buffer, so every tick died mid-quote
+    # before the agent binary ever started. The prompt-lock tests above catch
+    # content drift but not re-inlining — this gate does. Every cron entry a
+    # Unix guide tells the agent to write must stay far below the buffer.
+    from importlib.resources import files
+
+    doc = (files(f"memu.hosts.{pkg}") / "BRIDGING_TASK.md").read_text(encoding="utf-8")
+    cron_entries = [line for line in doc.splitlines() if line.lstrip().startswith("0 * * * * ")]
+    assert cron_entries, f"{pkg} guide lost its cron entry example"
+    for line in cron_entries:
+        assert len(line) < 512, f"{pkg} cron entry is {len(line)} chars — cron truncates around 1KB: {line[:80]!r}"
 
 
 def test_install_rejects_nonpositive_interval(

--- a/tests/test_scheduling_windows.py
+++ b/tests/test_scheduling_windows.py
@@ -185,27 +185,32 @@ def test_builders_escape_single_quotes_in_paths() -> None:
 
 
 def test_pipeline_prompt_matches_the_bridging_doc() -> None:
-    # The prompt exists twice — this code builder and the doc's cron block — and the
-    # PR promised they stay verbatim. Lock it here: drift fails a test, not silently later.
+    # The prompt exists twice — this code builder and the doc's pipeline-prompt.txt
+    # block (the single-line fence the Unix registration step writes to disk) — and
+    # they must stay verbatim. Lock it here: drift fails a test, not silently later.
     from importlib.resources import files
 
     doc = (files("memu.hosts.claude_code") / "BRIDGING_TASK.md").read_text(encoding="utf-8")
-    cron_line = next(line for line in doc.splitlines() if "claude -p 'Run the memU" in line)
-    doc_prompt = cron_line.split("claude -p '", 1)[1].rstrip()
-    assert doc_prompt.endswith("'")
-    assert doc_prompt[:-1] == prompt.bridging_pipeline_prompt(CLAUDE)
+    doc_prompt = next(
+        line.strip()
+        for line in doc.splitlines()
+        if line.strip().startswith("Run the memU bridging pipeline.")
+    )
+    assert doc_prompt == prompt.bridging_pipeline_prompt(CLAUDE)
 
 
 def test_cursor_pipeline_prompt_matches_the_bridging_doc() -> None:
     # Wiring cursor makes bridging_pipeline_prompt(CURSOR) live on Windows; lock its
-    # guide's cron block to the canon the same way claude's is locked.
+    # guide's pipeline-prompt.txt block to the canon the same way claude's is locked.
     from importlib.resources import files
 
     doc = (files("memu.hosts.cursor") / "BRIDGING_TASK.md").read_text(encoding="utf-8")
-    cron_line = next(line for line in doc.splitlines() if "-p 'Run the memU" in line)
-    doc_prompt = cron_line.split("-p '", 1)[1].rstrip()
-    assert doc_prompt.endswith("'")
-    assert doc_prompt[:-1] == prompt.bridging_pipeline_prompt(CURSOR)
+    doc_prompt = next(
+        line.strip()
+        for line in doc.splitlines()
+        if line.strip().startswith("Run the memU bridging pipeline.")
+    )
+    assert doc_prompt == prompt.bridging_pipeline_prompt(CURSOR)
 
 
 def test_install_rejects_nonpositive_interval(

--- a/tests/test_scheduling_windows.py
+++ b/tests/test_scheduling_windows.py
@@ -192,9 +192,7 @@ def test_pipeline_prompt_matches_the_bridging_doc() -> None:
 
     doc = (files("memu.hosts.claude_code") / "BRIDGING_TASK.md").read_text(encoding="utf-8")
     doc_prompt = next(
-        line.strip()
-        for line in doc.splitlines()
-        if line.strip().startswith("Run the memU bridging pipeline.")
+        line.strip() for line in doc.splitlines() if line.strip().startswith("Run the memU bridging pipeline.")
     )
     assert doc_prompt == prompt.bridging_pipeline_prompt(CLAUDE)
 
@@ -206,9 +204,7 @@ def test_cursor_pipeline_prompt_matches_the_bridging_doc() -> None:
 
     doc = (files("memu.hosts.cursor") / "BRIDGING_TASK.md").read_text(encoding="utf-8")
     doc_prompt = next(
-        line.strip()
-        for line in doc.splitlines()
-        if line.strip().startswith("Run the memU bridging pipeline.")
+        line.strip() for line in doc.splitlines() if line.strip().startswith("Run the memU bridging pipeline.")
     )
     assert doc_prompt == prompt.bridging_pipeline_prompt(CURSOR)
 


### PR DESCRIPTION
Fixes #591 — this is the docs-only shape of that issue's Expected behavior: the same **file + wrapper** pattern the Windows helper established in #546/#571, ported to the Unix registration steps. The field incident described below is the one #591 cites (its reporter's self-fix is this PR's pattern). The deeper follow-up #591 also blesses — extending the `schedule {install,verify,status,uninstall}` helper to Unix so registration becomes one deterministic command instead of agent-followed docs — is planned as separate PRs (claude_code first, then a cursor fan-out mirroring #546 → #571).

Also folds in the Unix follow-up flagged in #571: the cursor bridge script now runs `cd ~/.memu/hosts/cursor && cursor-agent --trust -p ...` — headless cursor-agent refuses untrusted directories ("Workspace Trust Required", exit 1), so without the flag the first cron run dies on that wall; trust lands on memU's own tree, never `--yolo`.

## Problem

The Unix registration steps in `claude_code`, `cursor`, `hermes`, and `generic` `BRIDGING_TASK.md` all instructed the installing agent to write the full ~1.2 KB pipeline prompt as a single-quoted **inline crontab command**. macOS/BSD cron truncates a crontab line at roughly 1 KB before handing it to `/bin/sh`, so the shell receives a command cut off mid-quote and **every tick dies instantly** with:

```
/bin/sh: -c: line 0: unexpected EOF while looking for matching `''
/bin/sh: -c: line 1: syntax error: unexpected end of file
```

The error is mailed to `/var/mail/$USER` and visible nowhere else; the agent binary never starts, so the whole hourly bridging cycle is silently dropped.

**Field-confirmed:** on one macOS machine, the inlined `claude -p '...'` (1320 chars) and `hermes -p '...'` entries failed this way on every tick, while the short script-invoking codex entry beside them (49 chars) kept working.

## Fix

Mirror the Windows `schtasks /TR` solution (memU#539) that already exists in the same docs — nothing long ever touches the scheduler's command line:

1. The pipeline prompt lives verbatim in `~/.memu/hosts/<host>/bridge-prompt.txt`.
2. A small `~/.memu/hosts/<host>/bridge.sh` reads it, invokes the agent headless, and appends output to `bridge.log` (previously an inlined entry discarded all output — now every tick leaves a diagnosable trace). It carries an atomic `mkdir`-based single-instance lock so an hourly tick can't race a still-running backlog run and double-commit; stale locks older than 3 h are reclaimed.
3. The crontab entry becomes one short line: `0 * * * * $HOME/.memu/hosts/<host>/bridge.sh`.

Verified in the field: after the switch, the next hourly tick executed `bridge.sh` cleanly (no EOF mail), and the lock correctly logged `skipped: another bridging run is in progress` while a long backlog run was still going; the backlog run itself completed 21 jobs and committed 33 recall files.

**Fixed in passing:** the hermes doc's inline example invoked `hermes -p`, but Hermes' one-shot flag is `-z`/`--oneshot` (there is no `-p`) — that entry could never have worked even without truncation. The hermes doc now also points to Hermes' native `cronjob` tool as the preferred mechanism, with raw crontab as fallback.

**Consistency updates:** each host's `UNINSTALL.md` Part 1 now recognizes both the new `bridge.sh` entry and legacy inline entries (removal grep matches both), and notes that `bridge.sh`/`bridge-prompt.txt`/`bridge.log` go with the host-residue cleanup; `claude_code/INSTALL.md`'s cron-entry detection grep likewise matches both layouts.

Docs-only change; no code paths affected. `codex` and `openclaw` docs are untouched — they register through native schedulers, not raw crontab.

---

修复 #591 —— 本 PR 是该 issue Expected behavior 中"纯文档改动"的那条路线:把 Windows helper 在 #546/#571 确立的 **file + wrapper** 模式移植到 Unix 注册步骤。下文描述的实机事故正是 #591 所引用的那次(其"现场报告者的自行修复"就是本 PR 的模式)。#591 同样认可的更深层后续——把 `schedule {install,verify,status,uninstall}` helper 扩展到 Unix,让注册从"agent 照文档执行"变成"跑一条确定命令"——计划作为独立 PR 跟进(先 claude_code,再仿照 #546 → #571 扇出 cursor)。

同时顺带修掉 #571 预告的 Unix 侧遗留:cursor 的 bridge 脚本现在执行 `cd ~/.memu/hosts/cursor && cursor-agent --trust -p ...` —— 无头 cursor-agent 在未信任目录会直接拒绝("Workspace Trust Required",exit 1),不带该 flag 首次 cron 运行就会死在这面墙上;信任只落在 memU 自己的工作树,绝不用 `--yolo`。

## 问题

`claude_code`、`cursor`、`hermes`、`generic` 四个 host 的 `BRIDGING_TASK.md` 中,Unix 注册步骤都指示安装 agent 把约 1.2 KB 的管线 prompt 以单引号内联的方式**整段写进 crontab 命令行**。macOS/BSD cron 在把 crontab 行交给 `/bin/sh` 之前会在约 1 KB 处截断,shell 拿到的是一条在引号中间被切断的残缺命令,导致**每次整点触发都当场失败**:

```
/bin/sh: -c: line 0: unexpected EOF while looking for matching `''
/bin/sh: -c: line 1: syntax error: unexpected end of file
```

该报错只会寄送到 `/var/mail/$USER`,别处毫无痕迹;agent 二进制根本没有启动,整个小时级 bridging 周期被静默丢弃。

**实机确认:**同一台 macOS 机器上,内联的 `claude -p '...'`(1320 字符)和 `hermes -p '...'` 两条记录每次触发都如此失败,而旁边调用短脚本的 codex 记录(49 字符)一直正常。

## 修复

照搬同一批文档中已有的 Windows `schtasks /TR` 方案(memU#539)——任何长内容都不再经过调度器的命令行:

1. 管线 prompt 原文存放于 `~/.memu/hosts/<host>/bridge-prompt.txt`。
2. 一个小的 `~/.memu/hosts/<host>/bridge.sh` 读取它、headless 调用 agent,并把输出追加到 `bridge.log`(旧的内联写法会丢弃全部输出——现在每次触发都留下可诊断的痕迹)。脚本带有基于原子 `mkdir` 的单实例锁,防止整点触发与仍在运行的积压任务竞争同一个 `jobs/` 目录造成重复提交;超过 3 小时的过期锁会被回收。
3. crontab 记录缩成一行短命令:`0 * * * * $HOME/.memu/hosts/<host>/bridge.sh`。

实机验证:切换后下一个整点 cron 干净地执行了 `bridge.sh`(不再有 EOF 报错邮件),且在一轮长积压运行仍在进行时,锁正确记录了 `skipped: another bridging run is in progress`;积压那轮自身完成了 21 个任务并提交了 33 个 recall 文件。

**顺带修复:**hermes 文档的内联示例用的是 `hermes -p`,但 Hermes 的一次性运行标志是 `-z`/`--oneshot`(根本没有 `-p`)——即使没有截断问题,那条记录也永远跑不起来。hermes 文档现在同时指明优先使用 Hermes 原生 `cronjob` 工具,raw crontab 作为回退方案。

**一致性更新:**各 host 的 `UNINSTALL.md` Part 1 现在同时识别新的 `bridge.sh` 记录和旧式内联记录(删除用的 grep 两种都能匹配),并注明 `bridge.sh`/`bridge-prompt.txt`/`bridge.log` 随 host 残留一并清理;`claude_code/INSTALL.md` 的 cron 记录检测 grep 同样兼容两种布局。

纯文档改动,不影响任何代码路径。`codex` 与 `openclaw` 的文档未动——它们通过原生调度器注册,不使用 raw crontab。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
