### PR TITLE
docs: fix bridging task name in codex/openclaw uninstall guides

### DIFF
--- a/src/memu/hosts/codex/UNINSTALL.md
+++ b/src/memu/hosts/codex/UNINSTALL.md
@@ -27,10 +27,12 @@ instruction file exactly as they are.
 ## Part 1 — Unregister the bridging (record) task
 
 Find the Codex scheduled task that runs the memU bridging pipeline — it was
-created at install time (named e.g. `memu-bridging`) with the three-step
+created at install time (named e.g. `memu-remember`) with the three-step
 prepare / self-evolve / commit prompt — and delete **that task only**, through
-the same scheduled-task surface Codex used to create it. Any other scheduled
-tasks the user has are theirs and stay.
+the same scheduled-task surface Codex used to create it. The name is only a
+hint (the user may have chosen another); the load-bearing signal is the prompt,
+which runs the memU bridging pipeline. Any other scheduled tasks the user has
+are theirs and stay.
 
 ### ✅ Verify Part 1
 

--- a/src/memu/hosts/openclaw/UNINSTALL.md
+++ b/src/memu/hosts/openclaw/UNINSTALL.md
@@ -27,9 +27,11 @@ instruction file exactly as they are.
 ## Part 1 — Unregister the bridging (record) task
 
 Find the OpenClaw cron job that runs the memU bridging pipeline — it was
-created at install time through OpenClaw's native scheduler with the
-three-step prepare / self-evolve / commit prompt — and delete **that job
-only**, through the same scheduler surface. Any other cron jobs the user has
+created at install time (named e.g. `memu-remember`) through OpenClaw's native
+scheduler with the three-step prepare / self-evolve / commit prompt — and
+delete **that job only**, through the same scheduler surface. The name is only
+a hint (the user may have chosen another); the load-bearing signal is the
+prompt, which runs the memU bridging pipeline. Any other cron jobs the user has
 are theirs and stay.
 
 ### ✅ Verify Part 1


### PR DESCRIPTION
## Problem

The `BRIDGING_TASK.md` install guides standardize on **`memu-remember`** as the scheduled task name across all three hosts. But the uninstall guides drifted:

- **Codex** — `UNINSTALL.md` Part 1 named the task `memu-bridging`, contradicting the install guide. An agent following it would hunt for a task that never existed under that name.
- **OpenClaw** — `UNINSTALL.md` Part 1 gave no name anchor at all, forcing the agent to match on prompt content alone.
- **Claude Code** — already correct (identifies the Unix entry by the `claude -p 'Run the memU bridging pipeline. …'` prompt, and removes the Windows task via the helper). No change needed.

## Fix

- Align Codex and OpenClaw on `memu-remember`.
- Add a note in both that the name is only a hint (the user may have chosen another); the load-bearing signal is the pipeline prompt — the same robust approach the Claude Code guide already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)