### PR TITLE
fix: PostgresRecallFileSegmentRepo._cache_segment appends duplicate segments to cache on repeated queries

### DIFF
--- a/src/memu/database/postgres/repositories/recall_file_segment_repo.py
+++ b/src/memu/database/postgres/repositories/recall_file_segment_repo.py
@@ -38,7 +38,8 @@ class PostgresRecallFileSegmentRepo(PostgresRepoBase, RecallFileSegmentRepo):
 
     def _cache_segment(self, row: Any) -> RecallFileSegment:
         seg = self._row_to_record(row)
-        self.segments.append(seg)
+        if not any(s.id == seg.id for s in self.segments):
+            self.segments.append(seg)
         return seg
 
     def list_segments(self, where: Mapping[str, Any] | None = None) -> list[RecallFileSegment]:

--- a/tests/test_cache_segment_duplicates.py
+++ b/tests/test_cache_segment_duplicates.py
@@ -1,40 +1,86 @@
-"""Unit test verifying list_segments does not duplicate segment objects in cache."""
+"""Unit test verifying PostgresRecallFileSegmentRepo list_segments deduplicates segment cache."""
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
-from memu.app.settings import DatabaseConfig, DefaultUserModel
-from memu.database.factory import build_database
-from memu.database.interfaces import Database
+pytest.importorskip("pgvector")
+
+from memu.database.postgres.models import RecallFileSegment as SQLARecallFileSegment
+from memu.database.postgres.repositories.recall_file_segment_repo import PostgresRecallFileSegmentRepo
+from memu.database.postgres.schema import SQLAModels
+from memu.database.state import DatabaseState
 
 
-@pytest.fixture(params=["inmemory", "sqlite"])
-def db_backend(request: pytest.FixtureRequest, tmp_path: Any) -> Database:
-    if request.param == "inmemory":
-        config = DatabaseConfig.model_validate({"metadata_store": {"provider": "inmemory"}})
-    else:
-        config = DatabaseConfig.model_validate(
-            {"metadata_store": {"provider": "sqlite", "dsn": f"sqlite:///{tmp_path}/memu.sqlite3"}}
-        )
-    return build_database(config=config, user_model=DefaultUserModel)
+class StubSession:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def scalars(self, stmt: Any) -> StubSession:
+        return self
+
+    def all(self) -> list[Any]:
+        return self._rows
 
 
-def test_list_segments_no_duplicates_in_cache(db_backend: Database) -> None:
-    # 1. Create a recall file and a segment
-    f = db_backend.recall_file_repo.get_or_create_recall_file(
-        name="file1", description="desc", embedding=[0.1], user_data={"user_id": "u1"}
+class StubSessionManager:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    @contextmanager
+    def session(self):
+        yield StubSession(self._rows)
+
+
+def test_postgres_list_segments_deduplicates_cache() -> None:
+    state = DatabaseState()
+    sqla_models = SQLAModels(
+        Resource=MagicMock(),
+        RecallFile=MagicMock(),
+        RecallFileSegment=SQLARecallFileSegment,
     )
-    db_backend.recall_file_segment_repo.create_segment(
-        recall_file_id=f.id, text="seg1", embedding=[0.1], user_data={"user_id": "u1"}
+
+    row1 = MagicMock()
+    row1.id = "seg-1"
+    row1.recall_file_id = "file-1"
+    row1.track = "memory"
+    row1.text = "text 1"
+    row1.embedding = [0.1, 0.2]
+    row1.created_at = None
+    row1.updated_at = None
+
+    row2 = MagicMock()
+    row2.id = "seg-2"
+    row2.recall_file_id = "file-1"
+    row2.track = "memory"
+    row2.text = "text 2"
+    row2.embedding = [0.3, 0.4]
+    row2.created_at = None
+    row2.updated_at = None
+
+    canned_rows = [row1, row2]
+    sessions = StubSessionManager(canned_rows)
+
+    repo = PostgresRecallFileSegmentRepo(
+        state=state,
+        recall_file_segment_model=MagicMock(),
+        sqla_models=sqla_models,
+        sessions=sessions,  # type: ignore[arg-type]
+        scope_fields=[],
     )
 
-    # 2. Call list_segments multiple times
-    db_backend.recall_file_segment_repo.list_segments()
-    db_backend.recall_file_segment_repo.list_segments()
-    db_backend.recall_file_segment_repo.list_segments()
+    # Calling list_segments 3 times should return 2 rows each time,
+    # and keep the cache size at 2 (2 -> 2 -> 2) instead of growing (2 -> 4 -> 6).
+    res1 = repo.list_segments()
+    res2 = repo.list_segments()
+    res3 = repo.list_segments()
 
-    # 3. Cache must still contain only 1 segment
-    assert len(db_backend.recall_file_segment_repo.segments) == 1
+    assert len(res1) == 2
+    assert len(res2) == 2
+    assert len(res3) == 2
+    assert len(repo.segments) == 2
+    assert [s.id for s in repo.segments] == ["seg-1", "seg-2"]

--- a/tests/test_cache_segment_duplicates.py
+++ b/tests/test_cache_segment_duplicates.py
@@ -1,4 +1,4 @@
-"""Unit test verifying PostgresRecallFileSegmentRepo list_segments deduplicates segment cache."""
+"""Unit test verifying recall file segment repositories do not duplicate segment objects in cache."""
 
 from __future__ import annotations
 
@@ -8,12 +8,36 @@ from unittest.mock import MagicMock
 
 import pytest
 
-pytest.importorskip("pgvector")
+from memu.app.settings import DatabaseConfig, DefaultUserModel
+from memu.database.factory import build_database
+from memu.database.interfaces import Database
 
-from memu.database.postgres.models import RecallFileSegment as SQLARecallFileSegment
-from memu.database.postgres.repositories.recall_file_segment_repo import PostgresRecallFileSegmentRepo
-from memu.database.postgres.schema import SQLAModels
-from memu.database.state import DatabaseState
+
+@pytest.fixture(params=["inmemory", "sqlite"])
+def db_backend(request: pytest.FixtureRequest, tmp_path: Any) -> Database:
+    if request.param == "inmemory":
+        config = DatabaseConfig.model_validate({"metadata_store": {"provider": "inmemory"}})
+    else:
+        config = DatabaseConfig.model_validate({
+            "metadata_store": {"provider": "sqlite", "dsn": f"sqlite:///{tmp_path}/memu.sqlite3"}
+        })
+    return build_database(config=config, user_model=DefaultUserModel)
+
+
+def test_list_segments_no_duplicates_in_cache(db_backend: Database) -> None:
+    """Test inmemory and sqlite backends do not duplicate segment objects in cache."""
+    f = db_backend.recall_file_repo.get_or_create_recall_file(
+        name="file1", description="desc", embedding=[0.1], user_data={"user_id": "u1"}
+    )
+    db_backend.recall_file_segment_repo.create_segment(
+        recall_file_id=f.id, text="seg1", embedding=[0.1], user_data={"user_id": "u1"}
+    )
+
+    db_backend.recall_file_segment_repo.list_segments()
+    db_backend.recall_file_segment_repo.list_segments()
+    db_backend.recall_file_segment_repo.list_segments()
+
+    assert len(db_backend.recall_file_segment_repo.segments) == 1
 
 
 class StubSession:
@@ -37,6 +61,14 @@ class StubSessionManager:
 
 
 def test_postgres_list_segments_deduplicates_cache() -> None:
+    """Test PostgresRecallFileSegmentRepo list_segments deduplication logic directly with a stub session."""
+    pytest.importorskip("pgvector")
+
+    from memu.database.postgres.models import RecallFileSegment as SQLARecallFileSegment
+    from memu.database.postgres.repositories.recall_file_segment_repo import PostgresRecallFileSegmentRepo
+    from memu.database.postgres.schema import SQLAModels
+    from memu.database.state import DatabaseState
+
     state = DatabaseState()
     sqla_models = SQLAModels(
         Resource=MagicMock(),

--- a/tests/test_cache_segment_duplicates.py
+++ b/tests/test_cache_segment_duplicates.py
@@ -1,0 +1,40 @@
+"""Unit test verifying list_segments does not duplicate segment objects in cache."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from memu.app.settings import DatabaseConfig, DefaultUserModel
+from memu.database.factory import build_database
+from memu.database.interfaces import Database
+
+
+@pytest.fixture(params=["inmemory", "sqlite"])
+def db_backend(request: pytest.FixtureRequest, tmp_path: Any) -> Database:
+    if request.param == "inmemory":
+        config = DatabaseConfig.model_validate({"metadata_store": {"provider": "inmemory"}})
+    else:
+        config = DatabaseConfig.model_validate(
+            {"metadata_store": {"provider": "sqlite", "dsn": f"sqlite:///{tmp_path}/memu.sqlite3"}}
+        )
+    return build_database(config=config, user_model=DefaultUserModel)
+
+
+def test_list_segments_no_duplicates_in_cache(db_backend: Database) -> None:
+    # 1. Create a recall file and a segment
+    f = db_backend.recall_file_repo.get_or_create_recall_file(
+        name="file1", description="desc", embedding=[0.1], user_data={"user_id": "u1"}
+    )
+    db_backend.recall_file_segment_repo.create_segment(
+        recall_file_id=f.id, text="seg1", embedding=[0.1], user_data={"user_id": "u1"}
+    )
+
+    # 2. Call list_segments multiple times
+    db_backend.recall_file_segment_repo.list_segments()
+    db_backend.recall_file_segment_repo.list_segments()
+    db_backend.recall_file_segment_repo.list_segments()
+
+    # 3. Cache must still contain only 1 segment
+    assert len(db_backend.recall_file_segment_repo.segments) == 1


### PR DESCRIPTION
## 📝 Pull Request Summary

In PostgresRecallFileSegmentRepo, calling list_segments() or load_existing() multiple times causes duplicate RecallFileSegment objects to accumulate in self.segments. This is because     _cache_segment unconditionally appends every mapped row to the self.segments list without checking if the segment is already present.                                                    
                                                                                                                                                                                           
This violates backend parity with SQLiteRecallFileSegmentRepo, which checks if not any(s.id == seg.id for s in self.segments): before appending. 

---

## ✅ What does this PR do?
- Prevents the segment to cache if it already cached.


---

## 🤔 Why is this change needed?
- In PostgresRecallFileSegmentRepo, the internal _cache_segment helper method unconditionally appended mapped RecallFileSegment rows directly to self.segments whenever records were read  
  from the database.
  
  Because self.segments is a persistent in-memory list on DatabaseState, calling list_segments() or load_existing() repeatedly (which occurs during multi-stage retrieval workflows) caused
  the exact same RecallFileSegment objects to accumulate multiple times in memory.
  
  • User Impact:
      • Causes memory leaks over time as identical segment objects accumulate in the in-memory state list on every query.
      • Distorts in-memory segment indexing/search by processing duplicate segment records.
      • Fixes a backend parity discrepancy with SQLiteRecallFileSegmentRepo, which already deduplicates segment IDs prior to caching (if not any(s.id == seg.id for s in self.segments):). 

- Link any relevant issue or discussion.

---

## 🔍 Type of Change
Please check what applies:

- [* ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (please explain)

---

## ✅ PR Quality Checklist

- [ ] PR title follows an allowed format (for example `feat:`, `fix:`, `docs:`, `memory base:`)
- [ *] Changes are limited in scope and easy to review
- [ ] Documentation updated where applicable
- [ ] No breaking changes (or clearly documented)
- [ ] Related issues or discussions linked

---

