### PR TITLE
docs: align contributor setup with current requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ We welcome all types of contributions:
 ## 🚀 Quick Start for Contributors
 
 ### Prerequisites
-- Python 3.13+
+- Python 3.11+
 - Git
 - [uv](https://github.com/astral-sh/uv) (Python package manager)
 - A code editor (VS Code recommended)
@@ -76,7 +76,7 @@ uv run python -m pytest
 uv run python -m pytest --cov --cov-config=pyproject.toml --cov-report=html
 
 # Run specific test file
-uv run python -m pytest tests/rust_entry_test.py
+uv run python -m pytest tests/test_vector.py
 
 # Run tests with specific marker
 uv run python -m pytest -m "not slow"
@@ -120,9 +120,8 @@ For feature requests, please describe:
 
 3. **Test your changes**
    ```bash
+   make check
    make test
-   make lint
-   make coverage
    ```
 
 4. **Submit pull request**

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![PyPI version](https://badge.fury.io/py/memu-cli.svg)](https://badge.fury.io/py/memu-cli)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Chat-5865F2?logo=discord&logoColor=white)](https://discord.com/invite/hQZntfGsbJ)
 [![Twitter](https://img.shields.io/badge/Twitter-Follow-1DA1F2?logo=x&logoColor=white)](https://x.com/memU_ai)
 


### PR DESCRIPTION
## 📝 Pull Request Summary

Align the contributor documentation with the current Python requirements, test layout, and available Make targets.

---

## ✅ What does this PR do?

- Updates the documented minimum Python version from 3.13 to 3.11.
- Replaces the removed `tests/rust_entry_test.py` example with `tests/test_vector.py`.
- Replaces the nonexistent `make lint` and `make coverage` commands with `make check` and `make test`.

---

## 🤔 Why is this change needed?

PR #576 lowered the minimum supported Python version to 3.11 and removed the Rust scaffolding, but the contributor documentation still reflects the previous setup.

The stale instructions can cause new contributors to use an unnecessarily restrictive Python version, reference a deleted test file, or run unavailable Make targets.

Follow-up to #576.

---

## 🔍 Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (please explain)

---

## ✅ PR Quality Checklist

- [x] PR title follows an allowed format (for example `feat:`, `fix:`, `docs:`, `memory base:`)
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable
- [x] No breaking changes (or clearly documented)
- [x] Related issues or discussions linked

---

## 🧪 Validation

- `make check`
- `make test` (`222 passed`)
- `uv run python -m pytest tests/test_vector.py` (`2 passed`)

---

## 📌 Optional

- [ ] Screenshots or examples added (if applicable)
- [x] Edge cases considered
- [ ] Follow-up tasks mentioned
