### PR TITLE
docs: add UTM parameters to the View online link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ memU is a lightweight, agent-driven memory system that gives users a shared LLM 
 
 memU works with Codex, Claude Code, Cursor, OpenClaw, Hermes, WorkBuddy, Cola, and more. See [Host adapters](#host-adapters-memory-for-desktop-coding-agents).
 
-**Cross-device · Free · Unlimited · [View online](https://memu.so)**
+**Cross-device · Free · Unlimited · [View online](https://memu.so/?utm_source=github&utm_medium=readme&utm_campaign=view_online)**
 
 Get your API key from [memu.so](https://memu.so), then send this message to your agent:
 


### PR DESCRIPTION
## Summary

Add UTM parameters to the "View online" link in the README so that clicks from GitHub can be measured in Google Analytics on memu.so:

`https://memu.so/?utm_source=github&utm_medium=readme&utm_campaign=view_online`

The destination and link text are unchanged; visitors see no difference. Works together with the GA4 tag added to the website (NevaMind-AI/memu-website-v2#2). Traffic from this link shows up in GA under source/medium `github / readme`.

## 摘要

给 README 中的 "View online" 链接加上 UTM 参数,使来自 GitHub 的点击可以在 memu.so 的 Google Analytics 中被单独统计:

`https://memu.so/?utm_source=github&utm_medium=readme&utm_campaign=view_online`

链接目标和文字均不变,访问者无感知。与网站侧新增的 GA4 标签(NevaMind-AI/memu-website-v2#2)配合使用,该链接的流量会以 `github / readme` 的 source/medium 出现在 GA 报告中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)