### PR TITLE
ci: split build into lint and test workflows with a Windows matrix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: lint
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv & set Python
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+          enable-cache: true
+          cache-python: true
+
+      - name: Ensure Python 3.13
+        run: uv python install 3.13
+
+      - name: Sync dependencies
+        run: uv sync --frozen
+
+      - name: Run style checks
+        run: uv run make check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,19 @@
-name: build
+name: test
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ${{ matrix.os }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.11", "3.13"]
 
     steps:
@@ -24,12 +30,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Sync dependencies
-        run: |
-          uv sync --frozen
-          uv run pre-commit install
-
-      - name: Run style checks
-        run: uv run make check
+        run: uv sync --frozen
 
       - name: Run tests
-        run: uv run make test
+        run: uv run python -m pytest --cov --cov-config=pyproject.toml --cov-report=xml

--- a/tests/test_host_templates.py
+++ b/tests/test_host_templates.py
@@ -87,9 +87,9 @@ def test_fetch_is_off_when_base_url_is_blank() -> None:
 @pytest.mark.parametrize(
     "body, status",
     [
-        (f"server {MEMORY_KEYS}".encode(), 404),  # non-200
-        (b"x" * (templates._MAX_BYTES + 1), 200),  # oversize
-        (b"missing the placeholders", 200),  # malformed
+        pytest.param(f"server {MEMORY_KEYS}".encode(), 404, id="non-200"),
+        pytest.param(b"x" * (templates._MAX_BYTES + 1), 200, id="oversize"),
+        pytest.param(b"missing the placeholders", 200, id="malformed"),
     ],
 )
 def test_fetch_rejects_bad_responses_without_caching(monkeypatch: pytest.MonkeyPatch, body: bytes, status: int) -> None:


### PR DESCRIPTION
## Summary

Split the single `build.yml` job into two workflows so lint runs once on Linux while tests gain an OS matrix that includes Windows.

- **`lint.yml`** — `ubuntu-latest`, Python 3.13; runs `make check` (lock-file check, pre-commit, mypy, deptry) exactly once.
- **`test.yml`** — matrix `{ubuntu-latest, windows-latest} × {3.11, 3.13}`, `fail-fast: false`; runs pytest with coverage directly (not via `make`, which isn't guaranteed on `windows-latest`).
- Removes `build.yml`. `pr-title.yml`, `publish-memu-cli.yml`, and `release-please.yml` are untouched.
- Both workflows keep the existing same-repo dedupe `if:` guard, so branch pushes and fork PRs behave exactly as before.

Closes #505.

## Why

Per #505, adding Windows to the combined job would rerun lint/pre-commit on every OS×Python cell and pull pre-commit onto Windows, where its hooks have CRLF pitfalls (cf. #482). Keeping lint single-run on ubuntu and giving only pytest the OS matrix avoids that and lets platform-specific test failures surface.

## Surfaced and fixed a real Windows-only failure

Enabling `windows-latest` immediately caught one — exactly the point of #505. `tests/test_host_templates.py::test_fetch_rejects_bad_responses_without_caching` has an "oversize" case that builds a 65,537-byte body, so pytest derived a node id longer than Windows' 32,767-character limit for the `PYTEST_CURRENT_TEST` environment variable. Setup and teardown then raised `ValueError: the environment variable is longer than 32767 characters` on Windows only (Linux has no such cap).

Fixed by giving each parametrization a short, explicit `pytest.param(..., id=...)`. The request bodies and assertions are unchanged, so the size guard is still exercised.

## Verification

Locally on Windows (Python 3.13):

- `pytest` → **222 passed, 0 errors** (previously 221 passed + 2 errors before the id fix).
- `make check`: pre-commit, mypy (129 source files), deptry, and `uv lock --locked` all clean.

CI on this PR additionally covers ubuntu × {3.11, 3.13} and windows × {3.11, 3.13}.

## Notes for maintainers

- I kept the existing `{3.11, 3.13}` Python pair in `test.yml` (build.yml already tested both) and added the OS dimension. Happy to reduce to 3.13-only if you prefer the exact shape proposed in #505.
- Branch protection's required status checks will need updating from `build` to `lint` and `test`.
