### PR TITLE
feat(config): config.env is written by a command, not by the agent (ADR 0017)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -21,19 +21,24 @@ binary, print and follow its guide.
 ## Step 1 — install the package
 
 ```
-pip install memu-cli
+pip install --upgrade memu-cli
 ```
 
 `memu-cli` is the package memU ships to bridge your agent to its long-term
 memory service; it installs helper interfaces only and is harmless to run on a
 personal machine.
 
+**Keep the `--upgrade`.** A machine that already has an older `memu-cli` would
+otherwise keep it, and the steps below name subcommands that older builds do not
+have — the symptom is `invalid choice`. If you meet that error at any point, you
+are on a stale build: upgrade, then re-run the command that failed.
+
 This puts `memu` and every host-adapter binary on `PATH`. If `pip` is not the
 right tool for this machine (managed Python, uv-only), use the equivalent —
 what matters is that the binaries below resolve from a bare, non-interactive
-shell. With uv this means `uv tool install memu-cli`, **not** `uv pip install`:
-however it is installed, `memu-cli` is a cross-session bridging tool and must
-be callable everywhere, not scoped to one project venv.
+shell. With uv this means `uv tool install --upgrade memu-cli`, **not**
+`uv pip install`: however it is installed, `memu-cli` is a cross-session
+bridging tool and must be callable everywhere, not scoped to one project venv.
 
 ## Step 2 — pick your host binary
 
@@ -62,6 +67,16 @@ It probes this machine and reports, per agent, whether **memorization** works
 instruction file exists to patch) — and it will redirect you to a dedicated
 binary if your host turns out to have one.
 
+Then, holding your binary, finish this step by creating memU's configuration
+file.
+
+```
+<your-binary> init --cloud-api-key <the user's memU key>
+```
+
+If the user does not mention an API key, or would rather keep memory on this
+device, run bare `<your-binary> init` and Step 3's guide will set up local memory.
+
 ## Step 3 — print your guide and follow it
 
 ```
@@ -69,9 +84,10 @@ binary if your host turns out to have one.
 ```
 
 Read what it prints, top to bottom, and follow it exactly. Every guide has the
-same shape — select the local or cloud backend once in `~/.memu/config.env`, register the
-scheduled bridging task (record), patch your instruction file (inject) — and
-every part ends with a **verify gate**; do not proceed past a failing one.
+same shape — settle the local or cloud backend once with `<your-binary> config`,
+register the scheduled bridging task (record), patch your instruction file
+(inject) — and every part ends with a **verify gate**; do not proceed past a
+failing one.
 
 Three rules that hold for every host:
 
@@ -82,9 +98,10 @@ Three rules that hold for every host:
   fatal error, or a *required input with no default* (the backend choice and
   its API key, or a missing credential) — treat those like the fatal case, not
   as routine confirmations to solicit.
-- **One backend.** If `~/.memu/config.env` already exists (another agent on this
-  machine is already integrated), reuse it as is. A second mode or local store
-  would split record and retrieval so the two installs no longer share memory.
+- **One backend.** If `<your-binary> config show` reports a mode with a backend
+  behind it (another agent on this machine is already integrated), reuse it as
+  is. A second mode or local store would split record and retrieval so the two
+  installs no longer share memory.
 - **Report the outcome — with the exact template below.** After installation,
   run:
 

--- a/docs/adr/0016-client-event-reporting.md
+++ b/docs/adr/0016-client-event-reporting.md
@@ -122,10 +122,12 @@ Flush points, all of them low-frequency and latency-tolerant:
 - `report uninstall` — **synchronously, before returning** (§4). Uninstall is the one event
   that cannot wait for a later flush, because `UNINSTALL.md` Part 3 may remove the very binary
   that would perform it.
-- `docs install` — which is also where `cli_install_started` is recorded (§4). A machine that
-  abandons the install never reaches `prepare` or `commit`, so this is the only flush its
-  events may ever get; the command has already contacted the docs server by then, so it costs
-  nothing new.
+- `init` and `docs install` — the two steps into the install funnel, where `cli_install_started`
+  and `install_guide_opened` are recorded (§4). A machine that abandons the install never
+  reaches `prepare` or `commit`, so these are the only flushes its events may ever get. `docs
+  install` has already contacted the docs server by then, so it costs nothing new; `init` is a
+  local command and pays one bounded, fail-open POST for being the earliest point the funnel
+  can be seen from.
 - `report error` — **synchronously, before returning** (§5), and for the same reason as
   `docs install` rather than as `report uninstall`: the runs that file an error are
   disproportionately the runs that never reach `prepare` or `commit`. A failed install, a
@@ -215,7 +217,8 @@ The dividing line is whether any code can observe the completion.
 | retrieve | `retrieval._cmd_retrieve` — one inline POST on success, spool-only on failure, never a flush (§2) |
 | remember finished | `host_cli._cmd_commit` — the terminal step of the record seam, which already holds the recall-file and resource counts |
 | `cli_error` | `host_cli.run`'s top-level `except` — see §5 |
-| `cli_install_started` | `host_cli._cmd_docs`, on `docs install` only — see below |
+| `cli_install_started` | `config_cmd._cmd_init`, after the config write — see below |
+| `install_guide_opened` | `host_cli._cmd_docs`, on `docs install` only — see below |
 
 **An explicit verb, registered once in `host_cli.build_parser` so every host inherits it:**
 
@@ -276,31 +279,50 @@ bury the rare signal inside the common one. Both stages therefore report through
 `agent_error_reported` alone, and gain a concrete event only if and when an instruction directs
 an agent to them.
 
-**Only the completion needs a verb; the start is observed.** `cli_install_started` is recorded
-by `docs install` itself, and flushed there. Printing the guide is the first act on the install
-path that *proves* `memu-cli` is installed and resolving — `SKILL.md` Step 3, immediately after
-the pip install — so the attempt can be seen without asking prose for it. The asymmetry with
-the completion is the point: `report install` is voluntary and undercounts, and a start that
-undercounted independently of it could report *more completions than attempts*, which is worse
-than no funnel at all. Taking the start in code makes `started >= completed` hold structurally,
-since the guides are only reachable through `docs install`.
+**Only the completion needs a verb; the way in is observed.** Two code-observed steps precede
+it, each flushed where it is recorded. `cli_install_started` is recorded by `init`, and
+`install_guide_opened` by `docs install`. The asymmetry with the completion is the point:
+`report install` is voluntary and undercounts, and a start that undercounted independently of
+it could report *more completions than attempts*, which is worse than no funnel at all. Taking
+both steps in code makes `started >= opened >= succeeded` hold structurally, since `SKILL.md`
+runs them in that order and the guides are reachable only through `docs install`.
 
 The `install-instruction` objection above does not carry over. It was rejected as a stand-in
-for *completion* because it also runs on re-runs and partial repairs; for a *start*, a re-run
-is a new attempt, which is the correct reading rather than a defect.
+for *completion* because it also runs on re-runs and partial repairs; for a step on the way
+*in*, a re-run is a new attempt, which is the correct reading rather than a defect.
 
-Flushing there, rather than recording only, is the load-bearing half. An install that dies in
-Part 2 never reaches `prepare` or `commit`, so without this flush its start — and every
+**Why the start sits at `init` and not at `docs install`.** It was originally at `docs install`,
+on the argument that printing the guide is the first act that *proves* `memu-cli` is installed
+and resolving. `init` (ADR 0017) is now `SKILL.md` Step 2 and proves the same thing one command
+earlier, while additionally holding the two facts the event most wants: the memU Cloud key, so
+the first envelope of an install is attributable rather than anonymous, and `MEMU_CLIENT_ID`,
+which it mints into `config.env` itself. The start is therefore emitted *after* the write —
+before it, `client_instance_id()` would find no id, generate a second one, persist it, and be
+overwritten, leaving the machine's first event reporting under an id its own config no longer
+contains. ADR 0017's open issue "where the install-start event belongs" is closed by this.
+
+`install_guide_opened` is the old emission, renamed rather than deleted: what it observes is
+unchanged and still worth a row, but it is now the funnel's *second* step, and a second name
+ending in `_started` beside the real one is the pair a consumer sums by accident. It carries no
+`cli_` prefix — the prefix marks what the client observed about *itself*, and this observes a
+document being asked for — and the gap between the two counts installs abandoned before they
+had begun.
+
+Flushing at both, rather than recording only, is the load-bearing half. An install that dies in
+Part 2 never reaches `prepare` or `commit`, so without these flushes its start — and every
 `cli_error` it accumulated on the way down — would sit in the spool until the cap ate it, and
-that run is precisely the one this event exists to make visible. The path affords a flush:
-`resolve_doc` has already blocked on a server GET by the time the guide is printed.
+that run is precisely the one these events exist to make visible. `docs install` affords a
+flush outright: `resolve_doc` has already blocked on a server GET by the time the guide is
+printed. `init` does not, and pays for it — one bounded POST on a local command, fail-open, so
+an unreachable endpoint costs the timeout rather than the write.
 
-The remaining costs are recorded rather than hidden. A guide re-printed mid-run — a compaction,
-a restarted agent — counts twice, so the start is *attempts as observed*, not distinct
-machines. A start event's `deployment_mode` predates Part 1.2's backend choice, so it is a
-default and must never be joined on. And failure *detail* still rests on an agent choosing to
-call `report error`, which is voluntary and model-judged: the funnel says that an install died,
-never why.
+The remaining costs are recorded rather than hidden. `init` is idempotent and gets re-run on
+repairs and on a second host, and a guide re-printed mid-run — a compaction, a restarted agent
+— counts twice, so both steps are *attempts as observed*, not distinct machines. A start
+event's `deployment_mode` is the mode `init` inferred, which Part 1.2's backend choice may
+still change, so it must never be joined on. And failure *detail* still rests on an agent
+choosing to call `report error`, which is voluntary and model-judged: the funnel says that an
+install died, never why.
 
 **The names on the wire**, settled with the backend and held as constants in one place so a
 later revision is one edit:
@@ -314,7 +336,8 @@ later revision is one edit:
 | `memory_commit_failed` | code | the `commit` store call raised |
 | `memory_search_succeeded` / `_failed` | code | `retrieve` |
 | `memory_list_succeeded` / `_failed` | code | a whole-store sweep — `prepare`'s mirror, or `memu list-files` |
-| `cli_install_started` | code | `docs install` printed the guide |
+| `cli_install_started` | code | `init` wrote `config.env` |
+| `install_guide_opened` | code | `docs install` printed the guide |
 | `cli_install_succeeded` | agent | `report install` |
 | `cli_install_failed` | agent | `report error --stage install` |
 | `cli_uninstall_succeeded` | agent | `report uninstall` |
@@ -325,7 +348,9 @@ later revision is one edit:
 
 The `cli_` prefix marks what the client observed about *itself* — its own install, its own
 uncaught exception, its own spool overflowing — against the `memory_` family, which reports on
-memU's actual work.
+memU's actual work. `install_guide_opened` is the one name outside both, and deliberately: it
+reports a *document* being asked for, which is neither the client's own lifecycle nor memU's
+work on memory.
 
 **One name per action and outcome, replacing `core_action_completed` and its
 `properties.action_name` discriminator.** The first writing put three actions and both outcomes
@@ -637,9 +662,10 @@ document.
   floor on install volume, not a census. The trustworthy denominator is the first `retrieve` or
   first `commit` seen from a `client_instance_id` — both code-observed — and dashboards should
   be built on those, with `cli_install_succeeded` read as a funnel signal rather than a total.
-  `cli_install_started` is code-observed and so does not share this bias, but it counts
-  attempts as observed rather than machines (§4), which makes it a numerator for "how many
-  installs finish", not a substitute denominator for "how many installs exist".
+  `cli_install_started` and `install_guide_opened` are code-observed and so do not share this
+  bias, but they count attempts as observed rather than machines (§4), which makes them
+  numerators for "how many installs finish", not substitute denominators for "how many installs
+  exist".
 - **`succeeded + failed` never equals `started`, wherever a `_failed` leg is agent-reported.**
   This holds for `cli_install_*`, `cli_uninstall_*`, and `memory_update_*` — the three families
   §4 fans an agent report out into. The `_failed` counts are a floor; the honest failure number

--- a/docs/adr/0016-client-event-reporting.md
+++ b/docs/adr/0016-client-event-reporting.md
@@ -60,11 +60,11 @@ Four facts about this codebase constrain the answer, and each one rules somethin
    body updates on the low-frequency `prepare` rather than on the per-turn hook (`host_cli.py`).
    As first written this constraint was "must never fetch", and the retrieve event was
    spool-only. **Amended:** the backend asked for that event promptly and accepted the round
-   trip, so `retrieve` now delivers *its own single envelope* inline — see §2. What the
-   amendment does not relax is the bound: a `flush()` there would drain the whole spool at one
-   POST per event, up to `MAX_FLUSH_POSTS`, which is a cost that grows with how far behind the
-   machine has fallen. One request per turn is a constant; a flush is not, and the difference is
-   the entire content of this constraint.
+   trip, so `retrieve` now delivers *its own single envelope* inline, on both its success and
+   its failure leg — see §2. What the amendment does not relax is the bound: a `flush()` there
+   would drain the whole spool at one POST per event, up to `MAX_FLUSH_POSTS`, which is a cost
+   that grows with how far behind the machine has fallen. One request per turn is a constant; a
+   flush is not, and the difference is the entire content of this constraint.
 2. **Install and uninstall are agent-driven prose, not commands.** `INSTALL.md` is a
    multi-part guide with verify gates; `UNINSTALL.md` likewise. No code path spans either, so
    no code path can *observe* that one succeeded.
@@ -122,12 +122,17 @@ Flush points, all of them low-frequency and latency-tolerant:
 - `report uninstall` — **synchronously, before returning** (§4). Uninstall is the one event
   that cannot wait for a later flush, because `UNINSTALL.md` Part 3 may remove the very binary
   that would perform it.
-- `init` and `docs install` — the two steps into the install funnel, where `cli_install_started`
-  and `install_guide_opened` are recorded (§4). A machine that abandons the install never
-  reaches `prepare` or `commit`, so these are the only flushes its events may ever get. `docs
-  install` has already contacted the docs server by then, so it costs nothing new; `init` is a
-  local command and pays one bounded, fail-open POST for being the earliest point the funnel
-  can be seen from.
+- `init`, `docs install`, and `report install` — **the whole install funnel** (§4). A machine
+  that abandons the install never reaches `prepare` or `commit`, so these are the only flushes
+  its events may ever get. `docs install` has already contacted the docs server by then, so it
+  costs nothing new; `init` is a local command and pays one bounded, fail-open POST for being
+  the earliest point the funnel can be seen from. **Amended:** `report install` was originally
+  spool-only, on the reasoning that an install which succeeded would go on to bridge and flush
+  there. That reasoning assumes the thing the event attests to. An install whose scheduled task
+  never registered still reaches `INSTALL.md`'s last step and still reports completing — and it
+  is exactly the run that never flushes, so the funnel would lose its terminal row on the
+  machines whose funnel matters most. Leaving one step of three spooled also made the
+  completion's delivery latency differ from its own siblings' for no gain a consumer could use.
 - `report error` — **synchronously, before returning** (§5), and for the same reason as
   `docs install` rather than as `report uninstall`: the runs that file an error are
   disproportionately the runs that never reach `prepare` or `commit`. A failed install, a
@@ -137,19 +142,20 @@ Flush points, all of them low-frequency and latency-tolerant:
   spent longer deciding than the POST takes, and fail-open means an unreachable endpoint costs
   the timeout, not the event, which stays spooled for the next attempt.
 - `report flush`, an explicit verb, for guides and for debugging.
-- **Not `retrieve`.** It delivers inline, but through the single-event path below rather than
-  a flush; the distinction is one POST versus all of them. See "the immediate path" below.
+- **Not `retrieve`.** It delivers inline on both legs, but through the single-event path below
+  rather than a flush; the distinction is one POST versus all of them. See "the immediate path"
+  below.
 - The CLI's top-level error handler — **except when the failing command is
   `retrieve`**. Flushing there is right for the bridging pair, where the thing that
   broke *is* the normal flush point, so waiting for it would mean waiting forever.
   It is wrong for the per-turn hook: a store the hook cannot reach fails it on
-  every turn, so the error path would put a blocking POST on the hot path once per
-  turn, precisely when the user is already broken. Caught by exercising a real
+  every turn, so a *drain* on that path would cost up to `MAX_FLUSH_POSTS` requests
+  per turn, precisely when the user is already broken. Caught by exercising a real
   install against a live endpoint, not by reasoning — constraint 1 alone does not
-  say that the error path is covered too. It still does not: the amendment to
-  constraint 1 lets a *successful* retrieve spend one POST, and deliberately leaves
-  the failing one spool-only, because "every turn" is exactly the multiplier the
-  failure path has and the success path does not.
+  say that the error path is covered too. This exemption is unchanged by the
+  amendment below: what it rules out is the unbounded drain, not reporting, and the
+  `memory_search_failed` envelope `retrieve` delivers for itself already says the
+  same thing at constant cost. Only the `cli_error` behind it waits.
 
 Mechanics, stated because they are what make a shared spool safe:
 
@@ -181,11 +187,17 @@ Two consequences are accepted rather than solved:
   spooled behind it. `occurred_at` says when each event happened and `event_id` makes a replay
   idempotent, so no consumer needs arrival order; a client that preserved it would have to
   drain the spool first, which is the cost this design exists to avoid.
-- **A failed `retrieve` still does not deliver.** The success leg reports inline; the failure
-  leg spools, for the same reason the CLI's error handler skips `retrieve` below — a store the
-  hook cannot reach fails it on *every* turn, and that is when a per-turn blocking POST is
-  least affordable. Nothing is stranded: the next successful retrieve carries the backlog out
-  ahead of its own event.
+- **A broken `retrieve` costs one POST per turn.** Both legs deliver. **Amended:** the failure
+  leg was originally spool-only, on the reasoning that a store the hook cannot reach fails it
+  on *every* turn, so that is when a per-turn blocking POST is least affordable. The reasoning
+  held for the cost and inverted the value. A machine whose retrieval is broken is the one this
+  whole feature exists to surface, and the later flush its event would wait for runs on the
+  bridging pair — which the same broken store breaks. Spooling made the least healthy machine
+  the quietest one, which is the failure mode §5 names as its motivation. So the cost is
+  accepted and named rather than avoided: a fully broken store adds up to `_TIMEOUT_SECONDS` to
+  each turn's hook until it is fixed. That is a constant, it is bounded by the timeout rather
+  than by the backlog, and it is the same constant the success leg already pays. What is *not*
+  accepted is a drain, which is why the error handler's `retrieve` exemption above stands.
 
 Note that `report uninstall` does *not* use this path — it triggers an ordinary flush inline,
 which is a spool operation, and it needs the whole spool gone rather than one event sent.
@@ -214,7 +226,7 @@ The dividing line is whether any code can observe the completion.
 
 | Event | Call site |
 | --- | --- |
-| retrieve | `retrieval._cmd_retrieve` — one inline POST on success, spool-only on failure, never a flush (§2) |
+| retrieve | `retrieval._cmd_retrieve` — one inline POST on either leg, never a flush (§2) |
 | remember finished | `host_cli._cmd_commit` — the terminal step of the record seam, which already holds the recall-file and resource counts |
 | `cli_error` | `host_cli.run`'s top-level `except` — see §5 |
 | `cli_install_started` | `config_cmd._cmd_init`, after the config write — see below |
@@ -280,8 +292,9 @@ bury the rare signal inside the common one. Both stages therefore report through
 an agent to them.
 
 **Only the completion needs a verb; the way in is observed.** Two code-observed steps precede
-it, each flushed where it is recorded. `cli_install_started` is recorded by `init`, and
-`install_guide_opened` by `docs install`. The asymmetry with the completion is the point:
+it. `cli_install_started` is recorded by `init`, and `install_guide_opened` by `docs install`.
+All three steps flush where they are recorded, so provenance is the only asymmetry left in the
+funnel and delivery is not one of them. The provenance asymmetry is the point:
 `report install` is voluntary and undercounts, and a start that undercounted independently of
 it could report *more completions than attempts*, which is worse than no funnel at all. Taking
 both steps in code makes `started >= opened >= succeeded` hold structurally, since `SKILL.md`
@@ -308,13 +321,15 @@ ending in `_started` beside the real one is the pair a consumer sums by accident
 document being asked for — and the gap between the two counts installs abandoned before they
 had begun.
 
-Flushing at both, rather than recording only, is the load-bearing half. An install that dies in
-Part 2 never reaches `prepare` or `commit`, so without these flushes its start — and every
-`cli_error` it accumulated on the way down — would sit in the spool until the cap ate it, and
-that run is precisely the one these events exist to make visible. `docs install` affords a
+Flushing at all three, rather than recording only, is the load-bearing half. An install that
+dies in Part 2 never reaches `prepare` or `commit`, so without these flushes its start — and
+every `cli_error` it accumulated on the way down — would sit in the spool until the cap ate it,
+and that run is precisely the one these events exist to make visible. `docs install` affords a
 flush outright: `resolve_doc` has already blocked on a server GET by the time the guide is
 printed. `init` does not, and pays for it — one bounded POST on a local command, fail-open, so
-an unreachable endpoint costs the timeout rather than the write.
+an unreachable endpoint costs the timeout rather than the write. `report install` was the last
+to join them, and the argument for exempting it — a completed install goes on to bridge, and
+will flush there — turned out to assume the very thing the event reports; see §2.
 
 The remaining costs are recorded rather than hidden. `init` is idempotent and gets re-run on
 repairs and on a second host, and a guide re-printed mid-run — a compaction, a restarted agent
@@ -680,14 +695,16 @@ document.
   broken, events accumulate to the cap and are then dropped. This is the correct failure — a
   broken bridging task is precisely a thing worth being unable to hide — but it means "no
   events from this install" has two causes, and reading it as "uninstalled" is wrong. Since §2,
-  a successful `retrieve` is the exception that partly covers this: it delivers its own event
-  and so keeps reporting from a machine whose bridging never runs, which also means the spool
-  reaches its cap far less often than originally expected.
-- **`retrieve` gains one blocking POST per successful turn.** Bounded to exactly one request,
-  taken after the result is already on stdout, and fail-open: an unreachable endpoint costs the
-  timeout and spools the event rather than losing it or failing the command. What must not
-  change is the *shape* — recording still neither parses nor rewrites the spool, and any future
-  work that makes it do either, or that turns this into a flush, re-opens constraint 1.
+  `retrieve` is the exception that largely covers this: it delivers its own event on either
+  leg, so a machine whose bridging never runs still reports every turn, and the spool reaches
+  its cap far less often than originally expected.
+- **`retrieve` gains one blocking POST per turn, successful or not.** Bounded to exactly one
+  request, taken after the result is already on stdout, and fail-open: an unreachable endpoint
+  costs the timeout and spools the event rather than losing it or failing the command. The
+  failure leg's share of this is the cost §2 names and accepts — a fully broken store adds the
+  timeout to every turn until it is fixed. What must not change is the *shape* — recording still
+  neither parses nor rewrites the spool, and any future work that makes it do either, or that
+  turns either leg into a flush, re-opens constraint 1.
 - **The spool is a new file under `~/.memu` that uninstall does not mention.** `UNINSTALL.md`
   Part 3 needs a line for it, and `report uninstall`'s flush should leave it empty anyway.
   It is not alone: `events.jsonl.*.sending`, the `events.dropped` counter, and §5's

--- a/docs/adr/0016-client-event-reporting.md
+++ b/docs/adr/0016-client-event-reporting.md
@@ -230,7 +230,7 @@ The dividing line is whether any code can observe the completion.
 | remember finished | `host_cli._cmd_commit` — the terminal step of the record seam, which already holds the recall-file and resource counts |
 | `cli_error` | `host_cli.run`'s top-level `except` — see §5 |
 | `cli_install_started` | `config_cmd._cmd_init`, after the config write — see below |
-| `install_guide_opened` | `host_cli._cmd_docs`, on `docs install` only — see below |
+| `install_guide_opened` / `uninstall_guide_opened` | `host_cli._cmd_docs`, on the two lifecycle guides and not on `docs task` — see below |
 
 **An explicit verb, registered once in `host_cli.build_parser` so every host inherits it:**
 
@@ -321,6 +321,15 @@ ending in `_started` beside the real one is the pair a consumer sums by accident
 document being asked for — and the gap between the two counts installs abandoned before they
 had begun.
 
+`uninstall_guide_opened` is that same observation on the way out, added later and for the gap
+rather than for symmetry. `cli_uninstall_succeeded` is agent-reported and undercounts like
+every other verb, and the removal path had no code-observed step at all to read it against, so
+an uninstall that was begun and abandoned was indistinguishable from one never begun. There is
+deliberately no `cli_uninstall_started` beside it: nothing on the way out corresponds to `init`,
+and inventing one would put a `_started` name next to this — the exact pair the rename above
+exists to avoid. `docs task` stays uninstrumented for a different reason: it is printed by a
+scheduled run rather than by anyone deciding anything, so it would count how often cron fires.
+
 Flushing at all three, rather than recording only, is the load-bearing half. An install that
 dies in Part 2 never reaches `prepare` or `commit`, so without these flushes its start — and
 every `cli_error` it accumulated on the way down — would sit in the spool until the cap ate it,
@@ -353,6 +362,7 @@ later revision is one edit:
 | `memory_list_succeeded` / `_failed` | code | a whole-store sweep — `prepare`'s mirror, or `memu list-files` |
 | `cli_install_started` | code | `init` wrote `config.env` |
 | `install_guide_opened` | code | `docs install` printed the guide |
+| `uninstall_guide_opened` | code | `docs uninstall` printed the guide |
 | `cli_install_succeeded` | agent | `report install` |
 | `cli_install_failed` | agent | `report error --stage install` |
 | `cli_uninstall_succeeded` | agent | `report uninstall` |
@@ -363,8 +373,8 @@ later revision is one edit:
 
 The `cli_` prefix marks what the client observed about *itself* — its own install, its own
 uncaught exception, its own spool overflowing — against the `memory_` family, which reports on
-memU's actual work. `install_guide_opened` is the one name outside both, and deliberately: it
-reports a *document* being asked for, which is neither the client's own lifecycle nor memU's
+memU's actual work. The `*_guide_opened` pair are the names outside both, and deliberately: they
+report a *document* being asked for, which is neither the client's own lifecycle nor memU's
 work on memory.
 
 **One name per action and outcome, replacing `core_action_completed` and its
@@ -677,10 +687,10 @@ document.
   floor on install volume, not a census. The trustworthy denominator is the first `retrieve` or
   first `commit` seen from a `client_instance_id` — both code-observed — and dashboards should
   be built on those, with `cli_install_succeeded` read as a funnel signal rather than a total.
-  `cli_install_started` and `install_guide_opened` are code-observed and so do not share this
-  bias, but they count attempts as observed rather than machines (§4), which makes them
-  numerators for "how many installs finish", not substitute denominators for "how many installs
-  exist".
+  `cli_install_started`, `install_guide_opened` and `uninstall_guide_opened` are code-observed
+  and so do not share this bias, but they count attempts as observed rather than machines (§4),
+  which makes them numerators for "how many installs finish", not substitute denominators for
+  "how many installs exist".
 - **`succeeded + failed` never equals `started`, wherever a `_failed` leg is agent-reported.**
   This holds for `cli_install_*`, `cli_uninstall_*`, and `memory_update_*` — the three families
   §4 fans an agent report out into. The `_failed` counts are a floor; the honest failure number

--- a/docs/adr/0017-config-env-as-a-command.md
+++ b/docs/adr/0017-config-env-as-a-command.md
@@ -40,11 +40,13 @@ retrieval block's text, so memU writes it; the guide's instruction is "do not
 hand-write this". `config.env` is a strictly harder file — merge semantics, a
 secret, a cross-host invariant — and has no such command.
 
-**The install-start event fires before the key exists.** `_report_install_started`
+**The install-start event fires before the key exists.** `cli_install_started`
 (ADR 0016 §4) is emitted from `docs install`, because printing the guide is the
 first act on the install path that proves `memu-cli` resolves. On a first install
 that happens in step 2, before step 3 has collected the memU Cloud key, so the
-event goes out with no `Authorization` header and lands unattributed.
+event goes out with no `Authorization` header and lands unattributed. (The
+emission has since moved into `init` — see Open issues, where that was left open
+and is now settled; `docs install` keeps its own event as `install_guide_opened`.)
 
 This second problem is **less severe than it first appears, and should not be the
 sole justification for this ADR.** Every envelope already carries
@@ -397,7 +399,9 @@ Positive:
   instead of by emphasis in a document.
 - Unrelated keys, comments, and another host's settings survive a re-install.
 - Permissions and atomicity stop depending on the agent remembering `chmod 600`.
-- The install-start event carries the key when the user had one to give.
+- The install-start event carries the key when the user had one to give — and now
+  fires from `init` itself, so it is the first event of an install rather than the
+  second, and attributed whenever `--cloud-api-key` was passed at all.
 - `MEMU_CLIENT_ID` exists before anything reports, rather than being appended by
   whichever event happened to fire first.
 - `SKILL.md`'s command surface becomes something we expect never to change.
@@ -430,18 +434,25 @@ Costs / limitations:
   is a separate question this ADR does not settle.
 - **Nothing checks the key until Part 1's gate.** Deferring verification (above)
   costs the earliest failure point: a garbled key now survives `init`, survives
-  `docs install` — whose install-start event it is attached to — and dies at
-  `doctor`, several steps and one wasted funnel event later. Accepted for now
+  `docs install`, and dies at `doctor` — several steps and one wasted funnel
+  event later, that event being the `init` start the key is attached to. Accepted for now
   because keys are copied, not typed, and because a re-`init` repairs one. When
   it is added: **before** the write, never after, for the guard-state reason
   given above, and reusing `doctor`'s call rather than inventing a second one.
-- **Where the install-start event belongs.** This ADR only reorders the existing
-  emission at `docs install`. Moving it into `init` — the first command on the
-  install path that knows both the host and the key — is defensible and would
-  make attribution unconditional, but `docs install` is the point that proves the
-  package resolves, and re-running `init` on an already-configured machine is a
-  weaker signal of "an attempt started". Left as is until the funnel data says
-  otherwise.
+- ~~**Where the install-start event belongs.**~~ **Settled: it belongs in `init`.**
+  This ADR shipped with the emission left at `docs install` and only reordered
+  relative to the write; the start has since moved into `init`, which is the first
+  command on the install path and knows both the host and the key, so attribution
+  is now unconditional rather than dependent on the user having configured cloud
+  before Step 3. The two objections were answered rather than overruled. `docs
+  install` still proves the package resolves — it keeps its own event under the
+  name `install_guide_opened`, so nothing that was observable stopped being
+  observable, and the funnel gained a step instead of trading one. And a re-run of
+  `init` being a weaker signal is the same property a re-printed guide already
+  had: both count attempts-as-observed, which §4 of ADR 0016 already said out
+  loud. The one thing the move made load-bearing is ordering *within* `init` — the
+  event must follow the write, or `client_instance_id()` mints and persists a
+  second id that the write then overwrites.
 - **Local mode's flag surface will grow.** Every new local knob is a new `config`
   flag. Acceptable while `INSTALL.md` is refreshable, but if the count keeps
   climbing, a `config set KEY=VALUE` form will be tempting — and would forfeit the

--- a/docs/adr/0017-config-env-as-a-command.md
+++ b/docs/adr/0017-config-env-as-a-command.md
@@ -342,33 +342,52 @@ same module is acceptable, but the guides name only `<your-binary>`.
 
 ### Guide changes
 
-- **`SKILL.md`** gains a Step 2.5 between binary selection and `docs install`:
-  ask the user for their memU API key, then run
+- **`SKILL.md` Step 1** installs with `pip install --upgrade memu-cli` (and
+  `uv tool install --upgrade`), because the flag is what makes the rest of this
+  ADR reachable — see the stale-build note below.
+- **`SKILL.md` Step 2** ends by running `init`, rather than gaining the "Step
+  2.5" an earlier draft of this ADR called for. Asking for the key and creating
+  the file is the *finalization* of picking a binary — you cannot run
+  `<your-binary> init` before you have `<your-binary>` — and a numbered step
+  between two numbered steps reads as an afterthought on the one surface where
+  numbering is the structure. Ask the user for their memU API key, then
   `<your-binary> init --cloud-api-key <key>`; no key → bare `<your-binary> init`.
   The prose stays minimal on purpose — everything that might change lives in the
   command's own output — with one exception it must state, because the command
   states it only *after* acting: passing a key on a machine already using local
   memory switches it to the cloud, and the local memories stop being retrieved.
 - **`INSTALL.md` §1.2** collapses from ~70 lines of write-these-keys instruction
-  to "if already configured, skip; otherwise `config --cloud|--local …`". The
-  local-mode knobs and the no-embedding-key fallback survive as guidance for
-  *choosing arguments*, not for writing the file.
-- **Preflight** gains a cheaper probe: `<binary> config show` as the one-shot "is
-  the backend configured" question, replacing the file test and the
-  `MEMU_MEMORY_MODE` grep the preflight blocks do by hand today.
+  to "`config show`; if already configured, reuse; otherwise
+  `config --cloud|--local …`". The local-mode knobs and the no-embedding-key
+  fallback survive as guidance for *choosing arguments*, not for writing the
+  file, and the "repair the connection, never the identity" paragraph becomes
+  what it always described: a `config --embed-base-url` call for the connection,
+  and a guard that refuses the identity.
+- **§1.2 also names `init`**, hedged with "if you arrived from `SKILL.md` you
+  have already run this". An agent handed the guide directly — the user pasted
+  `<binary> docs install` output, or found the file — never passes through
+  `SKILL.md`, and `init` is idempotent, so the duplicated instruction costs a
+  no-op and the missing one costs a config file.
+- **The "is the backend already configured" probe** becomes `<binary> config
+  show` — one command, no file test, no `MEMU_MEMORY_MODE` grep. It opens §1.2
+  rather than joining Claude Code's Preflight block (the only host with one):
+  that block runs *before* Part 1 and exists to find out whether `memu-*`
+  resolves at all, so a probe that needs the binary cannot live in it.
 
-There are seven guides carrying this section, not one: six hosts head it
+There are eight guides carrying this section, not one: seven hosts head it
 `### 1.2 Configure the memory backend`, the generic adapter has it as its
-`## Part 1`, and Cola states it in prose with no heading. All seven change.
+`## Part 1`, and Cola states it in prose with no heading. All eight change.
 
 **The guides ship ahead of the code they name, and must not.** `docs install`
 prefers the *server's* copy of `INSTALL.md` over the packaged one
 (`templates.resolve_doc`, ADR 0013), so the moment this text is published
 server-side every machine still on an older `memu-cli` is handed a guide telling
 it to run a subcommand its binary does not have — argparse answers `invalid
-choice` at the first step of Part 1. The server-side publish is therefore gated
-on the release that carries the commands, and the new §1.2 keeps a line pointing
-an agent that hits that error at upgrading `memu-cli`.
+choice` at the first step of Part 1. Three things answer this, and the first two
+are the real fix: the install step in every guide carries `--upgrade`, so the
+ordinary path never *has* a stale binary; every guide names `invalid choice`
+explicitly as the stale-build symptom with "upgrade and re-run" as the cure; and
+the server-side publish is still gated on the release that carries the commands.
 
 ## Consequences
 

--- a/docs/adr/0017-config-env-as-a-command.md
+++ b/docs/adr/0017-config-env-as-a-command.md
@@ -78,9 +78,10 @@ function whose guard policy is a parameter. `init` is the inferring front door;
                         [--embed-base-url URL] [--embed-model M] [--force]
 ```
 
-`--force` is on `config` only. `init` has none, by construction: it is the verb
-that *infers*, so an inference it cannot justify must hand the decision back
-rather than offer a way to override a guard the caller never saw.
+`--force` is on `config` only, and `init` needs none: it never refuses, so there
+is nothing to override. That is not a weaker contract than `config`'s but a
+different one, and the reason is where each verb sits — see "`init` never
+refuses" below.
 
 The split is not cosmetic — the two verbs have different *policies*, and the
 place each is named is the reason:
@@ -100,16 +101,43 @@ place each is named is the reason:
 Zero or one flag, idempotent, safe to run on any machine in any state:
 
 - `init --cloud-api-key K` — the user provided a key, which *is* the choice of
-  cloud. Sets `MEMU_MEMORY_MODE=cloud` and persists the key.
+  cloud. Sets `MEMU_MEMORY_MODE=cloud` and persists the key, whatever the file
+  said before.
 - `init` — no key offered. If the file already declares `MEMU_MEMORY_MODE`,
   **keep it**: a re-install where the user did not re-supply a key must not flip
   cloud to local. If absent, set `local`.
 - In every case, generate and persist `MEMU_CLIENT_ID` if missing.
 
-Bare `init` cannot refuse — every branch it takes either keeps what is there or
-fills a vacuum. Only `init --cloud-api-key` can, and only on the one case the
-inference rules do not cover (below), where it prints the `config … --force` to
-run instead of offering a flag of its own.
+#### `init` never refuses
+
+Not "rarely" — never. Bare `init` has nothing to refuse *on*: every branch it
+takes either keeps what is there or fills a vacuum. `init --cloud-api-key` on a
+machine already configured for local with `MEMU_DB` set is the one case that
+looks like it should, and it does not either. Three reasons, in order of weight:
+
+- **A refusal there is terminal.** `init` has no `--force`, and it is the *first*
+  command on the install path — the one `SKILL.md` names before `docs install`.
+  Exiting non-zero does not redirect the agent to a better command so much as
+  stop the install, and every step after it, on a machine whose user has just
+  handed over their key.
+- **The signal is unambiguous.** Having a memU Cloud key in hand and passing it
+  is about as explicit as intent gets at this point in the flow. Treating it as
+  something the caller might not have meant reads the situation wrong.
+- **Nothing is destroyed.** The local store is not touched: `MEMU_DB` stays in
+  the file and the rows stay in the database, unread until the mode is switched
+  back with `config --local --force`. What the flip costs is that memories
+  written locally stop being retrieved, and new ones go to the key's cloud
+  account instead — real, reversible, and exactly the kind of consequence a
+  warning is for.
+
+So `init` says it, loudly, and proceeds: a `switched` row beside the mode, and a
+fuller `warning:` on stderr naming what happened and the command that undoes it.
+The guides carry the same consequence in prose where they ask for the key.
+
+This is the one place `init` and `config` are allowed to disagree about the same
+state test, and the asymmetry is the point: `config`'s caller named a backend and
+can be handed `--force`, so refusing them costs one re-run. `init`'s caller has
+no such second move.
 
 Writing `MEMU_MEMORY_MODE=local` explicitly, rather than relying on
 `memory_mode()`'s compatibility default, also retires the ambiguity `INSTALL.md`
@@ -154,7 +182,8 @@ flip. Once written, an *inferred* default is indistinguishable from a *chosen*
 one, and a declaration-based guard can only see the file.
 
 What the invariant actually protects is existing memory, not a string. So a mode
-change is refused only when the current mode has something to lose:
+change is refused only when the current mode has something to lose — and only on
+`config`, which is the verb that can offer the override:
 
 | Current state | `config --<other-mode>` |
 | --- | --- |
@@ -196,10 +225,10 @@ from prose into a gate.
 Two cases the inference rules do not cover on their own, settled here:
 
 - **`init --cloud-api-key K` when the file says `local`.** This is a mode flip by
-  inference. The state-based guard decides it: a vacuous local config flips
-  silently; a local config with `MEMU_DB` set refuses and prints the explicit
-  `config --cloud --cloud-api-key K --force` to run instead. That printed command
-  is what `init` has in place of a `--force` of its own.
+  inference, and `init` makes it in every case: a vacuous local config flips
+  silently, a local config with `MEMU_DB` set flips with the warning described
+  under "`init` never refuses". The same state test still decides *whether to
+  warn*; it just does not decide whether to act.
 - **`init --cloud-api-key K2` when `K1` is stored.** Replace it, and say so
   loudly ("replacing the stored memU Cloud key"). Refusing would block the
   legitimate rotated-key repair, and the client cannot distinguish a rotation
@@ -293,8 +322,11 @@ pointer that `docs install` will guide the rest. On Windows the `config` line
 reads `…\.memu\config.env (plaintext key; Windows ACLs inherited)` — see File
 mechanics.
 
-A refusal prints the same shape: what is on disk, why it is protected, and the
-exact `config … --force` to run if the change was meant.
+A `config` refusal prints the same shape: what is on disk, why it is protected,
+and the exact `config … --force` to run if the change was meant. An `init` that
+flipped a machine off a configured local store prints that shape too — a
+`switched` row in the block, then the consequence and the `config --local
+--force` that reverses it — but exits `0`, because it did the thing.
 
 ### On the host binaries, not `memu`
 
@@ -314,7 +346,9 @@ same module is acceptable, but the guides name only `<your-binary>`.
   ask the user for their memU API key, then run
   `<your-binary> init --cloud-api-key <key>`; no key → bare `<your-binary> init`.
   The prose stays minimal on purpose — everything that might change lives in the
-  command's own output.
+  command's own output — with one exception it must state, because the command
+  states it only *after* acting: passing a key on a machine already using local
+  memory switches it to the cloud, and the local memories stop being retrieved.
 - **`INSTALL.md` §1.2** collapses from ~70 lines of write-these-keys instruction
   to "if already configured, skip; otherwise `config --cloud|--local …`". The
   local-mode knobs and the no-embedding-key fallback survive as guidance for
@@ -358,6 +392,13 @@ Costs / limitations:
   exposed — but see Open issues.
 - One more command in a flow whose main failure mode is agents skipping steps.
   `init` is idempotent and cheap, which is the mitigation, not a guarantee.
+- `init --cloud-api-key` can strand a local store behind a warning nobody read.
+  This is the deliberate trade in "`init` never refuses", and it is the one place
+  where the safer behaviour was traded away for a flow that completes. The store
+  survives and one `config --local --force` restores it, so the cost is confusion
+  and a stretch of unretrieved memories rather than data loss — but the warning
+  is all that stands between the two, and warnings are read less often than exit
+  codes are.
 
 ## Open issues
 

--- a/docs/adr/0017-config-env-as-a-command.md
+++ b/docs/adr/0017-config-env-as-a-command.md
@@ -1,0 +1,396 @@
+ADR 0017: `config.env` Is Written by a Command, Not by the Agent — `init` for the Entry, `config` for the Detail
+
+- Status: Proposed
+- Date: 2026-08-05
+- Builds on: ADR 0009 (the CLI seam and one config loader), ADR 0010 (multi-host
+  adapters, one shared parser from a `HostSpec`), ADR 0012 (cloud/local backend
+  selection, config in `~/.memu`), ADR 0013 (server-refreshable agent-facing
+  docs), ADR 0016 (client event reporting, the install funnel)
+- Scope: who writes `~/.memu/config.env` during an install, and through what
+  command surface. It changes neither seam's behaviour, the store, the schema of
+  the file, nor `env.py`'s resolution order — only the mechanism that produces
+  the file and the two guides that drive it.
+
+## Context
+
+The install pipeline has three steps today:
+
+1. `SKILL.md` — the entry document. Tells the agent to `pip install memu-cli`
+   and pick its host binary.
+2. `<binary> docs install` — prints the packaged, server-refreshable guide.
+3. `INSTALL.md` — the guide, followed top to bottom.
+
+`~/.memu/config.env` is created in step 3, by the agent, from prose. Two
+problems follow from that placement.
+
+**The file is written by hand.** `INSTALL.md` §1.2 tells the agent which keys to
+write and the agent writes them, typically with a heredoc or `echo >>`. That file
+is shared across every host on the machine, carries a plaintext credential, and
+holds an invariant the guide can only state in words: record and inject must
+agree on the backend, and in local mode on the DSN and embedding space too, or
+retrieval silently returns nothing (ADR 0009's opening argument). The guide
+already spends a paragraph on "repair the connection, never the identity" —
+`MEMU_DB`, `MEMU_EMBED_PROVIDER`, `MEMU_EMBED_MODEL` must never be edited on an
+existing store — and enforces it with nothing but emphasis. Field behaviour
+matches the exposure: agents occasionally rewrite the file rather than merge into
+it, taking unrelated keys with them.
+
+This is the same argument that produced `install-instruction`. memU owns the
+retrieval block's text, so memU writes it; the guide's instruction is "do not
+hand-write this". `config.env` is a strictly harder file — merge semantics, a
+secret, a cross-host invariant — and has no such command.
+
+**The install-start event fires before the key exists.** `_report_install_started`
+(ADR 0016 §4) is emitted from `docs install`, because printing the guide is the
+first act on the install path that proves `memu-cli` resolves. On a first install
+that happens in step 2, before step 3 has collected the memU Cloud key, so the
+event goes out with no `Authorization` header and lands unattributed.
+
+This second problem is **less severe than it first appears, and should not be the
+sole justification for this ADR.** Every envelope already carries
+`client_instance_id`, and `client_instance_id()` generates *and persists* the id
+into `config.env` on first use — so the unattributed start already carries a
+stable id that every later authenticated event on that machine reuses. The
+backend can join anonymous → account on it retroactively. What ordering fixes is
+attribution *at emission* — and it is what would let a later release fail fast on
+a wrong key, which this one does not attempt (see Open issues).
+
+The obvious alternative for the ordering — spool the start event without flushing
+and let a later flush attach the key — is rejected: the flush at `docs install`
+exists precisely so an install that dies in Part 2 still reports its start, and
+those are the runs the event was added for.
+
+## Decision
+
+### Two verbs over one writer
+
+`<binary> init` and `<binary> config`, registered on the shared host parser
+(`host_cli.build_parser`) so every host adapter gets both, backed by **one** merge
+function whose guard policy is a parameter. `init` is the inferring front door;
+`config` is the explicit one. They must not each own a code path for
+`MEMU_CLOUD_API_KEY`, or the two will drift within a release.
+
+```
+<binary> init [--cloud-api-key K]                    # entry; named in SKILL.md
+<binary> config show                                 # read-only; the preflight probe
+<binary> config --cloud [--cloud-api-key K] [--cloud-base-url URL] [--force]
+<binary> config --local [--db PATH] [--embed-provider P] [--embed-api-key K]
+                        [--embed-base-url URL] [--embed-model M] [--force]
+```
+
+`--force` is on `config` only. `init` has none, by construction: it is the verb
+that *infers*, so an inference it cannot justify must hand the decision back
+rather than offer a way to override a guard the caller never saw.
+
+The split is not cosmetic — the two verbs have different *policies*, and the
+place each is named is the reason:
+
+- `SKILL.md` is the least updatable surface memU has. It ships to users, is
+  pasted into repos, and — unlike `INSTALL.md` — does not go through
+  `templates.resolve_doc`, so it cannot be refreshed from the server (ADR 0013).
+  Anything named there needs a contract expected to hold for years. `init` with
+  at most one flag is that. A verb whose flag surface grows every time local mode
+  gains a knob is not.
+- `INSTALL.md` *is* server-refreshable, so `config`'s flag surface can evolve at
+  the server's pace.
+- Folding both into one verb is what produces the trap in the next section.
+
+### `init` — infers, and hands back what it cannot infer
+
+Zero or one flag, idempotent, safe to run on any machine in any state:
+
+- `init --cloud-api-key K` — the user provided a key, which *is* the choice of
+  cloud. Sets `MEMU_MEMORY_MODE=cloud` and persists the key.
+- `init` — no key offered. If the file already declares `MEMU_MEMORY_MODE`,
+  **keep it**: a re-install where the user did not re-supply a key must not flip
+  cloud to local. If absent, set `local`.
+- In every case, generate and persist `MEMU_CLIENT_ID` if missing.
+
+Bare `init` cannot refuse — every branch it takes either keeps what is there or
+fills a vacuum. Only `init --cloud-api-key` can, and only on the one case the
+inference rules do not cover (below), where it prints the `config … --force` to
+run instead of offering a flag of its own.
+
+Writing `MEMU_MEMORY_MODE=local` explicitly, rather than relying on
+`memory_mode()`'s compatibility default, also retires the ambiguity `INSTALL.md`
+currently has to explain in prose ("an existing file without `MEMU_MEMORY_MODE`
+is local mode for backward compatibility"). It is safe to write into a file that
+was silent on the question — including one carrying a `MEMU_CLOUD_API_KEY`,
+which looks like a cloud install being demoted but is not: `memory_mode()`
+already resolves that file to local today, so `init` records the mode the machine
+was already in rather than changing it.
+
+### `config` — explicit, and refuses ambiguity
+
+`--cloud` or `--local` is **mandatory** to touch `MEMU_MEMORY_MODE`. This is the
+verb `INSTALL.md` §1.2 drives once the user has actually chosen a backend, and
+the only verb that configures the local-mode knobs.
+
+`config --local` with no `--db` is **allowed**, and writes the mode alone. The
+alternative — requiring `--db` whenever none is set — would put the refusal in
+the wrong place: this verb runs inside `INSTALL.md`, where the agent is already
+in a conversation with the user about the store and can ask. A mode with no
+store fails the Part 1 verify gate loudly, which is the right amount of
+enforcement for a value only the user can supply.
+
+### `config show` — the read side, and the preflight probe
+
+Prints the resolved mode and the keys that are set (never their values, beyond
+`set`/`unset` for anything credential-shaped), and writes nothing. This is the
+"is the backend already configured" question that `INSTALL.md`'s preflight and
+§1.2's opening `if already configured, skip` both ask, and it is why the read
+side is a *named* subcommand: a bare `config` that printed while a bare `init`
+wrote is exactly the asymmetry agents get wrong.
+
+### The one-backend guard is state-based, not declaration-based
+
+This is the load-bearing decision, and without it the whole design has a hole.
+
+If `MEMU_MEMORY_MODE` were an identity key guarded on declaration alone, the most
+ordinary first install breaks: the agent runs bare `init` in step 2.5 (the user
+had not found their key yet), `local` lands on disk, the guide then asks the
+backend question, the user says cloud — and `config --cloud` is refused as a mode
+flip. Once written, an *inferred* default is indistinguishable from a *chosen*
+one, and a declaration-based guard can only see the file.
+
+What the invariant actually protects is existing memory, not a string. So a mode
+change is refused only when the current mode has something to lose:
+
+| Current state | `config --<other-mode>` |
+| --- | --- |
+| `local`, `MEMU_DB` set | refuse without `--force` |
+| `cloud`, `MEMU_CLOUD_API_KEY` present | refuse without `--force` |
+| anything else (a vacuous declaration) | change it silently — this is the first real choice |
+
+**"Has something to lose" is judged by declaration of the store, not by the
+store's contents.** `MEMU_DB` being set is enough; whether the file exists, or
+holds one memory or ten thousand, is not asked. `MEMU_DB` spans a bare path, a
+`sqlite://` URL, a `postgres://` DSN and the in-memory sentinel
+(`env.database_config`), so "the store exists" has no single cheap meaning —
+and the one shape where it is cheap, a local SQLite file, is also the shape
+where `database_config` *creates the parent directory as a side effect* of
+being asked. A guard that mutates the filesystem to answer a question is worse
+than a guard that over-refuses, and over-refusing costs one `--force` on a path
+where the agent is already talking to the user.
+
+**The state the guard reads is the file, never the resolved environment.** Every
+other consumer in this codebase asks `env.env()`, which consults `os.environ`
+first — correct for *resolving* config, wrong for *deciding what is on disk*. An
+exported `MEMU_CLOUD_API_KEY` in the calling shell would otherwise make
+`config --local` refuse a file that never declared anything, and `init`'s
+"already set, keep it" would preserve a mode nobody ever wrote. So the writer and
+the guard take the parsed dotenv as their only input, and the process
+environment reaches neither.
+
+`MEMU_DB`, `MEMU_EMBED_PROVIDER` and `MEMU_EMBED_MODEL` keep an *unconditional*
+guard: those three bind an embedding space that already has vectors in it, and
+"fixing" one silently strands every existing vector. Unconditional means no state
+test, not no escape — `--force` still overrides, and must, because the
+alternative to a supported override is the user hand-editing the file, which is
+the thing this ADR exists to stop. Setting one of the three where none was set is
+not a change and needs nothing. Connection-level keys
+(`MEMU_CLOUD_BASE_URL`, `MEMU_BASE_URL`, `NO_PROXY`) are freely updatable — this
+is the guide's existing "repair the connection, never the identity" rule, moved
+from prose into a gate.
+
+Two cases the inference rules do not cover on their own, settled here:
+
+- **`init --cloud-api-key K` when the file says `local`.** This is a mode flip by
+  inference. The state-based guard decides it: a vacuous local config flips
+  silently; a local config with `MEMU_DB` set refuses and prints the explicit
+  `config --cloud --cloud-api-key K --force` to run instead. That printed command
+  is what `init` has in place of a `--force` of its own.
+- **`init --cloud-api-key K2` when `K1` is stored.** Replace it, and say so
+  loudly ("replacing the stored memU Cloud key"). Refusing would block the
+  legitimate rotated-key repair, and the client cannot distinguish a rotation
+  from a different account. Announcing it is the honest middle.
+
+### File mechanics
+
+Merge, never rewrite. Parse the existing file, set only the named keys, leave
+every other line and comment byte-identical, write to a temp file and
+`os.replace`, `mkdir(0700)` the directory and `chmod 600` the file, then
+`env.reload()`.
+
+**One writer, for every key — including `MEMU_CLIENT_ID`.** `events.client_instance_id()`
+already writes that key today, by appending to the file with no atomicity and no
+permissions, and deliberately re-reading afterwards so two racing first runs
+converge. Left alone it becomes a second mechanism for the same file, and a
+worse interaction than duplication: this section's read-modify-write plus
+`os.replace` *silently discards* a concurrent append. So `client_instance_id()`
+moves onto this writer, keeping the two properties it was built with — it
+swallows `OSError` and still returns an id, and it re-reads rather than trusting
+what it wrote. That places the writer where `events` can import it without
+reaching into `memu.hosts`.
+
+**Permissions are reported as what actually happened.** `chmod 600` restricts
+nothing on Windows — `os.chmod` there moves the read-only bit and no ACL — so
+claiming it on that platform would replace an instruction the agent might follow
+(today's guides say to restrict the file to the current user) with a line
+asserting a protection that does not exist. POSIX chmods and says so; Windows
+says the file holds a plaintext key and that its ACLs are inherited. Doing the
+real thing there means shelling out to `icacls`, which is a subprocess and a new
+failure mode on the install path; not worth it for a claim, and the honest line
+leaves the door open to adding it later.
+
+**Do not persist defaults.** `MEMU_CLOUD_BASE_URL` is written only when it
+differs from `DEFAULT_CLOUD_BASE_URL`; baking today's default into the file
+freezes a value the code should own across upgrades. Note also that
+`MEMU_BASE_URL` is the *embedding* endpoint (local mode) and has no role in cloud
+configuration — the two are easy to conflate.
+
+### Flag naming follows the variable
+
+`--cloud-api-key`, not `--api-key`. The codebase deliberately separates
+`MEMU_CLOUD_API_KEY` (memU Cloud) from `MEMU_API_KEY` (the embedding provider),
+and `INSTALL.md` has to warn against confusing them. A bare `--api-key` re-opens
+that door on the one surface meant to close it. Local mode's embedding credential
+is `--embed-api-key` for the same reason.
+
+### Neither verb verifies — `doctor` stays the only prover
+
+`init` and `config` report what is *declared*. `doctor` remains the only command
+that proves the backend answers, and Part 1's verify gate remains where a wrong
+key is caught.
+
+Verifying the key inside `init --cloud-api-key` was considered and deferred (see
+Open issues). Two reasons. The key is usually pasted from memU's own website
+alongside the install instruction, so a *wrong* key is a rarer failure than the
+design was weighting it as; and where an agent does garble one, the recovery is
+already specified — a later `init --cloud-api-key K2` replaces it loudly.
+
+The ordering argument is worth stating precisely, because it is what makes
+deferring safe: verification must run **before** the write, not after. A
+write-then-verify `init` leaves `cloud` plus a bad key on disk when it fails,
+and that is exactly the state the guard table reads as "cloud, key present —
+refuse without `--force`". The user who then abandons cloud and asks for local
+hits a refusal on the most ordinary first install, which is the failure the
+state-based guard exists to eliminate. Nothing needs to be on disk to verify —
+the cloud client takes its base URL and key as arguments — so whenever
+verification is added, it is added ahead of the write.
+
+### Refusals are an exit code, not an exception
+
+A guard refusal returns a distinct non-zero status (`2`, as `prepare` already
+uses for a missing session log) from the handler. It must not raise: `host_cli.run`
+catches exceptions into `record_cli_error` and flushes, which would file every
+ordinary "you meant `--force`" into the error feed as if memU had broken.
+
+### Output is the agent's next-step signal
+
+Decisive lines, not a diff:
+
+```
+mode      cloud (from --cloud-api-key)
+key       set
+client    a1b2… (generated)
+config    ~/.memu/config.env (chmod 600)
+ready — continue with `memu-claude-code docs install`
+```
+
+and for the bare case, `mode local (default; no store configured yet)` plus a
+pointer that `docs install` will guide the rest. On Windows the `config` line
+reads `…\.memu\config.env (plaintext key; Windows ACLs inherited)` — see File
+mechanics.
+
+A refusal prints the same shape: what is on disk, why it is protected, and the
+exact `config … --force` to run if the change was meant.
+
+### On the host binaries, not `memu`
+
+`memu` is the algorithmically correct home — `config.env` is host-irrelevant, and
+ADR 0009 makes `memu` the algorithm surface with the adapters as sidecars. It is
+nonetheless the wrong choice here. The install flow's ergonomic bet is that
+`SKILL.md` Step 2 hands the agent exactly *one* binary name and every later step
+is `<your-binary> …`; a second binary mid-flow adds a branch, a fresh
+"command not found" mode, and a name far likelier to be shadowed on `PATH` than
+`memu-claude-code` is. `doctor` is already just as host-irrelevant in substance
+and lives on the host binaries for this reason. A thin `memu init` alias over the
+same module is acceptable, but the guides name only `<your-binary>`.
+
+### Guide changes
+
+- **`SKILL.md`** gains a Step 2.5 between binary selection and `docs install`:
+  ask the user for their memU API key, then run
+  `<your-binary> init --cloud-api-key <key>`; no key → bare `<your-binary> init`.
+  The prose stays minimal on purpose — everything that might change lives in the
+  command's own output.
+- **`INSTALL.md` §1.2** collapses from ~70 lines of write-these-keys instruction
+  to "if already configured, skip; otherwise `config --cloud|--local …`". The
+  local-mode knobs and the no-embedding-key fallback survive as guidance for
+  *choosing arguments*, not for writing the file.
+- **Preflight** gains a cheaper probe: `<binary> config show` as the one-shot "is
+  the backend configured" question, replacing the file test and the
+  `MEMU_MEMORY_MODE` grep the preflight blocks do by hand today.
+
+There are seven guides carrying this section, not one: six hosts head it
+`### 1.2 Configure the memory backend`, the generic adapter has it as its
+`## Part 1`, and Cola states it in prose with no heading. All seven change.
+
+**The guides ship ahead of the code they name, and must not.** `docs install`
+prefers the *server's* copy of `INSTALL.md` over the packaged one
+(`templates.resolve_doc`, ADR 0013), so the moment this text is published
+server-side every machine still on an older `memu-cli` is handed a guide telling
+it to run a subcommand its binary does not have — argparse answers `invalid
+choice` at the first step of Part 1. The server-side publish is therefore gated
+on the release that carries the commands, and the new §1.2 keeps a line pointing
+an agent that hits that error at upgrading `memu-cli`.
+
+## Consequences
+
+Positive:
+
+- The cross-host invariant is enforced by code on the one file that carries it,
+  instead of by emphasis in a document.
+- Unrelated keys, comments, and another host's settings survive a re-install.
+- Permissions and atomicity stop depending on the agent remembering `chmod 600`.
+- The install-start event carries the key when the user had one to give.
+- `MEMU_CLIENT_ID` exists before anything reports, rather than being appended by
+  whichever event happened to fire first.
+- `SKILL.md`'s command surface becomes something we expect never to change.
+
+Costs / limitations:
+
+- Two more verbs on every host binary, and a required-input prompt (the backend
+  choice) moves into `SKILL.md` — the surface we cannot refresh from the server.
+- The key lands in `argv`, so it is visible to `ps`, shell history, and the
+  session transcript. Not a regression — the heredoc it replaces is equally
+  exposed — but see Open issues.
+- One more command in a flow whose main failure mode is agents skipping steps.
+  `init` is idempotent and cheap, which is the mitigation, not a guarantee.
+
+## Open issues
+
+- **The credential is in `argv`, and memU mines transcripts.** The record seam
+  reads the very session log that will contain `init --cloud-api-key sk-…`.
+  Accepting `MEMU_CLOUD_API_KEY` from the process environment, and
+  `--cloud-api-key -` to read one line from stdin, are both cheap to add; agents
+  are unreliable with stdin, so the flag stays primary. Whether the bridging
+  pipeline should additionally redact key-shaped strings from mined transcripts
+  is a separate question this ADR does not settle.
+- **Nothing checks the key until Part 1's gate.** Deferring verification (above)
+  costs the earliest failure point: a garbled key now survives `init`, survives
+  `docs install` — whose install-start event it is attached to — and dies at
+  `doctor`, several steps and one wasted funnel event later. Accepted for now
+  because keys are copied, not typed, and because a re-`init` repairs one. When
+  it is added: **before** the write, never after, for the guard-state reason
+  given above, and reusing `doctor`'s call rather than inventing a second one.
+- **Where the install-start event belongs.** This ADR only reorders the existing
+  emission at `docs install`. Moving it into `init` — the first command on the
+  install path that knows both the host and the key — is defensible and would
+  make attribution unconditional, but `docs install` is the point that proves the
+  package resolves, and re-running `init` on an already-configured machine is a
+  weaker signal of "an attempt started". Left as is until the funnel data says
+  otherwise.
+- **Local mode's flag surface will grow.** Every new local knob is a new `config`
+  flag. Acceptable while `INSTALL.md` is refreshable, but if the count keeps
+  climbing, a `config set KEY=VALUE` form will be tempting — and would forfeit the
+  identity-key guard, which is the reason for named flags.
+
+## Out of scope
+
+- The schema of `config.env` or `env.py`'s resolution order (ADR 0009/0012).
+- Anything the guides *say* about choosing a backend — only who writes the result.
+- The bridging pipeline, the instruction seam, and `install-instruction`.
+- The event envelope and transport (ADR 0016); this ADR only changes when one
+  event is emitted relative to the config being written.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,3 +16,4 @@
 - [0014: Paginated `list_all_recall_files`](0014-paginated-list-all-recall-files.md)
 - [0015: The Bridging Run Must Not Mine Itself — Identity from the Host, Gate from the Launch](0015-bridging-must-not-mine-its-own-run.md)
 - [0016: Client Event Reporting — One Envelope, a Spool by Default, Bounded Payloads](0016-client-event-reporting.md)
+- [0017: `config.env` Is Written by a Command — `init` for the Entry, `config` for the Detail](0017-config-env-as-a-command.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,12 @@ disable_error_code = ["attr-defined", "call-arg"]
 module = ["pgvector.*"]
 ignore_missing_imports = true
 
+[tool.deptry.per_rule_ignores]
+# memu.trust imports certifi only as a fallback, inside a try/except that
+# degrades when it is absent — so it is deliberately a transitive dependency
+# (via httpx) rather than one this package declares and would then require.
+DEP003 = ["certifi"]
+
 [tool.ruff]
 target-version = "py311"
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memu-cli"
-version = "2.0.0-beta.0"
+version = "0.11.0-beta.0"
 authors = [
     {name = "MemU Team", email = "contact@nevamind.ai"},
 ]

--- a/src/memu/config_file.py
+++ b/src/memu/config_file.py
@@ -1,0 +1,165 @@
+"""Writing ``~/.memu/config.env`` — the one file every host shares (ADR 0017).
+
+:mod:`memu.env` reads this file; this module is the only thing that writes it.
+The asymmetry is deliberate and the reason is the file itself: it is shared by
+every host on the machine, it carries a plaintext credential, and it holds an
+invariant no single host can see — record and inject must agree on the backend,
+or retrieval silently returns nothing (ADR 0009). A file with those properties
+should not be produced by an agent following prose, and should not have two
+producers inside memU either.
+
+Three rules, and every caller gets all three for free:
+
+* **Merge, never rewrite.** Only the named keys change. Every other line —
+  another host's settings, the user's comments, a key this release has never
+  heard of — survives byte-identical. The one exception is a missing final
+  newline, which is added.
+* **Atomic.** The new text lands in a temp file beside the target and replaces
+  it with :func:`os.replace`, so a crash or a full disk leaves the old file
+  intact rather than a half-written one that no longer parses.
+* **Restricted.** ``0700`` on the directory it creates, ``0600`` on the file.
+
+The read side here is *not* :func:`memu.env.env`, and that difference is
+load-bearing rather than incidental. ``env()`` resolves the process environment
+first, which is right for answering "what is this run configured with" and wrong
+for answering "what does the file say" — the only question a writer and its
+guards may ask. An exported ``MEMU_CLOUD_API_KEY`` must not make a *file* that
+declares nothing look like a configured cloud install.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+
+from memu.env import CONFIG_ENV
+
+
+def config_path() -> Path:
+    """The config file this process reads and writes.
+
+    ``MEMU_CONFIG_ENV`` is read from :data:`os.environ` alone, never through
+    :func:`memu.env.env`: it names the file, so resolving it *from* that file
+    would be circular.
+    """
+    return Path(os.path.expanduser(os.environ.get("MEMU_CONFIG_ENV", CONFIG_ENV)))
+
+
+def read() -> dict[str, str]:
+    """Parse the file. Uncached, and blind to the process environment.
+
+    Deliberately not :func:`memu.env.env`. See the module docstring: this answers
+    what is *on disk*, which is the only input a guard about existing memory may
+    take. Parsing matches :func:`memu.env._file_values` — last assignment wins,
+    surrounding quotes stripped — so what a guard sees and what a later run
+    resolves cannot disagree.
+    """
+    try:
+        text = config_path().read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    values: dict[str, str] = {}
+    for raw in text.splitlines():
+        key, value = _split(raw)
+        if key:
+            values[key] = value.strip().strip("\"'")
+    return values
+
+
+def write_values(updates: Mapping[str, str]) -> tuple[Path, bool]:
+    """Merge ``updates`` into the file. Returns its path and whether it changed.
+
+    Raises :class:`OSError` rather than swallowing one — every caller here has a
+    user in front of it and a better answer than silence. :func:`memu.events.client_instance_id`
+    is the exception and catches it itself, because telemetry may never fail a
+    command.
+
+    Called with nothing to set, this still enforces the permissions on an existing
+    file, which is the cheap half of what it exists for.
+    """
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        text = ""
+    merged = _merged(text, dict(updates))
+    if merged == text and path.is_file():
+        _restrict(path)
+        return path, False
+
+    # Same directory, so the replace is a rename within one filesystem — the
+    # property the atomicity claim rests on. mkstemp already creates at 0600;
+    # _restrict is belt-and-braces for the umask-independent guarantee.
+    handle_fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=".config.env.")
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+            handle.write(merged)
+        _restrict(tmp)
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+        raise
+    return path, True
+
+
+def permission_note() -> str:
+    """What a command may truthfully claim it did to the file's permissions.
+
+    ``chmod 600`` restricts nothing on Windows — :func:`os.chmod` there moves the
+    read-only bit and touches no ACL — so a command that printed it anyway would
+    replace a real instruction (today's guides tell the agent to restrict the file
+    to the current user) with an assertion of protection that does not exist.
+    Doing the real thing means shelling out to ``icacls``: a subprocess and a new
+    failure mode on the install path, not worth it for a claim. So Windows says
+    what is actually true instead.
+    """
+    return "chmod 600" if os.name == "posix" else "plaintext key; Windows ACLs inherited"
+
+
+def _split(raw: str) -> tuple[str, str]:
+    """``KEY``, ``value`` for an assignment line; ``""``, ``""`` for anything else."""
+    line = raw.strip()
+    if not line or line.startswith("#"):
+        return "", ""
+    key, sep, value = line.partition("=")
+    if not sep:
+        return "", ""
+    return key.strip(), value
+
+
+def _merged(text: str, updates: dict[str, str]) -> str:
+    """``text`` with ``updates`` applied in place, everything else untouched.
+
+    A key already present is rewritten *where it is*, so it keeps its position
+    next to whatever comment explains it. A key present more than once — two
+    first runs racing to append ``MEMU_CLIENT_ID`` is the real case — has every
+    occurrence rewritten rather than one: the parser takes the last assignment,
+    so leaving an earlier one behind would preserve a value that no longer
+    resolves and confuse the next human to open the file.
+    """
+    lines = text.splitlines()
+    written: set[str] = set()
+    out: list[str] = []
+    for raw in lines:
+        key, _ = _split(raw)
+        if key and key in updates:
+            out.append(f"{key}={updates[key]}")
+            written.add(key)
+        else:
+            out.append(raw)
+    out.extend(f"{key}={value}" for key, value in updates.items() if key not in written)
+    return "".join(f"{line}\n" for line in out)
+
+
+def _restrict(path: Path) -> None:
+    """Owner-only, where that means something. See :func:`permission_note`."""
+    if os.name != "posix":
+        return
+    with contextlib.suppress(OSError):
+        path.chmod(0o600)

--- a/src/memu/events.py
+++ b/src/memu/events.py
@@ -115,18 +115,43 @@ the agent never reached ``commit``, or its self-evolve pass produced nothing. So
 is what makes the mixture visible to a query."""
 
 CLI_INSTALL_STARTED = "cli_install_started"
-"""An install *attempt*, recorded when a host prints its install guide — the
-first act on that path which proves ``memu-cli`` is installed and resolving on
-``PATH``.
+"""An install *attempt*, recorded by ``init`` once it has written ``config.env``.
 
-Code-observed rather than agent-reported, and that is the whole point: the
-completion below is prose-driven and undercounts (ADR 0016 §4), so a start that
-undercounted independently could report more completions than attempts. Two
-caveats for whoever reads these. A guide re-printed mid-run — a compaction, a
-restarted agent — counts twice, so the denominator is attempts-as-observed, not
-distinct machines. And ``deployment_mode`` here predates ``INSTALL.md`` Part 1.2's
-backend choice, so it is a default rather than the mode the install lands on:
-never join a start to a completion on that field."""
+``SKILL.md`` Step 2 — the first command on the install path, and the first act
+that proves ``memu-cli`` is installed and resolving on ``PATH``. Code-observed
+rather than agent-reported, and that is the whole point: the completion below is
+prose-driven and undercounts (ADR 0016 §4), so a start that undercounted
+independently could report more completions than attempts.
+
+Emitted *after* the write and never before, which is what makes it the funnel's
+first row rather than its first bug. ``init`` mints ``MEMU_CLIENT_ID`` into that
+same file (:func:`memu.hosts.config_cmd._client_id`), so an envelope built first
+would find no id in the environment and persist a second one of its own — one
+machine, two identities. The same ordering is what attaches an
+``init --cloud-api-key`` key to the header (ADR 0017), so the first event of an
+install is attributable to the account paying for it.
+
+Two caveats for whoever reads these. ``init`` is idempotent and gets re-run on
+repairs and on a second host, so this counts attempts-as-observed and is not a
+count of distinct machines — the same reading its predecessor at ``docs install``
+carried. And ``deployment_mode`` is the mode ``init`` inferred, which
+``INSTALL.md``'s own ``config`` step may still change: never join a start to a
+completion on that field."""
+
+INSTALL_GUIDE_OPENED = "install_guide_opened"
+"""A host printed its install guide — ``docs install``, ``SKILL.md`` Step 3.
+
+This is what ``cli_install_started`` used to mean. Renamed rather than dropped
+when the start moved one step earlier into ``init``: what it observes is
+unchanged and still worth a row, but it is the funnel's *second* step now, and a
+second name ending in ``_started`` beside the real one is the pair a consumer
+sums by accident.
+
+Between them, ``cli_install_started`` counts agents that got as far as writing a
+config and this counts the ones that went on to ask for the guide — so the gap is
+installs abandoned before they had begun. A guide re-printed mid-run — a
+compaction, a restarted agent — counts twice, so like the start it is
+attempts-as-observed."""
 
 CLI_INSTALL_SUCCEEDED = "cli_install_succeeded"
 """The agent reached the guide's final gate. Formerly ``cli_install_completed``,
@@ -274,6 +299,7 @@ _ALLOWED_PROPERTIES: dict[str, frozenset[str]] = {
     MEMORY_UPDATE_STARTED: frozenset(),
     MEMORY_UPDATE_FAILED: frozenset(),
     CLI_INSTALL_STARTED: frozenset(),
+    INSTALL_GUIDE_OPENED: frozenset(),
     CLI_INSTALL_SUCCEEDED: frozenset(),
     CLI_INSTALL_FAILED: frozenset(),
     CLI_UNINSTALL_SUCCEEDED: frozenset(),

--- a/src/memu/events.py
+++ b/src/memu/events.py
@@ -15,9 +15,10 @@ Two rules shape everything here, and both are inherited rather than invented:
 * **The per-turn hook must never drain the spool.** ``retrieve`` runs on every
   agent turn. Recording an event ordinarily *appends one line to a spool* and
   returns, with delivery happening later from the low-frequency bridging pair.
-  ``retrieve`` is the one exception, and a deliberately narrow one: it POSTs *its
-  own single envelope* inline (:func:`record` with ``deliver=True``) because the
-  backend asked for that event promptly and accepted the round trip it costs.
+  ``retrieve`` is the one exception, and a deliberately narrow one: on both its
+  legs it POSTs *its own single envelope* inline (:func:`record` with
+  ``deliver=True``) because the backend asked for that event promptly and accepted
+  the round trip it costs.
   What it must not do is :func:`flush`, which drains everything spooled — one
   event per POST, up to :data:`MAX_FLUSH_POSTS` of them, serially. That is an
   unbounded blocking run on the hottest path in the product, and it is why
@@ -849,17 +850,20 @@ def _module_of(filename: str) -> str:
 def flush() -> tuple[int, int]:
     """Deliver everything spooled, as ``(accepted, rejected)``.
 
-    Called from the latency-tolerant places only: ``prepare`` and ``commit``,
-    ``report uninstall`` (which cannot wait — ``UNINSTALL.md`` Part 3 may remove
-    the very binary that would flush later), the explicit ``report flush``, and
-    the CLI's error handler.
+    Called from the latency-tolerant places only: ``prepare`` and ``commit``;
+    every step of the install funnel (``init``, ``docs install``, ``report
+    install``), whose runs may never reach the bridging pair at all; ``report
+    uninstall`` (which cannot wait — ``UNINSTALL.md`` Part 3 may remove the very
+    binary that would flush later); ``report error``, for the same reason as the
+    funnel; the explicit ``report flush``; and the CLI's error handler.
 
     **Never from ``retrieve``.** This drains the whole spool one POST at a time, so
     its cost scales with how far behind the machine has fallen — bounded only by
     :data:`MAX_FLUSH_POSTS`, which is 200 requests. That is fine on the bridging
     pair and disqualifying on a per-turn hook, which instead delivers its own
-    single envelope through :func:`record` with ``deliver=True``. The distinction
-    is one event versus all of them, and it is the whole reason both exist.
+    single envelope through :func:`record` with ``deliver=True`` — on its failure
+    leg as much as its success one. The distinction is one event versus all of
+    them, and it is the whole reason both exist.
 
     Never raises. A failed POST leaves its file in place for the next flush.
     """

--- a/src/memu/events.py
+++ b/src/memu/events.py
@@ -64,7 +64,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from memu.env import CONFIG_ENV, env, env_declared, memory_mode, reload
+from memu import config_file
+from memu.env import env, env_declared, memory_mode, reload
 
 # --------------------------------------------------------------------------- #
 # The wire vocabulary: the endpoint, and every event name the client can emit.
@@ -377,10 +378,6 @@ def _spool_path() -> Path:
     return Path(os.path.expanduser(env("MEMU_EVENTS_SPOOL", SPOOL_PATH) or SPOOL_PATH))
 
 
-def _config_path() -> Path:
-    return Path(os.path.expanduser(os.environ.get("MEMU_CONFIG_ENV", CONFIG_ENV)))
-
-
 def client_version() -> str:
     """The installed ``memu-cli`` version.
 
@@ -406,19 +403,21 @@ def client_instance_id() -> str:
 
     Opaque and random: no hostname, no MAC, no user name. Nothing is derived, so
     nothing can be re-derived, and deleting the line is a complete reset.
+
+    Written through :func:`memu.config_file.write_values` rather than by appending
+    here, and that is not tidiness (ADR 0017). ``init`` now persists this same key,
+    and its writer is read-modify-write plus ``os.replace`` — which would silently
+    discard an append racing it. One writer, so the two cannot lose each other's
+    line; the fail-open ``except`` and the re-read below are this function's own
+    and survive the move.
     """
     existing = env("MEMU_CLIENT_ID")
     if existing:
         return existing
 
     generated = str(uuid.uuid4())
-    path = _config_path()
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        text = path.read_text(encoding="utf-8") if path.is_file() else ""
-        prefix = "" if (not text or text.endswith("\n")) else "\n"
-        with open(path, "a", encoding="utf-8") as handle:
-            handle.write(f"{prefix}MEMU_CLIENT_ID={generated}\n")
+        config_file.write_values({"MEMU_CLIENT_ID": generated})
     except OSError:
         # Unwritable config: still return an id so this run reports, it just will
         # not persist. A machine that cannot write its own config has a larger

--- a/src/memu/events.py
+++ b/src/memu/events.py
@@ -64,7 +64,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from memu import config_file
+from memu import config_file, trust
 from memu.env import env, env_declared, memory_mode, reload
 
 # --------------------------------------------------------------------------- #
@@ -1045,11 +1045,15 @@ def _post(url: str, event: dict[str, Any]) -> str:
     Blocking, on a short timeout, using ``urllib`` for the same reason
     :mod:`memu.hosts.templates` does: this must not depend on the async stack or
     on an HTTP client's configuration to stay fail-open.
+
+    That choice costs one thing, and :func:`memu.trust.urlopen_kwargs` pays it: a
+    Python with no CA bundle fails verification here while the ``httpx`` paths
+    sail through, and this function's ``except`` reads that as ``RETRY`` forever.
     """
     body = json.dumps(event, ensure_ascii=False, default=str).encode("utf-8")
     request = urllib.request.Request(url, data=body, headers=_headers(), method="POST")  # noqa: S310
     try:
-        with urllib.request.urlopen(request, timeout=_TIMEOUT_SECONDS) as response:  # noqa: S310
+        with urllib.request.urlopen(request, timeout=_TIMEOUT_SECONDS, **trust.urlopen_kwargs()) as response:  # noqa: S310
             return ACCEPTED if 200 <= getattr(response, "status", 200) < 300 else RETRY
     except urllib.error.HTTPError as exc:
         # A permanent 4xx means the server will reject this payload every time;

--- a/src/memu/events.py
+++ b/src/memu/events.py
@@ -159,6 +159,11 @@ CLI_INSTALL_SUCCEEDED = "cli_install_succeeded"
 before ``cli_install_failed`` gave it a counterpart to be symmetrical with."""
 
 CLI_INSTALL_FAILED = "cli_install_failed"
+
+UNINSTALL_GUIDE_OPENED = "uninstall_guide_opened"
+""":data:`INSTALL_GUIDE_OPENED`'s mirror on the way out — ``docs uninstall``
+printed ``UNINSTALL.md``"""
+
 CLI_UNINSTALL_SUCCEEDED = "cli_uninstall_succeeded"
 CLI_UNINSTALL_FAILED = "cli_uninstall_failed"
 """``report uninstall`` and ``report error --stage uninstall``. ``_succeeded`` was
@@ -303,6 +308,7 @@ _ALLOWED_PROPERTIES: dict[str, frozenset[str]] = {
     INSTALL_GUIDE_OPENED: frozenset(),
     CLI_INSTALL_SUCCEEDED: frozenset(),
     CLI_INSTALL_FAILED: frozenset(),
+    UNINSTALL_GUIDE_OPENED: frozenset(),
     CLI_UNINSTALL_SUCCEEDED: frozenset(),
     CLI_UNINSTALL_FAILED: frozenset(),
     AGENT_ERROR_REPORTED: frozenset({"stage", "detail"}),

--- a/src/memu/hosts/claude_code/INSTALL.md
+++ b/src/memu/hosts/claude_code/INSTALL.md
@@ -76,8 +76,14 @@ regardless, because the bridging task runs Python.
 ### 1.1 Install
 
 ```
-pip install memu-cli
+pip install --upgrade memu-cli
 ```
+
+**`--upgrade` matters, and a bare install is not enough.** A machine that
+already carries an older `memu-cli` keeps it otherwise, and this guide names
+subcommands (`init`, `config`) that older builds answer with `invalid choice`.
+If you meet that error anywhere below, you are on a stale build: upgrade, then
+re-run the command that failed.
 
 This puts `memu` (the library's own surface) and **`memu-claude-code`** (the
 Claude Code adapter) on `PATH`. Both Part 2 (record) and Part 3 (inject) go
@@ -95,53 +101,99 @@ non-interactive environment and needs this command to resolve there.
 
 ### 1.2 Configure the memory backend
 
-If `~/.memu/config.env` already exists from another memU host, reuse it as is
-and skip to the verify gate. An existing file without `MEMU_MEMORY_MODE` is
-local mode for backward compatibility.
+**Never write `~/.memu/config.env` by hand.** No heredoc, no `echo >>`, no
+editor. Every memU host on this machine shares that one file, it holds a
+plaintext credential, and it carries an invariant a text edit cannot keep:
+record and retrieval must agree on one backend — and in local mode on one store
+and one embedding space — or retrieval keeps succeeding and finds nothing.
+`memu-claude-code config` is the writer: it merges (anything it is not
+given is left alone, including comments and another host's settings), sets
+the file's permissions, and refuses the edits that break retrieval silently.
+
+**Came from memU's `SKILL.md`? You already ran `init`** — it created the file
+and, if the user handed over a memU Cloud key, already selected cloud memory.
+Read the state below rather than assuming which.
+
+If you came straight to this guide instead, run it now:
+
+```
+memu-claude-code init --cloud-api-key <the user's memU key>
+```
+
+Bare `memu-claude-code init` if the user has no key, or would rather keep
+memory on this device. Re-running is harmless either way — `init` is idempotent
+and keeps a mode it already finds. One caveat: passing a key selects **cloud**,
+and on a machine already using local memory that is a switch. Nothing is
+deleted, but memories written locally stop being retrieved; `init` warns and
+proceeds — so if you are unsure what this machine already uses, read the state
+first and say what the switch costs before you pass a key.
+
+Reading the state writes nothing:
+
+```
+memu-claude-code config show
+```
+
+If it reports a mode with a backend behind it, another memU host got here first:
+**reuse it as is** and go to the verify gate. A file that declares no mode is
+local mode, for backward compatibility with files written before the mode
+existed — `config show` says so.
 
 Otherwise ask the user to choose once:
 
 - **MemU Cloud** — memory and embeddings are hosted; requires a memU API key.
-- **This device** — use the existing local database and embedding configuration.
+- **This device** — a database and an embedding provider on this machine.
 
-For **MemU Cloud**, ask the user to provide their memU API key. If they do not
-have one, direct them to [memu.so](https://memu.so) to register and create one,
-then wait for the key before continuing. Write:
+**MemU Cloud.** Ask the user for their memU API key. If they do not have one,
+direct them to [memu.so](https://memu.so) to register and create one, then wait
+for the key before continuing.
 
-```env
-MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<memu-api-key>
+```
+memu-claude-code config --cloud --cloud-api-key <memu-api-key>
 ```
 
-The production endpoint defaults to `https://api.memu.so/api/v4/memory/`. The
-key is plaintext in this file: tell the user
-and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
-the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
-for local embedding providers.
+It reports where the file is and what protection it has; tell the user the key
+is stored there in plaintext. The production endpoint defaults to
+`https://api.memu.so/api/v4/memory/` — pass `--cloud-base-url` only for a
+non-default one, and never `--embed-api-key`, which is the *embedding
+provider's* credential and has no role in cloud mode.
 
 Cloud currently persists memory and skill recall files. It accepts workspace
 resources from the existing bridging pipeline for compatibility but does not
-persist or retrieve them yet; tell the user. After writing cloud configuration,
-skip the remaining local-mode guidance and go to the verify gate.
+persist or retrieve them yet; tell the user. Then skip the local-mode guidance
+below and go to the verify gate.
 
-For **This device**, write `MEMU_MEMORY_MODE=local` and collect the settings
-below. "This device" describes memory storage; it is fully offline only when
-the embedding provider is local too:
+**This device.** "This device" describes memory storage; it is fully offline
+only when the embedding provider is local too. One command carries the lot:
 
-| Setting | Env var | Example |
+```
+memu-claude-code config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-api-key <key>
+```
+
+| Setting | Flag | Example |
 | --- | --- | --- |
-| Database | `MEMU_DB` | `~/.memu/memu.sqlite3`, or a `postgres://…` DSN |
-| Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
-| API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
+| Database | `--db` | an absolute path (`~/.memu/memu.sqlite3`), or a `postgres://…` DSN |
+| Embedding provider | `--embed-provider` | `openai`, `jina`, `voyage`, … |
+| Embedding model | `--embed-model` | the provider's default if omitted |
+| Embedding credential | `--embed-api-key` | the provider's key — **not** the memU one |
+| Embedding endpoint | `--embed-base-url` | a local OpenAI-compatible server |
 
-**No embedding `MEMU_API_KEY`? Say so, then use a local embedding server.** If the user has no API key to
-give, tell them up front what that means: memory cannot be called across
-devices — everything stays on this machine, in a local database created for
-them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
-`MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local
-OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1`
-with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
-placeholder value — a local server ignores it.
+Only the flags you pass are written, so a later run can add one without
+disturbing the rest. Give `--db` an **absolute** path: a relative one resolves
+against a working directory the scheduled task does not have. And do not export
+any of this in a shell profile instead — the scheduled task does not inherit
+your interactive shell, so the file is the carrier.
+
+**No embedding key? Say so, then use a local embedding server.** If the user has
+no API key to give, tell them up front what that means: memory cannot be called
+across devices — everything stays on this machine, in a local database created
+for them (SQLite). Then configure exactly that — keep `openai` as the provider,
+point the endpoint at a local OpenAI-compatible server (e.g. Ollama), and pass
+any placeholder credential, which such a server ignores:
+
+```
+memu-claude-code config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-base-url http://localhost:11434/v1 --embed-model nomic-embed-text --embed-api-key local
+```
 
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
 local embedding server, a proxy is hijacking localhost traffic. The proxy may
@@ -156,21 +208,23 @@ memU. A local server reached through a **non-loopback** address
 a mechanical requirement with exactly one right answer — apply it and move on;
 do not ask the user.
 
-Write them to **`~/.memu/config.env`**, which every memU command loads. Use an
-**absolute** path for `MEMU_DB`, and `chmod 600` the file (the key is plaintext —
-tell the user). Do **not** instead export these in a shell profile: the scheduled
-task does not inherit your interactive shell.
+**The existing config fails doctor? Repair the connection, never the identity.**
+If `~/.memu/config.env` predates this install and `doctor` fails, diagnose the
+transport first — is the embedding server running, is a proxy in the way — before
+changing anything. A connection-level repair is an ordinary `config` call and is
+allowed to land:
 
-**The existing config fails doctor? Repair the connection, never the
-identity.** If `~/.memu/config.env` predates this install and `doctor` fails,
-diagnose the transport first — is the embedding server running, is a proxy in
-the way — before touching the file. A minimal connection-level edit (say,
-`localhost` → `127.0.0.1`) is acceptable: back the file up first, and tell the
-user what changed and why. Never change `MEMU_DB`, `MEMU_EMBED_PROVIDER`, or
-`MEMU_EMBED_MODEL` on an existing store — those three bind the embedding
-space, and "fixing" them silently splits the user's memory (old vectors become
-unreachable until everything is re-embedded). If one of them looks wrong, stop
-and ask the user.
+```
+memu-claude-code config --local --embed-base-url http://127.0.0.1:11434/v1
+```
+
+The identity is the other matter. `--db`, `--embed-provider` and `--embed-model`
+bind the embedding space every existing vector was written against, so `config`
+**refuses to change one that is already set**: "fixing" it would strand the
+user's whole store while retrieval went on succeeding and finding nothing. The
+refusal names `--force`, which is for a store genuinely being replaced and never
+for making `doctor` go green. If one of the three looks wrong, stop and ask the
+user.
 
 ### ✅ Verify Part 1
 

--- a/src/memu/hosts/codex/INSTALL.md
+++ b/src/memu/hosts/codex/INSTALL.md
@@ -39,8 +39,14 @@ Python.
 ### 1.1 Install
 
 ```
-pip install memu-cli
+pip install --upgrade memu-cli
 ```
+
+**`--upgrade` matters, and a bare install is not enough.** A machine that
+already carries an older `memu-cli` keeps it otherwise, and this guide names
+subcommands (`init`, `config`) that older builds answer with `invalid choice`.
+If you meet that error anywhere below, you are on a stale build: upgrade, then
+re-run the command that failed.
 
 This puts two commands on `PATH`:
 
@@ -62,53 +68,99 @@ interactive environment.
 
 ### 1.2 Configure the memory backend
 
-If `~/.memu/config.env` already exists from another memU host, reuse it as is
-and skip to the verify gate. An existing file without `MEMU_MEMORY_MODE` is
-local mode for backward compatibility.
+**Never write `~/.memu/config.env` by hand.** No heredoc, no `echo >>`, no
+editor. Every memU host on this machine shares that one file, it holds a
+plaintext credential, and it carries an invariant a text edit cannot keep:
+record and retrieval must agree on one backend — and in local mode on one store
+and one embedding space — or retrieval keeps succeeding and finds nothing.
+`memu-codex config` is the writer: it merges (anything it is not
+given is left alone, including comments and another host's settings), sets
+the file's permissions, and refuses the edits that break retrieval silently.
+
+**Came from memU's `SKILL.md`? You already ran `init`** — it created the file
+and, if the user handed over a memU Cloud key, already selected cloud memory.
+Read the state below rather than assuming which.
+
+If you came straight to this guide instead, run it now:
+
+```
+memu-codex init --cloud-api-key <the user's memU key>
+```
+
+Bare `memu-codex init` if the user has no key, or would rather keep memory on
+this device. Re-running is harmless either way — `init` is idempotent and keeps
+a mode it already finds. One caveat: passing a key selects **cloud**, and on a
+machine already using local memory that is a switch. Nothing is deleted, but
+memories written locally stop being retrieved; `init` warns and proceeds — so
+if you are unsure what this machine already uses, read the state first and say
+what the switch costs before you pass a key.
+
+Reading the state writes nothing:
+
+```
+memu-codex config show
+```
+
+If it reports a mode with a backend behind it, another memU host got here first:
+**reuse it as is** and go to the verify gate. A file that declares no mode is
+local mode, for backward compatibility with files written before the mode
+existed — `config show` says so.
 
 Otherwise ask the user to choose once:
 
 - **MemU Cloud** — memory and embeddings are hosted; requires a memU API key.
-- **This device** — use the existing local database and embedding configuration.
+- **This device** — a database and an embedding provider on this machine.
 
-For **MemU Cloud**, ask the user to provide their memU API key. If they do not
-have one, direct them to [memu.so](https://memu.so) to register and create one,
-then wait for the key before continuing. Write:
+**MemU Cloud.** Ask the user for their memU API key. If they do not have one,
+direct them to [memu.so](https://memu.so) to register and create one, then wait
+for the key before continuing.
 
-```env
-MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<memu-api-key>
+```
+memu-codex config --cloud --cloud-api-key <memu-api-key>
 ```
 
-The production endpoint defaults to `https://api.memu.so/api/v4/memory/`. The
-key is plaintext in this file: tell the user
-and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
-the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
-for local embedding providers.
+It reports where the file is and what protection it has; tell the user the key
+is stored there in plaintext. The production endpoint defaults to
+`https://api.memu.so/api/v4/memory/` — pass `--cloud-base-url` only for a
+non-default one, and never `--embed-api-key`, which is the *embedding
+provider's* credential and has no role in cloud mode.
 
 Cloud currently persists memory and skill recall files. It accepts workspace
 resources from the existing bridging pipeline for compatibility but does not
-persist or retrieve them yet; tell the user. After writing cloud configuration,
-skip the remaining local-mode guidance and go to the verify gate.
+persist or retrieve them yet; tell the user. Then skip the local-mode guidance
+below and go to the verify gate.
 
-For **This device**, write `MEMU_MEMORY_MODE=local` and collect the settings
-below. "This device" describes memory storage; it is fully offline only when
-the embedding provider is local too:
+**This device.** "This device" describes memory storage; it is fully offline
+only when the embedding provider is local too. One command carries the lot:
 
-| Setting | Env var | Example |
+```
+memu-codex config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-api-key <key>
+```
+
+| Setting | Flag | Example |
 | --- | --- | --- |
-| Database | `MEMU_DB` | `~/.memu/memu.sqlite3`, or a `postgres://…` DSN |
-| Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
-| API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
+| Database | `--db` | an absolute path (`~/.memu/memu.sqlite3`), or a `postgres://…` DSN |
+| Embedding provider | `--embed-provider` | `openai`, `jina`, `voyage`, … |
+| Embedding model | `--embed-model` | the provider's default if omitted |
+| Embedding credential | `--embed-api-key` | the provider's key — **not** the memU one |
+| Embedding endpoint | `--embed-base-url` | a local OpenAI-compatible server |
 
-**No embedding `MEMU_API_KEY`? Say so, then use a local embedding server.** If the user has no API key to
-give, tell them up front what that means: memory cannot be called across
-devices — everything stays on this machine, in a local database created for
-them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
-`MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local
-OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1`
-with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
-placeholder value — a local server ignores it.
+Only the flags you pass are written, so a later run can add one without
+disturbing the rest. Give `--db` an **absolute** path: a relative one resolves
+against a working directory the scheduled task does not have. And do not export
+any of this in a shell profile instead — the scheduled task does not inherit
+your interactive shell, so the file is the carrier.
+
+**No embedding key? Say so, then use a local embedding server.** If the user has
+no API key to give, tell them up front what that means: memory cannot be called
+across devices — everything stays on this machine, in a local database created
+for them (SQLite). Then configure exactly that — keep `openai` as the provider,
+point the endpoint at a local OpenAI-compatible server (e.g. Ollama), and pass
+any placeholder credential, which such a server ignores:
+
+```
+memu-codex config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-base-url http://localhost:11434/v1 --embed-model nomic-embed-text --embed-api-key local
+```
 
 **Going local behind Codex's network proxy: nothing to ask.** Codex routes
 shell traffic through its proxy, which cannot reach *your* `localhost` — the
@@ -126,36 +178,23 @@ release, with that address in the list. Either way this is a mechanical
 requirement with exactly one right answer — apply it and move on; do not ask
 the user.
 
-Write them to **`~/.memu/config.env`**, which every memU command loads:
+**The existing config fails doctor? Repair the connection, never the identity.**
+If `~/.memu/config.env` predates this install and `doctor` fails, diagnose the
+transport first — is the embedding server running, is a proxy in the way — before
+changing anything. A connection-level repair is an ordinary `config` call and is
+allowed to land:
 
 ```
-MEMU_DB=/Users/<you>/.memu/memu.sqlite3
-MEMU_MEMORY_MODE=local
-MEMU_EMBED_PROVIDER=openai
-MEMU_API_KEY=<key or env-var name>
+memu-codex config --local --embed-base-url http://127.0.0.1:11434/v1
 ```
 
-Use an **absolute** path for `MEMU_DB`. A relative one resolves against the
-working directory, and the scheduled task has no reliable working directory.
-
-> Do **not** instead export these in a shell profile. The scheduled task does not
-> inherit your interactive shell. The file is the carrier; a profile export is
-> not. (A `MEMU_*` variable that *is* set in the environment wins over the file,
-> so you can still override for one command.)
-
-The API key sits in plaintext in this file. Tell the user, and set the
-permissions: `chmod 600 ~/.memu/config.env`.
-
-**The existing config fails doctor? Repair the connection, never the
-identity.** If `~/.memu/config.env` predates this install and `doctor` fails,
-diagnose the transport first — is the embedding server running, is a proxy in
-the way — before touching the file. A minimal connection-level edit (say,
-`localhost` → `127.0.0.1`) is acceptable: back the file up first, and tell the
-user what changed and why. Never change `MEMU_DB`, `MEMU_EMBED_PROVIDER`, or
-`MEMU_EMBED_MODEL` on an existing store — those three bind the embedding
-space, and "fixing" them silently splits the user's memory (old vectors become
-unreachable until everything is re-embedded). If one of them looks wrong, stop
-and ask the user.
+The identity is the other matter. `--db`, `--embed-provider` and `--embed-model`
+bind the embedding space every existing vector was written against, so `config`
+**refuses to change one that is already set**: "fixing" it would strand the
+user's whole store while retrieval went on succeeding and finding nothing. The
+refusal names `--force`, which is for a store genuinely being replaced and never
+for making `doctor` go green. If one of the three looks wrong, stop and ask the
+user.
 
 ### ✅ Verify Part 1
 
@@ -167,7 +206,8 @@ It prints the resolved mode plus its endpoint or local store/provider, and runs 
 must exit cleanly. **Zero hits is the expected result** — the store is new; you
 are testing that config resolves and the store answers, not that it has content.
 
-If it errors, fix `~/.memu/config.env` before continuing. Both later parts depend
+If it errors, fix it with another `memu-codex config` call — never by editing
+`~/.memu/config.env` — before continuing. Both later parts depend
 on this working, and both fail *silently* if it is wrong.
 
 ---

--- a/src/memu/hosts/cola/INSTALL.md
+++ b/src/memu/hosts/cola/INSTALL.md
@@ -19,14 +19,40 @@ skill plus its memory-bank pointer.
 ## Part 1 — Install and configure memU
 
 ```sh
-pip install memu-cli
+pip install --upgrade memu-cli
 memu-cola --help
 ```
 
-Reuse `~/.memu/config.env` if another memU host already configured it. Otherwise
-ask the user to choose MemU Cloud or this device, write the chosen `MEMU_*`
-settings to that file, use an absolute local `MEMU_DB`, and protect it with
-`chmod 600 ~/.memu/config.env`. Never put these settings only in a shell profile:
+`--upgrade` is not optional: an older `memu-cli` already on the machine would
+otherwise stay, and the subcommands below (`init`, `config`) do not exist on it
+— the symptom is `invalid choice`. If you meet that error anywhere, upgrade and
+re-run the command.
+
+Then create the configuration file. If you came from memU's `SKILL.md` this is
+already done and re-running is harmless (`init` is idempotent and keeps a mode
+it finds):
+
+```sh
+memu-cola init --cloud-api-key <the user's memU key>
+```
+
+Bare `memu-cola init` if the user has no key or wants memory on this device.
+Passing a key selects cloud memory, and on a machine already using local memory
+that is a switch — nothing is deleted, but memories written locally stop being
+retrieved; `init` warns and proceeds.
+
+**Never write `~/.memu/config.env` by hand** — `memu-cola config` owns it. It
+merges rather than rewrites, sets the file's permissions, and refuses the edits
+that break retrieval silently. Read the state with `memu-cola config show`; if
+another memU host already configured a backend, reuse it as is. Otherwise ask
+the user to choose once, and write the choice with one command:
+
+```sh
+memu-cola config --cloud --cloud-api-key <memu-api-key>
+memu-cola config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-api-key <key>
+```
+
+Give `--db` an absolute path. Never put these settings only in a shell profile:
 Cola's scheduled task does not inherit an interactive shell.
 
 ### Verify Part 1

--- a/src/memu/hosts/config_cmd.py
+++ b/src/memu/hosts/config_cmd.py
@@ -73,13 +73,17 @@ def _effective_mode(values: dict[str, str]) -> str:
 
 
 def _protection(values: dict[str, str]) -> str | None:
-    """Why the current backend must not be flipped, or ``None`` if it is vacuous.
+    """What the current backend has to lose, or ``None`` if it is vacuous.
 
     The state test ADR 0017 turns on: an *inferred* default is indistinguishable
     from a *chosen* one once written, so a guard that reads the declaration alone
     refuses the most ordinary first install (bare ``init`` lands ``local``, the
     guide then asks the question, the user says cloud). What the invariant
     protects is existing memory, so that is what gets asked about.
+
+    One question, two policies. ``config`` refuses on it, because its caller asked
+    for a specific backend and can be handed ``--force``; ``init`` only warns, and
+    the difference is that ``init`` has no override to hand back.
 
     Declaration of a store, not its contents: ``MEMU_DB`` spans a bare path, a
     ``sqlite://`` URL, a ``postgres://`` DSN and an in-memory sentinel, so "does
@@ -132,7 +136,9 @@ async def _cmd_init(args: argparse.Namespace) -> int:
     """Infer the backend from what the caller had to offer, and never lose a mode.
 
     The one command ``SKILL.md`` names, so it must be safe to run on any machine
-    in any state — including one another host already configured.
+    in any state — including one another host already configured. It never
+    refuses: it is the first step of the install, and a non-zero exit here with no
+    ``--force`` to offer strands every step after it.
     """
     values = config_file.read()
     declared = _declared_mode(values)
@@ -156,29 +162,43 @@ async def _cmd_init(args: argparse.Namespace) -> int:
         print(f"ready — continue with `{args.binary} docs install`")
         return 0
 
-    # A key *is* the choice of cloud, so this is a mode change by inference — the
-    # one thing `init` can refuse. It hands the decision back rather than growing a
-    # `--force` of its own: an override belongs on the verb whose caller was shown
-    # the guard, not on the one that inferred its way into it.
-    if _effective_mode(values) != "cloud":
-        why = _protection(values)
-        if why is not None:
-            print(f"error: {why}, so `init` will not switch this machine to cloud memory.", file=sys.stderr)
-            print("Run this instead if the switch is what you mean:", file=sys.stderr)
-            print(f"  {args.binary} config --cloud --cloud-api-key <key> --force", file=sys.stderr)
-            return REFUSED
+    # A key *is* the choice of cloud, and `init` acts on it even over a configured
+    # local store. `config`'s state guard (:func:`_refuse_flip`) is deliberately not
+    # applied here: `init` has no `--force`, so a refusal is terminal, and it is the
+    # first command on the install path — halting there halts everything after it.
+    # Having a key to hand is a strong enough statement of intent to honour, and
+    # nothing is destroyed by honouring it; the local store stays on disk, merely
+    # unread until the mode is switched back. So the cost is a warning, not a veto.
+    orphaned = _protection(values) if _effective_mode(values) != "cloud" else None
 
     stored = values.get("MEMU_CLOUD_API_KEY", "")
     replacing = bool(stored) and stored != args.cloud_api_key
     updates["MEMU_MEMORY_MODE"] = "cloud"
     updates["MEMU_CLOUD_API_KEY"] = args.cloud_api_key
     _row("mode", "cloud (from --cloud-api-key)")
+    if orphaned:
+        # Named on stdout beside the mode, because an agent that reads only the
+        # rows must still see that this run changed the backend out from under a
+        # store, and told in full below, because the user may not have meant it.
+        _row("switched", f"{orphaned} and is no longer read")
     # Loud, because the client cannot tell a rotated key from a different account.
     # Refusing would block the legitimate repair; saying nothing would hide the
     # case where it was not one.
     _row("key", "replaced — the previously stored memU Cloud key is gone" if replacing else "set")
     _row("client", f"{_short(client_id)}{' (generated)' if generated else ''}")
     _write(updates)
+    if orphaned:
+        # The only place this module writes to both streams in one run, so the only
+        # place ordering has to be forced: piped stdout is block-buffered and would
+        # otherwise flush *after* the warning, putting it above the block it follows.
+        sys.stdout.flush()
+        print(
+            "warning: this machine was in local mode with a store configured. Nothing was "
+            "deleted, but memories written there are not visible to cloud memory, and new "
+            "ones now go to the cloud account this key belongs to.",
+            file=sys.stderr,
+        )
+        print(f"To go back: `{args.binary} config --local --force`", file=sys.stderr)
     print(f"ready — continue with `{args.binary} docs install`")
     return 0
 

--- a/src/memu/hosts/config_cmd.py
+++ b/src/memu/hosts/config_cmd.py
@@ -24,7 +24,7 @@ import sys
 import uuid
 from typing import Any
 
-from memu import config_file
+from memu import config_file, events
 from memu import env as env_module
 
 IDENTITY_KEYS = ("MEMU_DB", "MEMU_EMBED_PROVIDER", "MEMU_EMBED_MODEL")
@@ -132,6 +132,44 @@ def _write(updates: dict[str, str]) -> None:
     _row("config", f"{path} ({config_file.permission_note()})")
 
 
+def _report_install_started(args: argparse.Namespace) -> None:
+    """The install funnel's start (ADR 0016 §4, ADR 0017), recorded by ``init``.
+
+    ``SKILL.md`` Step 2 is the first command on the install path, so it is the
+    earliest point that proves ``memu-cli`` is installed and resolving — earlier
+    than ``docs install``, which now reports the narrower
+    :data:`memu.events.INSTALL_GUIDE_OPENED`.
+
+    **Called after :func:`_write`, never before**, and that is the whole reason
+    this is a function rather than a line at the top of ``init``. The id every
+    envelope carries comes from :func:`memu.events.client_instance_id`, which
+    reads ``MEMU_CLIENT_ID`` from the resolved environment — where the one
+    :func:`_client_id` just generated does not appear until ``_write`` has
+    persisted it and reloaded. Report first and the event generates and persists a
+    *second* id, which ``_write`` then overwrites: one machine reporting under two
+    identities, and the ``client`` row printed above naming neither. The same
+    ordering is what puts a ``--cloud-api-key`` into :func:`memu.events._headers`,
+    so the first event of an install is attributable rather than anonymous.
+
+    Nothing between :func:`_client_id` and here does I/O or can raise, so the
+    alternative — an extra ``_write`` early to bank the id against a later error —
+    buys no durability, costs a second read-modify-write, and prints the ``config``
+    row twice.
+
+    Flushed rather than left spooled, for the reason ``docs install`` flushes: an
+    install that stops before the bridging pair ever runs has no other flush point,
+    and that run is exactly the one the funnel exists to show. Both calls are
+    fail-open, so an unreachable endpoint costs this command its timeout and
+    nothing else — never its exit code, and never the file it just wrote.
+    """
+    events.record(
+        events.CLI_INSTALL_STARTED,
+        host=getattr(args, "host", ""),
+        session_id_env=getattr(args, "session_id_env", ""),
+    )
+    events.flush()
+
+
 async def _cmd_init(args: argparse.Namespace) -> int:
     """Infer the backend from what the caller had to offer, and never lose a mode.
 
@@ -159,6 +197,7 @@ async def _cmd_init(args: argparse.Namespace) -> int:
             _row("mode", "local (default; no store configured yet)")
         _row("client", f"{_short(client_id)}{' (generated)' if generated else ''}")
         _write(updates)
+        _report_install_started(args)
         print(f"ready — continue with `{args.binary} docs install`")
         return 0
 
@@ -199,6 +238,9 @@ async def _cmd_init(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         print(f"To go back: `{args.binary} config --local --force`", file=sys.stderr)
+    # Below the warning rather than beside the write, unlike the branch above:
+    # this one blocks on a POST, and the warning is the line a user has to read.
+    _report_install_started(args)
     print(f"ready — continue with `{args.binary} docs install`")
     return 0
 
@@ -373,13 +415,20 @@ def _show() -> int:
     return 0
 
 
-def register(sub: Any, *, binary: str) -> None:
+def register(sub: Any, *, binary: str, host: str = "", session_id_env: str = "") -> None:
     """Add ``init`` and ``config`` to a host CLI's subparsers.
 
     ``binary`` is the host adapter's own command name, carried on the parser
     defaults purely so the next-step lines name the binary the agent is already
     holding — ``SKILL.md``'s ergonomic bet is that one binary name serves the
     whole flow.
+
+    ``host`` and ``session_id_env`` ride the same way, and only ``init`` reads
+    them: they are the envelope context for the install-start event
+    (:func:`_report_install_started`), which is the one thing in this module that
+    is not host-irrelevant. Both default to empty, so a caller that has no host —
+    the core ``memu`` binary, were these ever registered there — gets commands
+    that work and an event that reports ``agent_platform: none``.
     """
     initialiser = sub.add_parser(
         "init",
@@ -390,7 +439,7 @@ def register(sub: Any, *, binary: str) -> None:
         default="",
         help="The user's memU Cloud key. Providing one selects cloud memory; omit it to keep or default the mode",
     )
-    initialiser.set_defaults(handler=_cmd_init, binary=binary)
+    initialiser.set_defaults(handler=_cmd_init, binary=binary, host=host, session_id_env=session_id_env)
 
     configure = sub.add_parser(
         "config",

--- a/src/memu/hosts/config_cmd.py
+++ b/src/memu/hosts/config_cmd.py
@@ -1,0 +1,407 @@
+"""``init`` and ``config`` — the commands that write ``config.env`` (ADR 0017).
+
+Two verbs over one writer, because they have different *policies* and are named
+on surfaces with different update rates. ``init`` is the inferring front door,
+named in ``SKILL.md`` — the least updatable surface memU has, so its contract is
+one optional flag and is expected to hold for years. ``config`` is the explicit
+one, driven by ``INSTALL.md``, which *is* server-refreshable (ADR 0013) and can
+therefore grow flags at the server's pace.
+
+What they share is :mod:`memu.config_file`: neither owns a code path for
+``MEMU_CLOUD_API_KEY``, or the two drift within a release.
+
+**Every guard here reads the file, never :func:`memu.env.env`.** The question is
+"does this machine have memory to lose", and only the file can answer it — an
+exported ``MEMU_CLOUD_API_KEY`` in the calling shell would otherwise make
+``config --local`` refuse a file that declares nothing at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import uuid
+from typing import Any
+
+from memu import config_file
+from memu import env as env_module
+
+IDENTITY_KEYS = ("MEMU_DB", "MEMU_EMBED_PROVIDER", "MEMU_EMBED_MODEL")
+"""Keys that bind an embedding space, and may never be *changed* without ``--force``.
+
+Unlike the mode, these get no state test. The three together decide which vectors
+a query can be compared against, so "fixing" one on a store that already has
+vectors strands every one of them — silently, because retrieval still succeeds and
+simply finds nothing. Setting one that is absent is not a change and is free;
+``--force`` is the escape for the genuine repair, and exists so the alternative
+(the user hand-editing the file) does not become the only route.
+"""
+
+REFUSED = 2
+"""Exit status for a guard refusal.
+
+Matches ``prepare``'s missing-session-log, and it is *returned*, never raised:
+:func:`memu.hosts.host_cli.run` turns an exception into a ``cli_error`` event and
+flushes it, which would file every ordinary "you meant ``--force``" into the feed
+that exists to show memU breaking.
+"""
+
+
+def _row(label: str, value: str) -> None:
+    """One aligned output line, in ``doctor``'s shape."""
+    print(f"{label:<10}{value}")
+
+
+def _declared_mode(values: dict[str, str]) -> str:
+    """The mode the file states, or ``""`` if it states none (or nonsense)."""
+    raw = values.get("MEMU_MEMORY_MODE", "").strip().lower()
+    return raw if raw in ("local", "cloud") else ""
+
+
+def _effective_mode(values: dict[str, str]) -> str:
+    """The mode this file actually resolves to, absent declaration included.
+
+    Not the same question as :func:`_declared_mode`, and the difference is what
+    keeps a legacy install safe. A ``config.env`` written before ``MEMU_MEMORY_MODE``
+    existed declares no mode but is *in* local mode — :func:`memu.env.memory_mode`
+    defaults there for exactly that compatibility. Reading it as "vacuous" would
+    make ``config --cloud`` a silent, unguarded flip on the one population most
+    likely to have a large local store.
+    """
+    return _declared_mode(values) or "local"
+
+
+def _protection(values: dict[str, str]) -> str | None:
+    """Why the current backend must not be flipped, or ``None`` if it is vacuous.
+
+    The state test ADR 0017 turns on: an *inferred* default is indistinguishable
+    from a *chosen* one once written, so a guard that reads the declaration alone
+    refuses the most ordinary first install (bare ``init`` lands ``local``, the
+    guide then asks the question, the user says cloud). What the invariant
+    protects is existing memory, so that is what gets asked about.
+
+    Declaration of a store, not its contents: ``MEMU_DB`` spans a bare path, a
+    ``sqlite://`` URL, a ``postgres://`` DSN and an in-memory sentinel, so "does
+    the store exist" has no single cheap meaning — and in the one shape where it
+    is cheap, :func:`memu.env.database_config` answers it by *creating the parent
+    directory*. A guard that mutates the filesystem to decide is worse than one
+    that over-refuses, and over-refusing costs one ``--force``.
+    """
+    if _effective_mode(values) == "cloud":
+        if values.get("MEMU_CLOUD_API_KEY"):
+            return "a memU Cloud key is already stored"
+        return None
+    if values.get("MEMU_DB"):
+        return "a local store is already configured (MEMU_DB)"
+    return None
+
+
+def _client_id(values: dict[str, str]) -> tuple[dict[str, str], str, bool]:
+    """``MEMU_CLIENT_ID``, generated into the update set if the file lacks one.
+
+    Persisted here rather than being left to whichever event fires first, so the
+    id exists before anything reports (ADR 0016 §4). Read from the file, not
+    :func:`memu.events.client_instance_id`, for the module-wide reason: this is a
+    statement about the file's contents.
+    """
+    existing = values.get("MEMU_CLIENT_ID", "")
+    if existing:
+        return {}, existing, False
+    generated = str(uuid.uuid4())
+    return {"MEMU_CLIENT_ID": generated}, generated, True
+
+
+def _short(client_id: str) -> str:
+    return f"{client_id[:4]}…" if len(client_id) > 4 else client_id
+
+
+def _write(updates: dict[str, str]) -> None:
+    """Persist, re-resolve so anything later in this process sees it, and report.
+
+    The report is a decisive summary, not a diff, and it comes *after* the caller's
+    own rows: what the agent needs first is what this machine's backend now is, and
+    where the file lives only matters once it is asking a different question.
+    """
+    path, _ = config_file.write_values(updates)
+    env_module.reload()
+    _row("config", f"{path} ({config_file.permission_note()})")
+
+
+async def _cmd_init(args: argparse.Namespace) -> int:
+    """Infer the backend from what the caller had to offer, and never lose a mode.
+
+    The one command ``SKILL.md`` names, so it must be safe to run on any machine
+    in any state — including one another host already configured.
+    """
+    values = config_file.read()
+    declared = _declared_mode(values)
+    updates, client_id, generated = _client_id(values)
+
+    if not args.cloud_api_key:
+        # Nothing offered, so nothing is inferred: an existing mode is kept, and
+        # only a file that states none gets `local` — which is the mode it already
+        # resolves to, written down. A re-install where the user did not re-supply
+        # a key must never demote cloud to local.
+        if not declared:
+            updates["MEMU_MEMORY_MODE"] = "local"
+        if declared:
+            _row("mode", f"{declared} (kept)")
+        elif values.get("MEMU_DB"):
+            _row("mode", "local (recorded; the existing store is unchanged)")
+        else:
+            _row("mode", "local (default; no store configured yet)")
+        _row("client", f"{_short(client_id)}{' (generated)' if generated else ''}")
+        _write(updates)
+        print(f"ready — continue with `{args.binary} docs install`")
+        return 0
+
+    # A key *is* the choice of cloud, so this is a mode change by inference — the
+    # one thing `init` can refuse. It hands the decision back rather than growing a
+    # `--force` of its own: an override belongs on the verb whose caller was shown
+    # the guard, not on the one that inferred its way into it.
+    if _effective_mode(values) != "cloud":
+        why = _protection(values)
+        if why is not None:
+            print(f"error: {why}, so `init` will not switch this machine to cloud memory.", file=sys.stderr)
+            print("Run this instead if the switch is what you mean:", file=sys.stderr)
+            print(f"  {args.binary} config --cloud --cloud-api-key <key> --force", file=sys.stderr)
+            return REFUSED
+
+    stored = values.get("MEMU_CLOUD_API_KEY", "")
+    replacing = bool(stored) and stored != args.cloud_api_key
+    updates["MEMU_MEMORY_MODE"] = "cloud"
+    updates["MEMU_CLOUD_API_KEY"] = args.cloud_api_key
+    _row("mode", "cloud (from --cloud-api-key)")
+    # Loud, because the client cannot tell a rotated key from a different account.
+    # Refusing would block the legitimate repair; saying nothing would hide the
+    # case where it was not one.
+    _row("key", "replaced — the previously stored memU Cloud key is gone" if replacing else "set")
+    _row("client", f"{_short(client_id)}{' (generated)' if generated else ''}")
+    _write(updates)
+    print(f"ready — continue with `{args.binary} docs install`")
+    return 0
+
+
+def _refuse_flip(values: dict[str, str], target: str, binary: str) -> int | None:
+    if _effective_mode(values) == target:
+        return None
+    why = _protection(values)
+    if why is None:
+        return None
+    print(
+        f"error: {why}, so switching this machine to {target} memory is refused. Record and "
+        "retrieval must agree on one backend, or retrieval silently finds nothing.",
+        file=sys.stderr,
+    )
+    print(
+        f"If you mean to switch anyway, re-run with --force (`{binary} config --{target} … --force`).", file=sys.stderr
+    )
+    return REFUSED
+
+
+def _refuse_identity(values: dict[str, str], updates: dict[str, str]) -> int | None:
+    for key in IDENTITY_KEYS:
+        new = updates.get(key)
+        old = values.get(key, "")
+        if new is None or not old or new == old:
+            continue
+        print(
+            f"error: {key} is already set on this machine, and changing it strands every vector "
+            "already written against it — retrieval keeps succeeding and finds nothing.",
+            file=sys.stderr,
+        )
+        print(
+            "Repair the connection, never the identity. Re-run with --force only if the store is "
+            "genuinely being replaced.",
+            file=sys.stderr,
+        )
+        return REFUSED
+    return None
+
+
+async def _cmd_config(args: argparse.Namespace) -> int:
+    """Set the backend explicitly. The verb ``INSTALL.md`` drives."""
+    if args.show:
+        return _show()
+    if not args.cloud and not args.local:
+        # Mandatory, and not enforced by argparse's `required=True` only because
+        # `show` shares this parser. The refusal is the point of the verb: this is
+        # the explicit one, and a `config` that guessed a backend would be `init`.
+        print("error: `config` needs --cloud or --local.", file=sys.stderr)
+        print(f"To read the configuration without writing anything: `{args.binary} config show`", file=sys.stderr)
+        return REFUSED
+
+    values = config_file.read()
+    target = "cloud" if args.cloud else "local"
+    if not args.force:
+        refused = _refuse_flip(values, target, args.binary)
+        if refused is not None:
+            return refused
+
+    updates = _updates_for(target, args)
+    if not args.force:
+        refused = _refuse_identity(values, updates)
+        if refused is not None:
+            return refused
+
+    updates.update(_client_id(values)[0])
+    _row("mode", target + (" (forced)" if args.force else ""))
+    _report_backend(target, values, updates)
+    _write(updates)
+    print(f"ready — verify with `{args.binary} doctor`")
+    return 0
+
+
+def _updates_for(target: str, args: argparse.Namespace) -> dict[str, str]:
+    """The keys this invocation sets — the mode, plus whichever flags were passed."""
+    updates: dict[str, str] = {"MEMU_MEMORY_MODE": target}
+    if target == "cloud":
+        _collect(updates, args, (("cloud_api_key", "MEMU_CLOUD_API_KEY"),))
+        # Never persisted when it equals today's default: baking that value into
+        # the file freezes across upgrades a URL the code should own.
+        from memu.cloud import DEFAULT_CLOUD_BASE_URL
+
+        if args.cloud_base_url and args.cloud_base_url != DEFAULT_CLOUD_BASE_URL:
+            updates["MEMU_CLOUD_BASE_URL"] = args.cloud_base_url
+        return updates
+
+    _collect(
+        updates,
+        args,
+        (
+            ("db", "MEMU_DB"),
+            ("embed_provider", "MEMU_EMBED_PROVIDER"),
+            ("embed_model", "MEMU_EMBED_MODEL"),
+            # The embedding provider's credential and endpoint — never memU
+            # Cloud's. The two are one careless `--api-key` away from being
+            # confused, which is why neither flag is called that.
+            ("embed_api_key", "MEMU_API_KEY"),
+            ("embed_base_url", "MEMU_BASE_URL"),
+        ),
+    )
+    return updates
+
+
+def _report_backend(target: str, values: dict[str, str], updates: dict[str, str]) -> None:
+    """The one line that says whether this backend can actually work."""
+    if target == "local":
+        _row("store", updates.get("MEMU_DB") or values.get("MEMU_DB") or "unset — set one with --db before `doctor`")
+        return
+    stored, new = values.get("MEMU_CLOUD_API_KEY", ""), updates.get("MEMU_CLOUD_API_KEY", "")
+    if new and stored and new != stored:
+        _row("key", "replaced — the previously stored memU Cloud key is gone")
+    elif new or stored:
+        _row("key", "set")
+    else:
+        # Said now rather than left to the gate: cloud mode without a key is not a
+        # partial configuration, it is one that cannot work.
+        _row("key", "unset — cloud memory needs one; `doctor` will fail until it is set")
+
+
+def _collect(updates: dict[str, str], args: argparse.Namespace, pairs: tuple[tuple[str, str], ...]) -> None:
+    """Copy the flags the caller actually passed into the update set.
+
+    Absent flags are absent from the write, which is what makes every one of these
+    commands a merge rather than a form submission: `config --local --db X` on a
+    configured machine changes the store and leaves the provider alone.
+    """
+    for attr, key in pairs:
+        value = getattr(args, attr, None)
+        if value:
+            updates[key] = value
+
+
+def _show() -> int:
+    """Print what the file declares. Writes nothing — the whole point.
+
+    Named ``show`` rather than being what a bare ``config`` does. A bare verb that
+    printed while a bare ``init`` wrote is exactly the asymmetry agents get wrong,
+    and this one is quoted in guides that an agent runs before deciding whether to
+    configure anything.
+    """
+    path = config_file.config_path()
+    values = config_file.read()
+    if not path.is_file():
+        _row("config", f"{path} (not created yet)")
+        _row("mode", "local (default; nothing configured)")
+        return 0
+
+    _row("config", str(path))
+    declared = _declared_mode(values)
+    _row("mode", declared or "local (undeclared; local for backward compatibility)")
+    if _effective_mode(values) == "cloud":
+        _row("key", "set" if values.get("MEMU_CLOUD_API_KEY") else "unset")
+        _row("endpoint", values.get("MEMU_CLOUD_BASE_URL") or "default")
+    else:
+        _row("store", values.get("MEMU_DB") or "unset")
+        _row("provider", values.get("MEMU_EMBED_PROVIDER") or values.get("MEMU_LLM_PROVIDER") or "openai (default)")
+        _row("model", values.get("MEMU_EMBED_MODEL") or "provider default")
+        _row("embed key", "set" if values.get("MEMU_API_KEY") else "unset")
+    _row("client", _short(values.get("MEMU_CLIENT_ID", "")) or "unset")
+
+    # This command reports the *file*, but the process environment is what would
+    # actually win at runtime (`env.env`). Where the two disagree, saying so is
+    # the difference between a probe and a misleading one.
+    shadowed = sorted(
+        key
+        for key in ("MEMU_MEMORY_MODE", "MEMU_DB", "MEMU_CLOUD_API_KEY", "MEMU_EMBED_PROVIDER", "MEMU_EMBED_MODEL")
+        if os.environ.get(key) and os.environ[key] != values.get(key)
+    )
+    if shadowed:
+        print(f"note: the environment overrides what this file says for {', '.join(shadowed)}")
+    return 0
+
+
+def register(sub: Any, *, binary: str) -> None:
+    """Add ``init`` and ``config`` to a host CLI's subparsers.
+
+    ``binary`` is the host adapter's own command name, carried on the parser
+    defaults purely so the next-step lines name the binary the agent is already
+    holding — ``SKILL.md``'s ergonomic bet is that one binary name serves the
+    whole flow.
+    """
+    initialiser = sub.add_parser(
+        "init",
+        help="Create or update ~/.memu/config.env — the one command SKILL.md names before `docs install`",
+    )
+    initialiser.add_argument(
+        "--cloud-api-key",
+        default="",
+        help="The user's memU Cloud key. Providing one selects cloud memory; omit it to keep or default the mode",
+    )
+    initialiser.set_defaults(handler=_cmd_init, binary=binary)
+
+    configure = sub.add_parser(
+        "config",
+        help="Set the memory backend explicitly in ~/.memu/config.env, or `config show` to read it",
+    )
+    # `show` as a positional rather than a flag, so the read side is a name an
+    # agent types deliberately and can never be a bare `config` that wrote.
+    configure.add_argument(
+        "show",
+        nargs="?",
+        choices=("show",),
+        help="Print the declared configuration and exit, writing nothing",
+    )
+    mode = configure.add_mutually_exclusive_group()
+    mode.add_argument("--cloud", action="store_true", help="Select memU Cloud memory")
+    mode.add_argument("--local", action="store_true", help="Select local memory on this device")
+    configure.add_argument("--cloud-api-key", default="", help="memU Cloud key (cloud mode)")
+    configure.add_argument("--cloud-base-url", default="", help="Override the memU Cloud endpoint (cloud mode)")
+    configure.add_argument("--db", default="", help="Local store: an absolute path, a sqlite:// or a postgres:// DSN")
+    configure.add_argument("--embed-provider", default="", help="Embedding provider id (openai, jina, voyage, …)")
+    configure.add_argument("--embed-model", default="", help="Embedding model id")
+    # Named for the variable it writes, never `--api-key`: MEMU_API_KEY is the
+    # embedding provider's credential and MEMU_CLOUD_API_KEY is memU Cloud's, and
+    # this is the one surface meant to close the door on confusing them.
+    configure.add_argument("--embed-api-key", default="", help="Embedding provider credential (MEMU_API_KEY)")
+    configure.add_argument(
+        "--embed-base-url", default="", help="Embedding endpoint, e.g. a local OpenAI-compatible server"
+    )
+    configure.add_argument(
+        "--force",
+        action="store_true",
+        help="Override the one-backend guard. Only when the store is genuinely being replaced",
+    )
+    configure.set_defaults(handler=_cmd_config, binary=binary)

--- a/src/memu/hosts/cursor/INSTALL.md
+++ b/src/memu/hosts/cursor/INSTALL.md
@@ -38,8 +38,14 @@ and is not mined.
 ## Part 1 — Install memU
 
 ```
-pip install memu-cli
+pip install --upgrade memu-cli
 ```
+
+**`--upgrade` matters, and a bare install is not enough.** A machine that
+already carries an older `memu-cli` keeps it otherwise, and this guide names
+subcommands (`init`, `config`) that older builds answer with `invalid choice`.
+If you meet that error anywhere below, you are on a stale build: upgrade, then
+re-run the command that failed.
 
 This puts `memu` and **`memu-cursor`** on `PATH`. Confirm: `memu-cursor --help`.
 If it is not found, fix `PATH` now — the scheduled task in Part 2 runs from a
@@ -47,53 +53,99 @@ bare, non-interactive environment.
 
 ### 1.2 Configure the memory backend
 
-If `~/.memu/config.env` already exists from another memU host, reuse it as is
-and skip to the verify gate. An existing file without `MEMU_MEMORY_MODE` is
-local mode for backward compatibility.
+**Never write `~/.memu/config.env` by hand.** No heredoc, no `echo >>`, no
+editor. Every memU host on this machine shares that one file, it holds a
+plaintext credential, and it carries an invariant a text edit cannot keep:
+record and retrieval must agree on one backend — and in local mode on one store
+and one embedding space — or retrieval keeps succeeding and finds nothing.
+`memu-cursor config` is the writer: it merges (anything it is not
+given is left alone, including comments and another host's settings), sets
+the file's permissions, and refuses the edits that break retrieval silently.
+
+**Came from memU's `SKILL.md`? You already ran `init`** — it created the file
+and, if the user handed over a memU Cloud key, already selected cloud memory.
+Read the state below rather than assuming which.
+
+If you came straight to this guide instead, run it now:
+
+```
+memu-cursor init --cloud-api-key <the user's memU key>
+```
+
+Bare `memu-cursor init` if the user has no key, or would rather keep memory on
+this device. Re-running is harmless either way — `init` is idempotent and keeps
+a mode it already finds. One caveat: passing a key selects **cloud**, and on a
+machine already using local memory that is a switch. Nothing is deleted, but
+memories written locally stop being retrieved; `init` warns and proceeds — so
+if you are unsure what this machine already uses, read the state first and say
+what the switch costs before you pass a key.
+
+Reading the state writes nothing:
+
+```
+memu-cursor config show
+```
+
+If it reports a mode with a backend behind it, another memU host got here first:
+**reuse it as is** and go to the verify gate. A file that declares no mode is
+local mode, for backward compatibility with files written before the mode
+existed — `config show` says so.
 
 Otherwise ask the user to choose once:
 
 - **MemU Cloud** — memory and embeddings are hosted; requires a memU API key.
-- **This device** — use the existing local database and embedding configuration.
+- **This device** — a database and an embedding provider on this machine.
 
-For **MemU Cloud**, ask the user to provide their memU API key. If they do not
-have one, direct them to [memu.so](https://memu.so) to register and create one,
-then wait for the key before continuing. Write:
+**MemU Cloud.** Ask the user for their memU API key. If they do not have one,
+direct them to [memu.so](https://memu.so) to register and create one, then wait
+for the key before continuing.
 
-```env
-MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<memu-api-key>
+```
+memu-cursor config --cloud --cloud-api-key <memu-api-key>
 ```
 
-The production endpoint defaults to `https://api.memu.so/api/v4/memory/`. The
-key is plaintext in this file: tell the user
-and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
-the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
-for local embedding providers.
+It reports where the file is and what protection it has; tell the user the key
+is stored there in plaintext. The production endpoint defaults to
+`https://api.memu.so/api/v4/memory/` — pass `--cloud-base-url` only for a
+non-default one, and never `--embed-api-key`, which is the *embedding
+provider's* credential and has no role in cloud mode.
 
 Cloud currently persists memory and skill recall files. It accepts workspace
 resources from the existing bridging pipeline for compatibility but does not
-persist or retrieve them yet; tell the user. After writing cloud configuration,
-skip the remaining local-mode guidance and go to the verify gate.
+persist or retrieve them yet; tell the user. Then skip the local-mode guidance
+below and go to the verify gate.
 
-For **This device**, write `MEMU_MEMORY_MODE=local` and collect the settings
-below. "This device" describes memory storage; it is fully offline only when
-the embedding provider is local too:
+**This device.** "This device" describes memory storage; it is fully offline
+only when the embedding provider is local too. One command carries the lot:
 
-| Setting | Env var | Example |
+```
+memu-cursor config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-api-key <key>
+```
+
+| Setting | Flag | Example |
 | --- | --- | --- |
-| Database | `MEMU_DB` | `~/.memu/memu.sqlite3`, or a `postgres://…` DSN |
-| Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
-| API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
+| Database | `--db` | an absolute path (`~/.memu/memu.sqlite3`), or a `postgres://…` DSN |
+| Embedding provider | `--embed-provider` | `openai`, `jina`, `voyage`, … |
+| Embedding model | `--embed-model` | the provider's default if omitted |
+| Embedding credential | `--embed-api-key` | the provider's key — **not** the memU one |
+| Embedding endpoint | `--embed-base-url` | a local OpenAI-compatible server |
 
-**No embedding `MEMU_API_KEY`? Say so, then use a local embedding server.** If the user has no API key to
-give, tell them up front what that means: memory cannot be called across
-devices — everything stays on this machine, in a local database created for
-them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
-`MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local
-OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1`
-with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
-placeholder value — a local server ignores it.
+Only the flags you pass are written, so a later run can add one without
+disturbing the rest. Give `--db` an **absolute** path: a relative one resolves
+against a working directory the scheduled task does not have. And do not export
+any of this in a shell profile instead — the scheduled task does not inherit
+your interactive shell, so the file is the carrier.
+
+**No embedding key? Say so, then use a local embedding server.** If the user has
+no API key to give, tell them up front what that means: memory cannot be called
+across devices — everything stays on this machine, in a local database created
+for them (SQLite). Then configure exactly that — keep `openai` as the provider,
+point the endpoint at a local OpenAI-compatible server (e.g. Ollama), and pass
+any placeholder credential, which such a server ignores:
+
+```
+memu-cursor config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-base-url http://localhost:11434/v1 --embed-model nomic-embed-text --embed-api-key local
+```
 
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
 local embedding server, a proxy is hijacking localhost traffic. The proxy may
@@ -108,19 +160,23 @@ memU. A local server reached through a **non-loopback** address
 a mechanical requirement with exactly one right answer — apply it and move on;
 do not ask the user.
 
-Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
-never a shell-profile export — the scheduled task does not inherit your shell).
+**The existing config fails doctor? Repair the connection, never the identity.**
+If `~/.memu/config.env` predates this install and `doctor` fails, diagnose the
+transport first — is the embedding server running, is a proxy in the way — before
+changing anything. A connection-level repair is an ordinary `config` call and is
+allowed to land:
 
-**The existing config fails doctor? Repair the connection, never the
-identity.** If `~/.memu/config.env` predates this install and `doctor` fails,
-diagnose the transport first — is the embedding server running, is a proxy in
-the way — before touching the file. A minimal connection-level edit (say,
-`localhost` → `127.0.0.1`) is acceptable: back the file up first, and tell the
-user what changed and why. Never change `MEMU_DB`, `MEMU_EMBED_PROVIDER`, or
-`MEMU_EMBED_MODEL` on an existing store — those three bind the embedding
-space, and "fixing" them silently splits the user's memory (old vectors become
-unreachable until everything is re-embedded). If one of them looks wrong, stop
-and ask the user.
+```
+memu-cursor config --local --embed-base-url http://127.0.0.1:11434/v1
+```
+
+The identity is the other matter. `--db`, `--embed-provider` and `--embed-model`
+bind the embedding space every existing vector was written against, so `config`
+**refuses to change one that is already set**: "fixing" it would strand the
+user's whole store while retrieval went on succeeding and finding nothing. The
+refusal names `--force`, which is for a store genuinely being replaced and never
+for making `doctor` go green. If one of the three looks wrong, stop and ask the
+user.
 
 ### ✅ Verify Part 1
 

--- a/src/memu/hosts/generic/INSTALL.md
+++ b/src/memu/hosts/generic/INSTALL.md
@@ -35,9 +35,15 @@ setting anything up.
 ## Part 0 — Detect what this agent supports
 
 ```
-pip install memu-cli
+pip install --upgrade memu-cli
 memu-agent detect
 ```
+
+**`--upgrade` matters, and a bare install is not enough.** A machine that
+already carries an older `memu-cli` keeps it otherwise, and this guide names
+subcommands (`init`, `config`) that older builds answer with `invalid choice`.
+If you meet that error anywhere below, you are on a stale build: upgrade, then
+re-run the command that failed.
 
 `detect` surveys `~` for agent installations (or probes one directory:
 `memu-agent detect ~/.someagent`). For each it reports:
@@ -63,54 +69,99 @@ memU cannot integrate with this agent yet, and no amount of setup changes that.
 
 ## Part 1 — Configure the memory backend
 
-If another memU host adapter is already set up on this machine,
-`~/.memu/config.env` exists and **must be reused as is**; skip to the verify
-gate. An existing file without `MEMU_MEMORY_MODE` is local mode for backward
-compatibility.
+**Never write `~/.memu/config.env` by hand.** No heredoc, no `echo >>`, no
+editor. Every memU host on this machine shares that one file, it holds a
+plaintext credential, and it carries an invariant a text edit cannot keep:
+record and retrieval must agree on one backend — and in local mode on one store
+and one embedding space — or retrieval keeps succeeding and finds nothing.
+`memu-agent config` is the writer: it merges (anything it is not
+given is left alone, including comments and another host's settings), sets
+the file's permissions, and refuses the edits that break retrieval silently.
+
+**Came from memU's `SKILL.md`? You already ran `init`** — it created the file
+and, if the user handed over a memU Cloud key, already selected cloud memory.
+Read the state below rather than assuming which.
+
+If you came straight to this guide instead, run it now:
+
+```
+memu-agent init --cloud-api-key <the user's memU key>
+```
+
+Bare `memu-agent init` if the user has no key, or would rather keep memory on
+this device. Re-running is harmless either way — `init` is idempotent and keeps
+a mode it already finds. One caveat: passing a key selects **cloud**, and on a
+machine already using local memory that is a switch. Nothing is deleted, but
+memories written locally stop being retrieved; `init` warns and proceeds — so
+if you are unsure what this machine already uses, read the state first and say
+what the switch costs before you pass a key.
+
+Reading the state writes nothing:
+
+```
+memu-agent config show
+```
+
+If it reports a mode with a backend behind it, another memU host got here first:
+**reuse it as is** and go to the verify gate. A file that declares no mode is
+local mode, for backward compatibility with files written before the mode
+existed — `config show` says so.
 
 Otherwise ask the user to choose once:
 
 - **MemU Cloud** — memory and embeddings are hosted; requires a memU API key.
-- **This device** — use the existing local database and embedding configuration.
+- **This device** — a database and an embedding provider on this machine.
 
-For **MemU Cloud**, ask the user to provide their memU API key. If they do not
-have one, direct them to [memu.so](https://memu.so) to register and create one,
-then wait for the key before continuing. Write:
+**MemU Cloud.** Ask the user for their memU API key. If they do not have one,
+direct them to [memu.so](https://memu.so) to register and create one, then wait
+for the key before continuing.
 
-```env
-MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<memu-api-key>
+```
+memu-agent config --cloud --cloud-api-key <memu-api-key>
 ```
 
-The production endpoint defaults to `https://api.memu.so/api/v4/memory/`. The
-key is plaintext in this file: tell the user
-and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
-the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
-for local embedding providers.
+It reports where the file is and what protection it has; tell the user the key
+is stored there in plaintext. The production endpoint defaults to
+`https://api.memu.so/api/v4/memory/` — pass `--cloud-base-url` only for a
+non-default one, and never `--embed-api-key`, which is the *embedding
+provider's* credential and has no role in cloud mode.
 
 Cloud currently persists memory and skill recall files. It accepts workspace
 resources from the existing bridging pipeline for compatibility but does not
-persist or retrieve them yet; tell the user. After writing cloud configuration,
-skip the remaining local-mode guidance and go to the verify gate.
+persist or retrieve them yet; tell the user. Then skip the local-mode guidance
+below and go to the verify gate.
 
-For **This device**, write `MEMU_MEMORY_MODE=local` and collect the settings
-below. "This device" describes memory storage; it is fully offline only when
-the embedding provider is local too:
+**This device.** "This device" describes memory storage; it is fully offline
+only when the embedding provider is local too. One command carries the lot:
 
-| Setting | Env var | Example |
+```
+memu-agent config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-api-key <key>
+```
+
+| Setting | Flag | Example |
 | --- | --- | --- |
-| Database | `MEMU_DB` | `~/.memu/memu.sqlite3`, or a `postgres://…` DSN |
-| Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
-| API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
+| Database | `--db` | an absolute path (`~/.memu/memu.sqlite3`), or a `postgres://…` DSN |
+| Embedding provider | `--embed-provider` | `openai`, `jina`, `voyage`, … |
+| Embedding model | `--embed-model` | the provider's default if omitted |
+| Embedding credential | `--embed-api-key` | the provider's key — **not** the memU one |
+| Embedding endpoint | `--embed-base-url` | a local OpenAI-compatible server |
 
-**No embedding `MEMU_API_KEY`? Say so, then use a local embedding server.** If the user has no API key to
-give, tell them up front what that means: memory cannot be called across
-devices — everything stays on this machine, in a local database created for
-them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
-`MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local
-OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1`
-with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
-placeholder value — a local server ignores it.
+Only the flags you pass are written, so a later run can add one without
+disturbing the rest. Give `--db` an **absolute** path: a relative one resolves
+against a working directory the scheduled task does not have. And do not export
+any of this in a shell profile instead — the scheduled task does not inherit
+your interactive shell, so the file is the carrier.
+
+**No embedding key? Say so, then use a local embedding server.** If the user has
+no API key to give, tell them up front what that means: memory cannot be called
+across devices — everything stays on this machine, in a local database created
+for them (SQLite). Then configure exactly that — keep `openai` as the provider,
+point the endpoint at a local OpenAI-compatible server (e.g. Ollama), and pass
+any placeholder credential, which such a server ignores:
+
+```
+memu-agent config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-base-url http://localhost:11434/v1 --embed-model nomic-embed-text --embed-api-key local
+```
 
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
 local embedding server, a proxy is hijacking localhost traffic. The proxy may
@@ -125,19 +176,23 @@ memU. A local server reached through a **non-loopback** address
 a mechanical requirement with exactly one right answer — apply it and move on;
 do not ask the user.
 
-Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
-never a shell-profile export — a scheduled task does not inherit your shell).
+**The existing config fails doctor? Repair the connection, never the identity.**
+If `~/.memu/config.env` predates this install and `doctor` fails, diagnose the
+transport first — is the embedding server running, is a proxy in the way — before
+changing anything. A connection-level repair is an ordinary `config` call and is
+allowed to land:
 
-**The existing config fails doctor? Repair the connection, never the
-identity.** If `~/.memu/config.env` predates this install and `doctor` fails,
-diagnose the transport first — is the embedding server running, is a proxy in
-the way — before touching the file. A minimal connection-level edit (say,
-`localhost` → `127.0.0.1`) is acceptable: back the file up first, and tell the
-user what changed and why. Never change `MEMU_DB`, `MEMU_EMBED_PROVIDER`, or
-`MEMU_EMBED_MODEL` on an existing store — those three bind the embedding
-space, and "fixing" them silently splits the user's memory (old vectors become
-unreachable until everything is re-embedded). If one of them looks wrong, stop
-and ask the user.
+```
+memu-agent config --local --embed-base-url http://127.0.0.1:11434/v1
+```
+
+The identity is the other matter. `--db`, `--embed-provider` and `--embed-model`
+bind the embedding space every existing vector was written against, so `config`
+**refuses to change one that is already set**: "fixing" it would strand the
+user's whole store while retrieval went on succeeding and finding nothing. The
+refusal names `--force`, which is for a store genuinely being replaced and never
+for making `doctor` go green. If one of the three looks wrong, stop and ask the
+user.
 
 ### ✅ Verify Part 1
 

--- a/src/memu/hosts/hermes/INSTALL.md
+++ b/src/memu/hosts/hermes/INSTALL.md
@@ -39,8 +39,14 @@ home (`HERMES_HOME`, or a profile), pass `--session-dir <home>/state.db` to
 ## Part 1 — Install memU
 
 ```
-pip install memu-cli
+pip install --upgrade memu-cli
 ```
+
+**`--upgrade` matters, and a bare install is not enough.** A machine that
+already carries an older `memu-cli` keeps it otherwise, and this guide names
+subcommands (`init`, `config`) that older builds answer with `invalid choice`.
+If you meet that error anywhere below, you are on a stale build: upgrade, then
+re-run the command that failed.
 
 This puts `memu` and **`memu-hermes`** on `PATH`. Confirm: `memu-hermes --help`.
 If it is not found, fix `PATH` now — the scheduled task in Part 2 runs from a
@@ -48,53 +54,99 @@ bare, non-interactive environment.
 
 ### 1.2 Configure the memory backend
 
-If `~/.memu/config.env` already exists from another memU host, reuse it as is
-and skip to the verify gate. An existing file without `MEMU_MEMORY_MODE` is
-local mode for backward compatibility.
+**Never write `~/.memu/config.env` by hand.** No heredoc, no `echo >>`, no
+editor. Every memU host on this machine shares that one file, it holds a
+plaintext credential, and it carries an invariant a text edit cannot keep:
+record and retrieval must agree on one backend — and in local mode on one store
+and one embedding space — or retrieval keeps succeeding and finds nothing.
+`memu-hermes config` is the writer: it merges (anything it is not
+given is left alone, including comments and another host's settings), sets
+the file's permissions, and refuses the edits that break retrieval silently.
+
+**Came from memU's `SKILL.md`? You already ran `init`** — it created the file
+and, if the user handed over a memU Cloud key, already selected cloud memory.
+Read the state below rather than assuming which.
+
+If you came straight to this guide instead, run it now:
+
+```
+memu-hermes init --cloud-api-key <the user's memU key>
+```
+
+Bare `memu-hermes init` if the user has no key, or would rather keep memory on
+this device. Re-running is harmless either way — `init` is idempotent and keeps
+a mode it already finds. One caveat: passing a key selects **cloud**, and on a
+machine already using local memory that is a switch. Nothing is deleted, but
+memories written locally stop being retrieved; `init` warns and proceeds — so
+if you are unsure what this machine already uses, read the state first and say
+what the switch costs before you pass a key.
+
+Reading the state writes nothing:
+
+```
+memu-hermes config show
+```
+
+If it reports a mode with a backend behind it, another memU host got here first:
+**reuse it as is** and go to the verify gate. A file that declares no mode is
+local mode, for backward compatibility with files written before the mode
+existed — `config show` says so.
 
 Otherwise ask the user to choose once:
 
 - **MemU Cloud** — memory and embeddings are hosted; requires a memU API key.
-- **This device** — use the existing local database and embedding configuration.
+- **This device** — a database and an embedding provider on this machine.
 
-For **MemU Cloud**, ask the user to provide their memU API key. If they do not
-have one, direct them to [memu.so](https://memu.so) to register and create one,
-then wait for the key before continuing. Write:
+**MemU Cloud.** Ask the user for their memU API key. If they do not have one,
+direct them to [memu.so](https://memu.so) to register and create one, then wait
+for the key before continuing.
 
-```env
-MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<memu-api-key>
+```
+memu-hermes config --cloud --cloud-api-key <memu-api-key>
 ```
 
-The production endpoint defaults to `https://api.memu.so/api/v4/memory/`. The
-key is plaintext in this file: tell the user
-and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
-the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
-for local embedding providers.
+It reports where the file is and what protection it has; tell the user the key
+is stored there in plaintext. The production endpoint defaults to
+`https://api.memu.so/api/v4/memory/` — pass `--cloud-base-url` only for a
+non-default one, and never `--embed-api-key`, which is the *embedding
+provider's* credential and has no role in cloud mode.
 
 Cloud currently persists memory and skill recall files. It accepts workspace
 resources from the existing bridging pipeline for compatibility but does not
-persist or retrieve them yet; tell the user. After writing cloud configuration,
-skip the remaining local-mode guidance and go to the verify gate.
+persist or retrieve them yet; tell the user. Then skip the local-mode guidance
+below and go to the verify gate.
 
-For **This device**, write `MEMU_MEMORY_MODE=local` and collect the settings
-below. "This device" describes memory storage; it is fully offline only when
-the embedding provider is local too:
+**This device.** "This device" describes memory storage; it is fully offline
+only when the embedding provider is local too. One command carries the lot:
 
-| Setting | Env var | Example |
+```
+memu-hermes config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-api-key <key>
+```
+
+| Setting | Flag | Example |
 | --- | --- | --- |
-| Database | `MEMU_DB` | `~/.memu/memu.sqlite3`, or a `postgres://…` DSN |
-| Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
-| API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
+| Database | `--db` | an absolute path (`~/.memu/memu.sqlite3`), or a `postgres://…` DSN |
+| Embedding provider | `--embed-provider` | `openai`, `jina`, `voyage`, … |
+| Embedding model | `--embed-model` | the provider's default if omitted |
+| Embedding credential | `--embed-api-key` | the provider's key — **not** the memU one |
+| Embedding endpoint | `--embed-base-url` | a local OpenAI-compatible server |
 
-**No embedding `MEMU_API_KEY`? Say so, then use a local embedding server.** If the user has no API key to
-give, tell them up front what that means: memory cannot be called across
-devices — everything stays on this machine, in a local database created for
-them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
-`MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local
-OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1`
-with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
-placeholder value — a local server ignores it.
+Only the flags you pass are written, so a later run can add one without
+disturbing the rest. Give `--db` an **absolute** path: a relative one resolves
+against a working directory the scheduled task does not have. And do not export
+any of this in a shell profile instead — the scheduled task does not inherit
+your interactive shell, so the file is the carrier.
+
+**No embedding key? Say so, then use a local embedding server.** If the user has
+no API key to give, tell them up front what that means: memory cannot be called
+across devices — everything stays on this machine, in a local database created
+for them (SQLite). Then configure exactly that — keep `openai` as the provider,
+point the endpoint at a local OpenAI-compatible server (e.g. Ollama), and pass
+any placeholder credential, which such a server ignores:
+
+```
+memu-hermes config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-base-url http://localhost:11434/v1 --embed-model nomic-embed-text --embed-api-key local
+```
 
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
 local embedding server, a proxy is hijacking localhost traffic. The proxy may
@@ -109,19 +161,23 @@ memU. A local server reached through a **non-loopback** address
 a mechanical requirement with exactly one right answer — apply it and move on;
 do not ask the user.
 
-Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
-never a shell-profile export — the scheduled task does not inherit your shell).
+**The existing config fails doctor? Repair the connection, never the identity.**
+If `~/.memu/config.env` predates this install and `doctor` fails, diagnose the
+transport first — is the embedding server running, is a proxy in the way — before
+changing anything. A connection-level repair is an ordinary `config` call and is
+allowed to land:
 
-**The existing config fails doctor? Repair the connection, never the
-identity.** If `~/.memu/config.env` predates this install and `doctor` fails,
-diagnose the transport first — is the embedding server running, is a proxy in
-the way — before touching the file. A minimal connection-level edit (say,
-`localhost` → `127.0.0.1`) is acceptable: back the file up first, and tell the
-user what changed and why. Never change `MEMU_DB`, `MEMU_EMBED_PROVIDER`, or
-`MEMU_EMBED_MODEL` on an existing store — those three bind the embedding
-space, and "fixing" them silently splits the user's memory (old vectors become
-unreachable until everything is re-embedded). If one of them looks wrong, stop
-and ask the user.
+```
+memu-hermes config --local --embed-base-url http://127.0.0.1:11434/v1
+```
+
+The identity is the other matter. `--db`, `--embed-provider` and `--embed-model`
+bind the embedding space every existing vector was written against, so `config`
+**refuses to change one that is already set**: "fixing" it would strand the
+user's whole store while retrieval went on succeeding and finding nothing. The
+refusal names `--force`, which is for a store genuinely being replaced and never
+for making `doctor` go green. If one of the three looks wrong, stop and ask the
+user.
 
 ### ✅ Verify Part 1
 

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -646,33 +646,36 @@ async def _cmd_docs(spec: HostSpec, args: argparse.Namespace) -> int:
     resolved = templates.resolve_doc(spec.host, filename, embedded)
     print(spec.render_doc(resolved))
     if args.doc == "install":
-        _report_install_started(spec)
+        _report_guide_opened(spec)
     return 0
 
 
-def _report_install_started(spec: HostSpec) -> None:
-    """The install funnel's entry point (ADR 0016 §4).
+def _report_guide_opened(spec: HostSpec) -> None:
+    """The install funnel's second step (ADR 0016 §4).
 
-    Printing this guide is the first act on the install path that *proves*
-    ``memu-cli`` is installed and resolving — `SKILL.md` Step 3, immediately after
-    the pip install — so the start is observed here rather than asked for in prose.
-    That is what makes ``started >= completed`` hold structurally: ``report
-    install`` is voluntary and undercounts, and a start that undercounted
-    independently of it could report more completions than attempts.
+    Formerly ``cli_install_started``, and only the name changed: the *start* now
+    sits one command earlier, at ``init`` — ``SKILL.md`` Step 2, which knows the
+    host and the key and writes the config this machine is identified by (ADR
+    0017). Printing the guide is Step 3, so what this observes is the narrower and
+    still worth-observing fact that an agent which configured memU went on to ask
+    for the guide.
 
-    ``install-instruction`` was rejected as a stand-in for *completion* precisely
-    because it also runs on re-runs and partial repairs. For a *start* that is the
-    correct reading: a re-run is a new attempt.
+    Code-observed on both legs, which is what makes ``started >= succeeded`` hold
+    structurally: ``report install`` is voluntary and undercounts, and a start
+    that undercounted independently of it could report more completions than
+    attempts. ``install-instruction`` was rejected as a stand-in for *completion*
+    precisely because it also runs on re-runs and partial repairs; for a step on
+    the way in, a re-run is a new attempt, which is the correct reading.
 
     Flushed, not merely recorded, and that is the load-bearing half. An install
     that dies in Part 2 never reaches ``prepare`` or ``commit`` — the ordinary
-    flush points — so without this its start, and every ``cli_error`` it collected
-    on the way down, would sit in the spool forever. That run is the exact one
-    this event exists to make visible. Affordable here because ``resolve_doc``
-    above has already blocked on a server GET: this is a guide-printing path, not
-    a hot one.
+    flush points — so without this its earlier events, and every ``cli_error`` it
+    collected on the way down, would sit in the spool forever. That run is the
+    exact one these events exist to make visible. Affordable here because
+    ``resolve_doc`` above has already blocked on a server GET: this is a
+    guide-printing path, not a hot one.
     """
-    events.record(events.CLI_INSTALL_STARTED, host=spec.host, session_id_env=spec.session_id_env)
+    events.record(events.INSTALL_GUIDE_OPENED, host=spec.host, session_id_env=spec.session_id_env)
     events.flush()
 
 
@@ -830,7 +833,7 @@ def build_parser(spec: HostSpec) -> argparse.ArgumentParser:
     # every later step is `<that binary> …`. A second binary mid-flow adds a
     # branch, a fresh "command not found", and a name likelier to be shadowed on
     # PATH. `doctor` is just as host-irrelevant and lives here for the same reason.
-    config_cmd.register(sub, binary=spec.binary)
+    config_cmd.register(sub, binary=spec.binary, host=spec.host, session_id_env=spec.session_id_env)
     instruction.register(
         sub,
         path=spec.instruction_path,

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -61,6 +61,20 @@ def _task_name_pattern(names: tuple[str, ...]) -> str:
     return "|".join(re.escape(name) for name in names)
 
 
+GUIDE_EVENTS = {
+    "install": events.INSTALL_GUIDE_OPENED,
+    "uninstall": events.UNINSTALL_GUIDE_OPENED,
+}
+"""Which of :data:`DOCS` report being opened (:func:`_report_guide_opened`).
+
+The two lifecycle guides, and deliberately not ``task``: ``BRIDGING_TASK.md`` is
+printed by a scheduled run rather than by someone deciding something, so a row per
+printing would count the schedule's frequency and nothing else — and the bridging
+pair it describes is already the most thoroughly instrumented path in the product.
+A doc missing here simply prints, which is what keeps adding one to ``DOCS`` from
+silently owing an event."""
+
+
 @dataclass(frozen=True)
 class HostSpec:
     """Everything host-specific about a host adapter's CLI — data, not code."""
@@ -645,37 +659,42 @@ async def _cmd_docs(spec: HostSpec, args: argparse.Namespace) -> int:
     embedded = (files(spec.package) / filename).read_text(encoding="utf-8")
     resolved = templates.resolve_doc(spec.host, filename, embedded)
     print(spec.render_doc(resolved))
-    if args.doc == "install":
-        _report_guide_opened(spec)
+    event = GUIDE_EVENTS.get(args.doc)
+    if event:
+        _report_guide_opened(spec, event)
     return 0
 
 
-def _report_guide_opened(spec: HostSpec) -> None:
-    """The install funnel's second step (ADR 0016 §4).
+def _report_guide_opened(spec: HostSpec, event: str) -> None:
+    """A lifecycle guide was printed — the install funnel's second step (ADR 0016 §4),
+    or its counterpart on the way out.
 
-    Formerly ``cli_install_started``, and only the name changed: the *start* now
-    sits one command earlier, at ``init`` — ``SKILL.md`` Step 2, which knows the
-    host and the key and writes the config this machine is identified by (ADR
-    0017). Printing the guide is Step 3, so what this observes is the narrower and
-    still worth-observing fact that an agent which configured memU went on to ask
-    for the guide.
+    ``install_guide_opened`` was formerly ``cli_install_started``, and only the name
+    changed: the *start* now sits one command earlier, at ``init`` — ``SKILL.md``
+    Step 2, which knows the host and the key and writes the config this machine is
+    identified by (ADR 0017). Printing the guide is Step 3, so what this observes is
+    the narrower and still worth-observing fact that an agent which configured memU
+    went on to ask for the guide. ``uninstall_guide_opened`` is the same observation
+    on the way out, and the only code-observed step the removal path has.
 
-    Code-observed on both legs, which is what makes ``started >= succeeded`` hold
-    structurally: ``report install`` is voluntary and undercounts, and a start
-    that undercounted independently of it could report more completions than
-    attempts. ``install-instruction`` was rejected as a stand-in for *completion*
-    precisely because it also runs on re-runs and partial repairs; for a step on
-    the way in, a re-run is a new attempt, which is the correct reading.
+    Code-observed on both legs of the install funnel, which is what makes
+    ``started >= succeeded`` hold structurally: ``report install`` is voluntary and
+    undercounts, and a start that undercounted independently of it could report more
+    completions than attempts. ``install-instruction`` was rejected as a stand-in for
+    *completion* precisely because it also runs on re-runs and partial repairs; for a
+    step on the way in, a re-run is a new attempt, which is the correct reading.
 
-    Flushed, not merely recorded, and that is the load-bearing half. An install
-    that dies in Part 2 never reaches ``prepare`` or ``commit`` — the ordinary
-    flush points — so without this its earlier events, and every ``cli_error`` it
-    collected on the way down, would sit in the spool forever. That run is the
-    exact one these events exist to make visible. Affordable here because
-    ``resolve_doc`` above has already blocked on a server GET: this is a
-    guide-printing path, not a hot one.
+    Flushed, not merely recorded, and that is the load-bearing half. An install that
+    dies in Part 2 never reaches ``prepare`` or ``commit`` — the ordinary flush
+    points — so without this its earlier events, and every ``cli_error`` it collected
+    on the way down, would sit in the spool forever. That run is the exact one these
+    events exist to make visible. On the uninstall side the deadline is harder still:
+    ``UNINSTALL.md`` Part 3 removes the package, so anything left spooled loses the
+    binary that would have sent it — the same reason ``report uninstall`` flushes
+    inline. Affordable in both cases because ``resolve_doc`` above has already
+    blocked on a server GET: this is a guide-printing path, not a hot one.
     """
-    events.record(events.INSTALL_GUIDE_OPENED, host=spec.host, session_id_env=spec.session_id_env)
+    events.record(event, host=spec.host, session_id_env=spec.session_id_env)
     events.flush()
 
 

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -37,7 +37,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from memu import events
-from memu.hosts import instruction, retrieval, templates
+from memu.hosts import config_cmd, instruction, retrieval, templates
 from memu.hosts.base import TranscriptSource
 from memu.hosts.bridging import Layout, commit, prepare, self_sessions
 from memu.hosts.bridging.pipeline import MAX_JOBS
@@ -824,6 +824,13 @@ def build_parser(spec: HostSpec) -> argparse.ArgumentParser:
     # the instruction lands in and the binary it names are ours to fill in.
     retrieval.register(sub, host=spec.host, session_id_env=spec.session_id_env)
     _register_report(sub, bind(_cmd_report))
+    # `config.env` is host-irrelevant, so `memu` is the algorithmically correct
+    # home for these (ADR 0009) — and the wrong one for the install flow, whose
+    # ergonomic bet is that `SKILL.md` hands the agent exactly one binary name and
+    # every later step is `<that binary> …`. A second binary mid-flow adds a
+    # branch, a fresh "command not found", and a name likelier to be shadowed on
+    # PATH. `doctor` is just as host-irrelevant and lives here for the same reason.
+    config_cmd.register(sub, binary=spec.binary)
     instruction.register(
         sub,
         path=spec.instruction_path,

--- a/src/memu/hosts/host_cli.py
+++ b/src/memu/hosts/host_cli.py
@@ -727,15 +727,25 @@ async def _cmd_report(spec: HostSpec, args: argparse.Namespace) -> int:
 
     if args.what == "install":
         events.record(events.CLI_INSTALL_SUCCEEDED, host=spec.host, session_id_env=spec.session_id_env)
+        # Flushed, which makes the whole funnel deliverable from the install itself:
+        # `init` and `docs install` already flush, and leaving only the terminal row
+        # spooled would put the event that asserts the install worked behind the
+        # bridging pair — machinery this event has not yet proven runs. The install
+        # whose schedule never registered is precisely the one a consumer must be
+        # able to see completing, and it is also the run least likely to flush later.
+        # Affordable for the same reason `report error` is: `INSTALL.md`'s last step
+        # is not a hot path, and fail-open means an unreachable endpoint costs the
+        # timeout, never the event.
+        events.flush()
         print(outcome)
         return 0
 
     if args.what == "uninstall":
         events.record(events.CLI_UNINSTALL_SUCCEEDED, host=spec.host, session_id_env=spec.session_id_env)
-        # The one event that cannot wait for a later flush: `UNINSTALL.md` Part 3
-        # may remove the very binary that would deliver it. A whole flush, not the
-        # single-event `deliver=True` path — what this needs is the spool *emptied*
-        # before the binary goes, not one envelope sent.
+        # The event with the hardest deadline: `UNINSTALL.md` Part 3 may remove the
+        # very binary that would deliver it, so there may be no later flush at all.
+        # A whole flush, not the single-event `deliver=True` path — what this needs
+        # is the spool *emptied* before the binary goes, not one envelope sent.
         events.flush()
         print(outcome)
         return 0
@@ -771,7 +781,9 @@ def _register_report(sub: Any, handler: Any) -> None:
     parser = sub.add_parser("report", help="Report a lifecycle event to memU")
     what = parser.add_subparsers(dest="what", required=True)
 
-    installed = what.add_parser("install", help="Record that installation completed successfully")
+    installed = what.add_parser(
+        "install", help="Record that installation completed successfully (delivers immediately)"
+    )
     installed.set_defaults(handler=handler)
 
     uninstalled = what.add_parser("uninstall", help="Record that memU was uninstalled (delivers immediately)")
@@ -926,9 +938,11 @@ def run(spec: HostSpec, argv: list[str] | None = None) -> int:
         #
         # Never for `retrieve`, though, and the exception is the whole point. That
         # is the per-turn hook, and a store it cannot reach fails it on *every*
-        # turn — so flushing here would put a blocking POST on the hot path, once
-        # per turn, exactly when the user is already broken. Its events wait for
-        # the bridging pair like any other.
+        # turn — so flushing here would drain the whole spool on the hot path, once
+        # per turn, exactly when the user is already broken. The distinction is one
+        # POST versus all of them, not reporting versus silence: `_cmd_retrieve` has
+        # already delivered its own `memory_search_failed` envelope by now, which is
+        # the bounded way to say the same thing. Only this `cli_error` waits.
         if command != "retrieve":
             events.flush()
         if os.environ.get("MEMU_DEBUG") == "1":

--- a/src/memu/hosts/openclaw/INSTALL.md
+++ b/src/memu/hosts/openclaw/INSTALL.md
@@ -41,8 +41,14 @@ cursor after it. If this install runs a non-default state dir
 ## Part 1 — Install memU
 
 ```
-pip install memu-cli
+pip install --upgrade memu-cli
 ```
+
+**`--upgrade` matters, and a bare install is not enough.** A machine that
+already carries an older `memu-cli` keeps it otherwise, and this guide names
+subcommands (`init`, `config`) that older builds answer with `invalid choice`.
+If you meet that error anywhere below, you are on a stale build: upgrade, then
+re-run the command that failed.
 
 This puts `memu` and **`memu-openclaw`** on `PATH`. Confirm:
 `memu-openclaw --help`. If it is not found, fix `PATH` now — the scheduled task
@@ -50,53 +56,99 @@ in Part 2 runs from a bare, non-interactive environment.
 
 ### 1.2 Configure the memory backend
 
-If `~/.memu/config.env` already exists from another memU host, reuse it as is
-and skip to the verify gate. An existing file without `MEMU_MEMORY_MODE` is
-local mode for backward compatibility.
+**Never write `~/.memu/config.env` by hand.** No heredoc, no `echo >>`, no
+editor. Every memU host on this machine shares that one file, it holds a
+plaintext credential, and it carries an invariant a text edit cannot keep:
+record and retrieval must agree on one backend — and in local mode on one store
+and one embedding space — or retrieval keeps succeeding and finds nothing.
+`memu-openclaw config` is the writer: it merges (anything it is not
+given is left alone, including comments and another host's settings), sets
+the file's permissions, and refuses the edits that break retrieval silently.
+
+**Came from memU's `SKILL.md`? You already ran `init`** — it created the file
+and, if the user handed over a memU Cloud key, already selected cloud memory.
+Read the state below rather than assuming which.
+
+If you came straight to this guide instead, run it now:
+
+```
+memu-openclaw init --cloud-api-key <the user's memU key>
+```
+
+Bare `memu-openclaw init` if the user has no key, or would rather keep memory
+on this device. Re-running is harmless either way — `init` is idempotent and
+keeps a mode it already finds. One caveat: passing a key selects **cloud**, and
+on a machine already using local memory that is a switch. Nothing is deleted,
+but memories written locally stop being retrieved; `init` warns and proceeds —
+so if you are unsure what this machine already uses, read the state first and
+say what the switch costs before you pass a key.
+
+Reading the state writes nothing:
+
+```
+memu-openclaw config show
+```
+
+If it reports a mode with a backend behind it, another memU host got here first:
+**reuse it as is** and go to the verify gate. A file that declares no mode is
+local mode, for backward compatibility with files written before the mode
+existed — `config show` says so.
 
 Otherwise ask the user to choose once:
 
 - **MemU Cloud** — memory and embeddings are hosted; requires a memU API key.
-- **This device** — use the existing local database and embedding configuration.
+- **This device** — a database and an embedding provider on this machine.
 
-For **MemU Cloud**, ask the user to provide their memU API key. If they do not
-have one, direct them to [memu.so](https://memu.so) to register and create one,
-then wait for the key before continuing. Write:
+**MemU Cloud.** Ask the user for their memU API key. If they do not have one,
+direct them to [memu.so](https://memu.so) to register and create one, then wait
+for the key before continuing.
 
-```env
-MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<memu-api-key>
+```
+memu-openclaw config --cloud --cloud-api-key <memu-api-key>
 ```
 
-The production endpoint defaults to `https://api.memu.so/api/v4/memory/`. The
-key is plaintext in this file: tell the user
-and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
-the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
-for local embedding providers.
+It reports where the file is and what protection it has; tell the user the key
+is stored there in plaintext. The production endpoint defaults to
+`https://api.memu.so/api/v4/memory/` — pass `--cloud-base-url` only for a
+non-default one, and never `--embed-api-key`, which is the *embedding
+provider's* credential and has no role in cloud mode.
 
 Cloud currently persists memory and skill recall files. It accepts workspace
 resources from the existing bridging pipeline for compatibility but does not
-persist or retrieve them yet; tell the user. After writing cloud configuration,
-skip the remaining local-mode guidance and go to the verify gate.
+persist or retrieve them yet; tell the user. Then skip the local-mode guidance
+below and go to the verify gate.
 
-For **This device**, write `MEMU_MEMORY_MODE=local` and collect the settings
-below. "This device" describes memory storage; it is fully offline only when
-the embedding provider is local too:
+**This device.** "This device" describes memory storage; it is fully offline
+only when the embedding provider is local too. One command carries the lot:
 
-| Setting | Env var | Example |
+```
+memu-openclaw config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-api-key <key>
+```
+
+| Setting | Flag | Example |
 | --- | --- | --- |
-| Database | `MEMU_DB` | `~/.memu/memu.sqlite3`, or a `postgres://…` DSN |
-| Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
-| API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
+| Database | `--db` | an absolute path (`~/.memu/memu.sqlite3`), or a `postgres://…` DSN |
+| Embedding provider | `--embed-provider` | `openai`, `jina`, `voyage`, … |
+| Embedding model | `--embed-model` | the provider's default if omitted |
+| Embedding credential | `--embed-api-key` | the provider's key — **not** the memU one |
+| Embedding endpoint | `--embed-base-url` | a local OpenAI-compatible server |
 
-**No embedding `MEMU_API_KEY`? Say so, then use a local embedding server.** If the user has no API key to
-give, tell them up front what that means: memory cannot be called across
-devices — everything stays on this machine, in a local database created for
-them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
-`MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local
-OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1`
-with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
-placeholder value — a local server ignores it.
+Only the flags you pass are written, so a later run can add one without
+disturbing the rest. Give `--db` an **absolute** path: a relative one resolves
+against a working directory the scheduled task does not have. And do not export
+any of this in a shell profile instead — the scheduled task does not inherit
+your interactive shell, so the file is the carrier.
+
+**No embedding key? Say so, then use a local embedding server.** If the user has
+no API key to give, tell them up front what that means: memory cannot be called
+across devices — everything stays on this machine, in a local database created
+for them (SQLite). Then configure exactly that — keep `openai` as the provider,
+point the endpoint at a local OpenAI-compatible server (e.g. Ollama), and pass
+any placeholder credential, which such a server ignores:
+
+```
+memu-openclaw config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-base-url http://localhost:11434/v1 --embed-model nomic-embed-text --embed-api-key local
+```
 
 **Shell proxies: nothing to ask.** If `doctor` fails with a **502** against a
 local embedding server, a proxy is hijacking localhost traffic. The proxy may
@@ -111,19 +163,23 @@ memU. A local server reached through a **non-loopback** address
 a mechanical requirement with exactly one right answer — apply it and move on;
 do not ask the user.
 
-Write them to **`~/.memu/config.env`** (absolute `MEMU_DB` path, `chmod 600`,
-never a shell-profile export — the scheduled task does not inherit your shell).
+**The existing config fails doctor? Repair the connection, never the identity.**
+If `~/.memu/config.env` predates this install and `doctor` fails, diagnose the
+transport first — is the embedding server running, is a proxy in the way — before
+changing anything. A connection-level repair is an ordinary `config` call and is
+allowed to land:
 
-**The existing config fails doctor? Repair the connection, never the
-identity.** If `~/.memu/config.env` predates this install and `doctor` fails,
-diagnose the transport first — is the embedding server running, is a proxy in
-the way — before touching the file. A minimal connection-level edit (say,
-`localhost` → `127.0.0.1`) is acceptable: back the file up first, and tell the
-user what changed and why. Never change `MEMU_DB`, `MEMU_EMBED_PROVIDER`, or
-`MEMU_EMBED_MODEL` on an existing store — those three bind the embedding
-space, and "fixing" them silently splits the user's memory (old vectors become
-unreachable until everything is re-embedded). If one of them looks wrong, stop
-and ask the user.
+```
+memu-openclaw config --local --embed-base-url http://127.0.0.1:11434/v1
+```
+
+The identity is the other matter. `--db`, `--embed-provider` and `--embed-model`
+bind the embedding space every existing vector was written against, so `config`
+**refuses to change one that is already set**: "fixing" it would strand the
+user's whole store while retrieval went on succeeding and finding nothing. The
+refusal names `--force`, which is for a store genuinely being replaced and never
+for making `doctor` go green. If one of the three looks wrong, stop and ask the
+user.
 
 ### ✅ Verify Part 1
 

--- a/src/memu/hosts/retrieval.py
+++ b/src/memu/hosts/retrieval.py
@@ -118,11 +118,12 @@ def _shape_for_agent(result: dict[str, Any]) -> dict[str, Any]:
 
 
 async def _cmd_retrieve(args: argparse.Namespace) -> int:
-    # Delivered inline, never flushed (ADR 0016): the backend wants the retrieval
-    # event promptly and accepted the round trip that costs, but this is still the
-    # per-turn hook, so what it may spend is *one* POST — `deliver=True` sends this
-    # envelope alone and spools it if that fails. `events.flush()` here would drain
-    # the whole spool, up to 200 serial requests on the hottest path in the product.
+    # Delivered inline on both legs, never flushed (ADR 0016): the backend wants the
+    # retrieval event promptly and accepted the round trip that costs, but this is
+    # still the per-turn hook, so what either leg may spend is *one* POST —
+    # `deliver=True` sends that envelope alone and spools it if it does not land.
+    # `events.flush()` here would drain the whole spool, up to 200 serial requests on
+    # the hottest path in the product, and that bound is what may never be relaxed.
     # The query text is deliberately not among what is recorded — counts only.
     started = time.monotonic()
     try:
@@ -133,18 +134,21 @@ async def _cmd_retrieve(args: argparse.Namespace) -> int:
         # returning nothing for a week — is a different proposition with a different
         # provenance, and stays on `agent_error_reported` (ADR 0016 §4).
         #
-        # Spooled, not delivered, and that asymmetry is deliberate. A store this
-        # hook cannot reach fails it on *every* turn, so delivering here would add
-        # a blocking POST to each one precisely when the user is already broken —
-        # the same reasoning that keeps `retrieve` out of the CLI error handler's
-        # flush (`host_cli.run`). Nothing is stranded: the next retrieve that
-        # succeeds carries these out ahead of itself, as does the bridging pair.
+        # Delivered, like the success leg. A store this hook cannot reach breaks the
+        # bridging pair with it, so the later flush this event would otherwise wait
+        # for is the same machinery its own failure implicates — leaving it spooled
+        # makes a broken machine the one that reports least. The cost is the same
+        # constant either leg pays, one POST, and it is bounded by `_TIMEOUT_SECONDS`
+        # rather than by how far behind the spool has fallen. What does not follow is
+        # a flush: `host_cli.run` still exempts `retrieve` from the error handler's,
+        # because *that* is the unbounded one.
         events.record_outcome(
             events.MEMORY_SEARCH_SUCCEEDED,
             events.MEMORY_SEARCH_FAILED,
             host=args.host,
             session_id_env=args.session_id_env,
             success=False,
+            deliver=True,
             result_count=0,
             latency_ms=round((time.monotonic() - started) * 1000),
         )

--- a/src/memu/hosts/templates.py
+++ b/src/memu/hosts/templates.py
@@ -44,6 +44,7 @@ import urllib.request
 from collections.abc import Iterable
 from pathlib import Path
 
+from memu import trust
 from memu.hosts.bridging.layout import BASE_DIR
 
 DEFAULT_BASE_URL = "https://memu.pro/sdk/instructions"
@@ -110,10 +111,14 @@ def _get(url: str) -> str | None:
     both templates and docs. ``None`` on offline, non-200, oversize, or
     undecodable; content trust is the *caller's* job, applied to what this returns.
 
-    Never raises.
+    Never raises — which is exactly why it needs
+    :func:`memu.trust.urlopen_kwargs`. A Python with no CA bundle fails
+    verification on every call, and the ``except`` below turns that into a
+    permanent, invisible "the server is unreachable": this machine would never
+    see a template update again and would never say so.
     """
     try:
-        with urllib.request.urlopen(url, timeout=_TIMEOUT_SECONDS) as resp:  # noqa: S310
+        with urllib.request.urlopen(url, timeout=_TIMEOUT_SECONDS, **trust.urlopen_kwargs()) as resp:  # noqa: S310
             if getattr(resp, "status", 200) != 200:
                 return None
             # Read one byte past the cap so an exactly-cap body is still accepted

--- a/src/memu/hosts/workbuddy/INSTALL.md
+++ b/src/memu/hosts/workbuddy/INSTALL.md
@@ -38,8 +38,14 @@ regardless, because the bridging task runs Python.
 ### 1.1 Install
 
 ```
-pip install memu-cli
+pip install --upgrade memu-cli
 ```
+
+**`--upgrade` matters, and a bare install is not enough.** A machine that
+already carries an older `memu-cli` keeps it otherwise, and this guide names
+subcommands (`init`, `config`) that older builds answer with `invalid choice`.
+If you meet that error anywhere below, you are on a stale build: upgrade, then
+re-run the command that failed.
 
 This puts `memu` (the library's own surface) and **`memu-workbuddy`** (the
 WorkBuddy adapter) on `PATH`. Both Part 2 (record) and Part 3 (inject) go
@@ -57,58 +63,117 @@ non-interactive environment and needs this command to resolve there.
 
 ### 1.2 Configure the memory backend
 
-If `~/.memu/config.env` already exists from another memU host, reuse it as is
-and skip to the verify gate. An existing file without `MEMU_MEMORY_MODE` is
-local mode for backward compatibility.
+**Never write `~/.memu/config.env` by hand.** No heredoc, no `echo >>`, no
+editor. Every memU host on this machine shares that one file, it holds a
+plaintext credential, and it carries an invariant a text edit cannot keep:
+record and retrieval must agree on one backend — and in local mode on one store
+and one embedding space — or retrieval keeps succeeding and finds nothing.
+`memu-workbuddy config` is the writer: it merges (anything it is not
+given is left alone, including comments and another host's settings), sets
+the file's permissions, and refuses the edits that break retrieval silently.
+
+**Came from memU's `SKILL.md`? You already ran `init`** — it created the file
+and, if the user handed over a memU Cloud key, already selected cloud memory.
+Read the state below rather than assuming which.
+
+If you came straight to this guide instead, run it now:
+
+```
+memu-workbuddy init --cloud-api-key <the user's memU key>
+```
+
+Bare `memu-workbuddy init` if the user has no key, or would rather keep memory
+on this device. Re-running is harmless either way — `init` is idempotent and
+keeps a mode it already finds. One caveat: passing a key selects **cloud**, and
+on a machine already using local memory that is a switch. Nothing is deleted,
+but memories written locally stop being retrieved; `init` warns and proceeds —
+so if you are unsure what this machine already uses, read the state first and
+say what the switch costs before you pass a key.
+
+Reading the state writes nothing:
+
+```
+memu-workbuddy config show
+```
+
+If it reports a mode with a backend behind it, another memU host got here first:
+**reuse it as is** and go to the verify gate. A file that declares no mode is
+local mode, for backward compatibility with files written before the mode
+existed — `config show` says so.
 
 Otherwise ask the user to choose once:
 
 - **MemU Cloud** — memory and embeddings are hosted; requires a memU API key.
-- **This device** — use the existing local database and embedding configuration.
+- **This device** — a database and an embedding provider on this machine.
 
-For **MemU Cloud**, ask the user to provide their memU API key. If they do not
-have one, direct them to [memu.so](https://memu.so) to register and create one,
-then wait for the key before continuing. Write:
+**MemU Cloud.** Ask the user for their memU API key. If they do not have one,
+direct them to [memu.so](https://memu.so) to register and create one, then wait
+for the key before continuing.
 
-```env
-MEMU_MEMORY_MODE=cloud
-MEMU_CLOUD_API_KEY=<memu-api-key>
+```
+memu-workbuddy config --cloud --cloud-api-key <memu-api-key>
 ```
 
-The production endpoint defaults to `https://api.memu.so/api/v4/memory/`. The
-key is plaintext in this file: tell the user
-and set user-only permissions (`chmod 600 ~/.memu/config.env` on POSIX; restrict
-the file to the current user on Windows). Do not reuse `MEMU_API_KEY`, which is
-for local embedding providers.
+It reports where the file is and what protection it has; tell the user the key
+is stored there in plaintext. The production endpoint defaults to
+`https://api.memu.so/api/v4/memory/` — pass `--cloud-base-url` only for a
+non-default one, and never `--embed-api-key`, which is the *embedding
+provider's* credential and has no role in cloud mode.
 
 Cloud currently persists memory and skill recall files. It accepts workspace
 resources from the existing bridging pipeline for compatibility but does not
-persist or retrieve them yet; tell the user. After writing cloud configuration,
-skip the remaining local-mode guidance and go to the verify gate.
+persist or retrieve them yet; tell the user. Then skip the local-mode guidance
+below and go to the verify gate.
 
-For **This device**, write `MEMU_MEMORY_MODE=local` and collect the settings
-below. "This device" describes memory storage; it is fully offline only when
-the embedding provider is local too:
+**This device.** "This device" describes memory storage; it is fully offline
+only when the embedding provider is local too. One command carries the lot:
 
-| Setting | Env var | Example |
+```
+memu-workbuddy config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-api-key <key>
+```
+
+| Setting | Flag | Example |
 | --- | --- | --- |
-| Database | `MEMU_DB` | `~/.memu/memu.sqlite3`, or a `postgres://…` DSN |
-| Embedding provider | `MEMU_EMBED_PROVIDER` | `openai`, `jina`, `voyage`, … |
-| API key | `MEMU_API_KEY` | the key, or the name of an env var holding it |
+| Database | `--db` | an absolute path (`~/.memu/memu.sqlite3`), or a `postgres://…` DSN |
+| Embedding provider | `--embed-provider` | `openai`, `jina`, `voyage`, … |
+| Embedding model | `--embed-model` | the provider's default if omitted |
+| Embedding credential | `--embed-api-key` | the provider's key — **not** the memU one |
+| Embedding endpoint | `--embed-base-url` | a local OpenAI-compatible server |
 
-**No embedding `MEMU_API_KEY`? Say so, then use a local embedding server.** If the user has no API key to
-give, tell them up front what that means: memory cannot be called across
-devices — everything stays on this machine, in a local database created for
-them (SQLite, e.g. `~/.memu/memu.sqlite3`). Then configure exactly that: keep
-`MEMU_EMBED_PROVIDER=openai`, point `MEMU_BASE_URL` at a local
-OpenAI-compatible embedding server (e.g. Ollama at `http://localhost:11434/v1`
-with `MEMU_EMBED_MODEL=nomic-embed-text`), and set `MEMU_API_KEY` to any
-placeholder value — a local server ignores it.
+Only the flags you pass are written, so a later run can add one without
+disturbing the rest. Give `--db` an **absolute** path: a relative one resolves
+against a working directory the scheduled task does not have. And do not export
+any of this in a shell profile instead — the scheduled task does not inherit
+your interactive shell, so the file is the carrier.
 
-Write them to **`~/.memu/config.env`**, which every memU command loads. Use an
-**absolute** path for `MEMU_DB`, and `chmod 600` the file (the key is plaintext —
-tell the user). Do **not** instead export these in a shell profile: the scheduled
-task does not inherit your interactive shell.
+**No embedding key? Say so, then use a local embedding server.** If the user has
+no API key to give, tell them up front what that means: memory cannot be called
+across devices — everything stays on this machine, in a local database created
+for them (SQLite). Then configure exactly that — keep `openai` as the provider,
+point the endpoint at a local OpenAI-compatible server (e.g. Ollama), and pass
+any placeholder credential, which such a server ignores:
+
+```
+memu-workbuddy config --local --db /absolute/path/memu.sqlite3 --embed-provider openai --embed-base-url http://localhost:11434/v1 --embed-model nomic-embed-text --embed-api-key local
+```
+
+**The existing config fails doctor? Repair the connection, never the identity.**
+If `~/.memu/config.env` predates this install and `doctor` fails, diagnose the
+transport first — is the embedding server running, is a proxy in the way — before
+changing anything. A connection-level repair is an ordinary `config` call and is
+allowed to land:
+
+```
+memu-workbuddy config --local --embed-base-url http://127.0.0.1:11434/v1
+```
+
+The identity is the other matter. `--db`, `--embed-provider` and `--embed-model`
+bind the embedding space every existing vector was written against, so `config`
+**refuses to change one that is already set**: "fixing" it would strand the
+user's whole store while retrieval went on succeeding and finding nothing. The
+refusal names `--force`, which is for a store genuinely being replaced and never
+for making `doctor` go green. If one of the three looks wrong, stop and ask the
+user.
 
 ### ✅ Verify Part 1
 

--- a/src/memu/trust.py
+++ b/src/memu/trust.py
@@ -30,6 +30,22 @@ from __future__ import annotations
 
 import functools
 import ssl
+from typing import TypedDict
+
+
+class UrlopenKwargs(TypedDict, total=False):
+    """The keyword arguments :func:`urlopen_kwargs` may supply.
+
+    A ``TypedDict`` rather than a plain ``dict``, because the call sites splat it
+    — and a ``dict[str, SSLContext]`` splatted into ``urlopen`` is, to a type
+    checker, a claim about *every* parameter that could absorb a keyword,
+    including the ``data`` / ``cafile`` / ``cadefault`` ones typeshed still
+    carries for 3.11. Naming the single key it can hold is what lets the checker
+    see that ``context`` is the only one being passed. ``total=False`` is the
+    empty case: no key at all, which is the common machine.
+    """
+
+    context: ssl.SSLContext
 
 
 @functools.cache
@@ -60,7 +76,7 @@ def ssl_context() -> ssl.SSLContext | None:
         return None
 
 
-def urlopen_kwargs() -> dict[str, ssl.SSLContext]:
+def urlopen_kwargs() -> UrlopenKwargs:
     """``context=`` for ``urlopen``, or an empty dict when there is nothing to say.
 
     The empty case is the point. On every machine with a working trust store the

--- a/src/memu/trust.py
+++ b/src/memu/trust.py
@@ -1,0 +1,72 @@
+"""TLS trust for the two stdlib HTTP call sites, and nothing else.
+
+:mod:`memu.events` and :mod:`memu.hosts.templates` both reach a memU server with
+``urllib`` rather than the ``httpx`` the rest of the package uses, because both
+are fail-open paths that must not depend on the async stack to stay silent about
+their own failures. That choice has one sharp edge, and this module is it.
+
+``urllib`` verifies against whatever trust store OpenSSL was pointed at. A
+python.org framework build whose bundled ``Install Certificates.command`` was
+never run is pointed at *nothing* — ``ssl.get_default_verify_paths()`` reports no
+``cafile`` and no ``capath`` — so every HTTPS call raises
+``CERTIFICATE_VERIFY_FAILED``. On a fail-open path that is not an error a user
+ever sees: events spool forever and never deliver, templates silently fall back
+to their embedded copies, and the machine looks identical to one that simply has
+nothing to report. ``httpx`` carries :mod:`certifi` and is unaffected, which is
+why ``retrieve`` keeps working on exactly the machine where ``report flush``
+delivers zero — the divergence that made this take an afternoon to find.
+
+**Why a fallback and not a pin.** Handing ``certifi`` to these two call sites
+unconditionally would fix that machine and break the opposite one: a corporate
+root CA installed OS-wide is in the system store and is *not* in ``certifi``, so
+every user behind a TLS-inspecting proxy would start failing exactly as silently
+as this. So the system store still wins wherever one exists, and ``certifi`` only
+fills a vacuum. A machine that works today is untouched by construction —
+:func:`ssl_context` returns ``None`` there, and ``None`` means "pass no context
+at all", which is literally the call these sites made before.
+"""
+
+from __future__ import annotations
+
+import functools
+import ssl
+
+
+@functools.cache
+def ssl_context() -> ssl.SSLContext | None:
+    """A verifying context for ``urlopen``, or ``None`` to use urllib's default.
+
+    Cached because the answer cannot change inside one process and the miss is
+    not free: building the fallback parses ``certifi``'s whole PEM bundle, and a
+    single :func:`memu.events.flush` may POST :data:`~memu.events.MAX_FLUSH_POSTS`
+    times. Call ``ssl_context.cache_clear()`` in a test that steers the paths.
+
+    Never raises. Every failure here returns ``None``, which is today's
+    behaviour — this must not become the reason a fail-open path stops being one.
+    """
+    try:
+        paths = ssl.get_default_verify_paths()
+        if paths.cafile or paths.capath:
+            # A trust store exists. Use it, MITM proxies and corporate CAs and
+            # all — this function's job is a vacuum, not a preference.
+            return None
+        import certifi
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        # Includes `certifi` absent: it arrives as an httpx dependency rather
+        # than one this module declares, so treat it as optional and degrade to
+        # the unverifiable-but-unchanged behaviour rather than raising here.
+        return None
+
+
+def urlopen_kwargs() -> dict[str, ssl.SSLContext]:
+    """``context=`` for ``urlopen``, or an empty dict when there is nothing to say.
+
+    The empty case is the point. On every machine with a working trust store the
+    call site passes no ``context`` argument whatsoever, so the fix cannot change
+    the behaviour — or the signature every stub in the test suite matches — of
+    the installs that were already fine.
+    """
+    context = ssl_context()
+    return {"context": context} if context is not None else {}

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -1,0 +1,384 @@
+"""``init`` and ``config`` — the commands that write ``config.env`` (ADR 0017).
+
+Weighted toward the two properties that make writing this file by command better
+than writing it by prose: **the merge never loses a line**, and **the guard never
+lets one backend's memory be stranded by a switch to the other**. A verb that
+sets the right key is table stakes; one that takes another host's settings with
+it, or that flips a configured store because a shell happened to export a
+variable, is the failure this replaced.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from memu import config_file
+from memu.hosts.claude_code.cli import SPEC
+from memu.hosts.host_cli import run
+
+
+@pytest.fixture
+def config(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> pathlib.Path:
+    """An isolated ``config.env`` path (not yet created). Returns it."""
+    from memu import env as env_module
+
+    path = tmp_path / "memu" / "config.env"
+    monkeypatch.setenv("MEMU_CONFIG_ENV", str(path))
+    # The dotenv loader is process-cached, and these commands write through it.
+    env_module.reload()
+    for key in ("MEMU_MEMORY_MODE", "MEMU_DB", "MEMU_CLOUD_API_KEY", "MEMU_CLIENT_ID"):
+        monkeypatch.delenv(key, raising=False)
+    return path
+
+
+def _write(path: pathlib.Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# The writer
+# --------------------------------------------------------------------------- #
+
+
+def test_merge_leaves_every_other_line_untouched(config: pathlib.Path) -> None:
+    """The field failure this command exists to end: a rewrite that takes
+    another host's settings, and the user's comments, with it."""
+    _write(
+        config,
+        "# written by hand in 2024\nMEMU_DB=/srv/memu.sqlite3\n\nMEMU_EMBED_PROVIDER=jina\nNO_PROXY=localhost\n",
+    )
+
+    config_file.write_values({"MEMU_MEMORY_MODE": "local"})
+
+    assert config.read_text(encoding="utf-8") == (
+        "# written by hand in 2024\n"
+        "MEMU_DB=/srv/memu.sqlite3\n"
+        "\n"
+        "MEMU_EMBED_PROVIDER=jina\n"
+        "NO_PROXY=localhost\n"
+        "MEMU_MEMORY_MODE=local\n"
+    )
+
+
+def test_existing_key_is_rewritten_in_place(config: pathlib.Path) -> None:
+    """In place, so a key keeps the comment that explains it — appending a second
+    assignment would resolve correctly and read as a contradiction."""
+    _write(config, "# the store\nMEMU_DB=/old\n# the endpoint\nMEMU_BASE_URL=http://localhost:11434/v1\n")
+
+    config_file.write_values({"MEMU_DB": "/new"})
+
+    assert config.read_text(encoding="utf-8") == (
+        "# the store\nMEMU_DB=/new\n# the endpoint\nMEMU_BASE_URL=http://localhost:11434/v1\n"
+    )
+
+
+def test_duplicate_assignments_all_collapse_to_the_new_value(config: pathlib.Path) -> None:
+    """Two first runs racing to append ``MEMU_CLIENT_ID`` is the real case. The
+    parser takes the last, so an untouched earlier line would preserve a value
+    that no longer resolves."""
+    _write(config, "MEMU_CLIENT_ID=one\nMEMU_DB=/srv/db\nMEMU_CLIENT_ID=two\n")
+
+    config_file.write_values({"MEMU_CLIENT_ID": "three"})
+
+    assert config.read_text(encoding="utf-8") == "MEMU_CLIENT_ID=three\nMEMU_DB=/srv/db\nMEMU_CLIENT_ID=three\n"
+    assert config_file.read()["MEMU_CLIENT_ID"] == "three"
+
+
+def test_file_is_owner_only(config: pathlib.Path) -> None:
+    config_file.write_values({"MEMU_CLOUD_API_KEY": "sk-secret"})
+
+    assert config.stat().st_mode & 0o777 == 0o600
+    assert config.parent.stat().st_mode & 0o077 == 0
+
+
+def test_nothing_to_set_still_restricts_an_existing_file(config: pathlib.Path) -> None:
+    _write(config, "MEMU_DB=/srv/db\n")
+    config.chmod(0o644)
+
+    _, changed = config_file.write_values({})
+
+    assert changed is False
+    assert config.stat().st_mode & 0o777 == 0o600
+
+
+def test_read_is_blind_to_the_process_environment(config: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The distinction the whole guard rests on. ``env.env()`` resolves the shell
+    first — correct for "what is this run using", wrong for "what is on disk"."""
+    _write(config, "MEMU_DB=/srv/db\n")
+    monkeypatch.setenv("MEMU_CLOUD_API_KEY", "sk-from-the-shell")
+
+    assert "MEMU_CLOUD_API_KEY" not in config_file.read()
+
+
+# --------------------------------------------------------------------------- #
+# init
+# --------------------------------------------------------------------------- #
+
+
+def test_bare_init_writes_local_and_a_client_id(config: pathlib.Path) -> None:
+    assert run(SPEC, ["init"]) == 0
+
+    values = config_file.read()
+    assert values["MEMU_MEMORY_MODE"] == "local"
+    assert values["MEMU_CLIENT_ID"]
+
+
+def test_bare_init_keeps_a_declared_cloud_mode(config: pathlib.Path) -> None:
+    """A re-install where the user did not re-supply a key must not demote cloud."""
+    _write(config, "MEMU_MEMORY_MODE=cloud\nMEMU_CLOUD_API_KEY=sk-1\n")
+
+    assert run(SPEC, ["init"]) == 0
+
+    assert config_file.read()["MEMU_MEMORY_MODE"] == "cloud"
+
+
+def test_bare_init_is_idempotent(config: pathlib.Path) -> None:
+    """SKILL.md's mitigation for agents that skip steps is that re-running is
+    free, so a second run must not generate a second client id."""
+    run(SPEC, ["init"])
+    first = config.read_text(encoding="utf-8")
+
+    assert run(SPEC, ["init"]) == 0
+    assert config.read_text(encoding="utf-8") == first
+
+
+def test_init_with_a_key_selects_cloud(config: pathlib.Path) -> None:
+    assert run(SPEC, ["init", "--cloud-api-key", "sk-1"]) == 0
+
+    values = config_file.read()
+    assert values["MEMU_MEMORY_MODE"] == "cloud"
+    assert values["MEMU_CLOUD_API_KEY"] == "sk-1"
+
+
+def test_init_with_a_key_flips_a_vacuous_local_config(config: pathlib.Path) -> None:
+    """The ordinary first install: bare ``init`` landed ``local`` before the guide
+    asked the question. An inferred default must not be treated as a choice."""
+    run(SPEC, ["init"])
+
+    assert run(SPEC, ["init", "--cloud-api-key", "sk-1"]) == 0
+    assert config_file.read()["MEMU_MEMORY_MODE"] == "cloud"
+
+
+def test_init_with_a_key_refuses_a_local_config_with_a_store(
+    config: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write(config, "MEMU_MEMORY_MODE=local\nMEMU_DB=/srv/db\n")
+
+    assert run(SPEC, ["init", "--cloud-api-key", "sk-1"]) == 2
+
+    assert config_file.read()["MEMU_MEMORY_MODE"] == "local"
+    # Hands the decision back with the exact command, because `init` has no
+    # --force of its own: the override belongs on the verb whose caller saw the guard.
+    assert "config --cloud --cloud-api-key <key> --force" in capsys.readouterr().err
+
+
+def test_init_never_echoes_the_key_in_its_refusal(config: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """It is already in argv, and memU mines the transcript this prints into."""
+    _write(config, "MEMU_MEMORY_MODE=local\nMEMU_DB=/srv/db\n")
+
+    run(SPEC, ["init", "--cloud-api-key", "sk-secret"])
+
+    assert "sk-secret" not in capsys.readouterr().err
+
+
+def test_init_replaces_a_stored_key_and_says_so(config: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Refusing would block the legitimate rotated-key repair, and the client
+    cannot tell a rotation from a different account. Announcing is the middle."""
+    _write(config, "MEMU_MEMORY_MODE=cloud\nMEMU_CLOUD_API_KEY=sk-1\n")
+
+    assert run(SPEC, ["init", "--cloud-api-key", "sk-2"]) == 0
+
+    assert config_file.read()["MEMU_CLOUD_API_KEY"] == "sk-2"
+    assert "replaced" in capsys.readouterr().out
+
+
+def test_init_ignores_a_mode_exported_in_the_shell(config: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """ "Already set" is a statement about the file. A shell export must not make
+    ``init`` keep a mode nobody ever wrote."""
+    monkeypatch.setenv("MEMU_MEMORY_MODE", "cloud")
+
+    assert run(SPEC, ["init"]) == 0
+
+    assert config_file.read()["MEMU_MEMORY_MODE"] == "local"
+
+
+# --------------------------------------------------------------------------- #
+# The one-backend guard
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("existing", "target", "expected"),
+    [
+        # Protected: the current mode has memory to lose.
+        ("MEMU_MEMORY_MODE=local\nMEMU_DB=/srv/db\n", "--cloud", 2),
+        ("MEMU_MEMORY_MODE=cloud\nMEMU_CLOUD_API_KEY=sk-1\n", "--local", 2),
+        # A legacy file predating MEMU_MEMORY_MODE is *in* local mode, not vacuous —
+        # and is the population most likely to hold a large store.
+        ("MEMU_DB=/srv/db\n", "--cloud", 2),
+        # Vacuous: a declaration with nothing behind it. This is the first real choice.
+        ("MEMU_MEMORY_MODE=local\n", "--cloud", 0),
+        ("MEMU_MEMORY_MODE=cloud\n", "--local", 0),
+        ("", "--cloud", 0),
+        # Not a flip at all.
+        ("MEMU_MEMORY_MODE=local\nMEMU_DB=/srv/db\n", "--local", 0),
+        ("MEMU_MEMORY_MODE=cloud\nMEMU_CLOUD_API_KEY=sk-1\n", "--cloud", 0),
+    ],
+)
+def test_mode_flip_guard(config: pathlib.Path, existing: str, target: str, expected: int) -> None:
+    if existing:
+        _write(config, existing)
+
+    assert run(SPEC, ["config", target]) == expected
+
+
+def test_force_overrides_the_flip_guard(config: pathlib.Path) -> None:
+    _write(config, "MEMU_MEMORY_MODE=local\nMEMU_DB=/srv/db\n")
+
+    assert run(SPEC, ["config", "--cloud", "--cloud-api-key", "sk-1", "--force"]) == 0
+
+    assert config_file.read()["MEMU_MEMORY_MODE"] == "cloud"
+
+
+def test_guard_ignores_a_key_exported_in_the_shell(config: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An exported credential must not make a file that declares nothing look
+    like a configured cloud install and refuse the first real choice."""
+    _write(config, "MEMU_MEMORY_MODE=cloud\n")
+    monkeypatch.setenv("MEMU_CLOUD_API_KEY", "sk-from-the-shell")
+
+    assert run(SPEC, ["config", "--local"]) == 0
+
+
+@pytest.mark.parametrize("key", ["MEMU_DB", "MEMU_EMBED_PROVIDER", "MEMU_EMBED_MODEL"])
+def test_identity_keys_refuse_a_change(config: pathlib.Path, key: str) -> None:
+    """These three bind an embedding space. Changing one strands every vector
+    already written against it, and retrieval keeps succeeding while finding
+    nothing — which is why the guard here is unconditional, not state-based."""
+    _write(config, f"MEMU_MEMORY_MODE=local\n{key}=original\n")
+    flag = {"MEMU_DB": "--db", "MEMU_EMBED_PROVIDER": "--embed-provider", "MEMU_EMBED_MODEL": "--embed-model"}[key]
+
+    assert run(SPEC, ["config", "--local", flag, "changed"]) == 2
+    assert config_file.read()[key] == "original"
+
+    assert run(SPEC, ["config", "--local", flag, "changed", "--force"]) == 0
+    assert config_file.read()[key] == "changed"
+
+
+def test_setting_an_absent_identity_key_is_not_a_change(config: pathlib.Path) -> None:
+    _write(config, "MEMU_MEMORY_MODE=local\n")
+
+    assert run(SPEC, ["config", "--local", "--db", "/srv/db"]) == 0
+
+
+def test_connection_keys_are_freely_updatable(config: pathlib.Path) -> None:
+    """ "Repair the connection, never the identity" — the guide's rule, now a gate."""
+    _write(config, "MEMU_MEMORY_MODE=local\nMEMU_DB=/srv/db\nMEMU_BASE_URL=http://localhost:11434/v1\n")
+
+    assert run(SPEC, ["config", "--local", "--embed-base-url", "http://127.0.0.1:11434/v1"]) == 0
+
+    assert config_file.read()["MEMU_BASE_URL"] == "http://127.0.0.1:11434/v1"
+
+
+# --------------------------------------------------------------------------- #
+# config
+# --------------------------------------------------------------------------- #
+
+
+def test_config_requires_a_backend(config: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert run(SPEC, ["config"]) == 2
+    assert "config show" in capsys.readouterr().err
+
+
+def test_config_local_without_a_store_is_allowed(config: pathlib.Path) -> None:
+    """The refusal would land in the wrong place: this verb runs inside INSTALL.md,
+    where the agent is already talking to the user about the store. Part 1's verify
+    gate is what catches a mode with nothing behind it."""
+    assert run(SPEC, ["config", "--local"]) == 0
+
+    assert config_file.read()["MEMU_MEMORY_MODE"] == "local"
+    assert "MEMU_DB" not in config_file.read()
+
+
+def test_config_does_not_persist_the_default_endpoint(config: pathlib.Path) -> None:
+    """Baking today's default into the file freezes across upgrades a value the
+    code should own."""
+    from memu.cloud import DEFAULT_CLOUD_BASE_URL
+
+    assert run(SPEC, ["config", "--cloud", "--cloud-api-key", "sk-1", "--cloud-base-url", DEFAULT_CLOUD_BASE_URL]) == 0
+
+    assert "MEMU_CLOUD_BASE_URL" not in config_file.read()
+
+
+def test_config_persists_a_non_default_endpoint(config: pathlib.Path) -> None:
+    assert run(SPEC, ["config", "--cloud", "--cloud-api-key", "sk-1", "--cloud-base-url", "https://staging/api/"]) == 0
+
+    assert config_file.read()["MEMU_CLOUD_BASE_URL"] == "https://staging/api/"
+
+
+def test_embed_api_key_writes_the_embedding_variable(config: pathlib.Path) -> None:
+    """``MEMU_API_KEY`` is the embedding provider's, ``MEMU_CLOUD_API_KEY`` is memU
+    Cloud's, and the guides have to warn against confusing them. Neither flag is
+    called ``--api-key`` for that reason."""
+    assert run(SPEC, ["config", "--local", "--embed-api-key", "sk-embed"]) == 0
+
+    values = config_file.read()
+    assert values["MEMU_API_KEY"] == "sk-embed"
+    assert "MEMU_CLOUD_API_KEY" not in values
+
+
+def test_config_only_writes_the_flags_it_was_given(config: pathlib.Path) -> None:
+    _write(config, "MEMU_MEMORY_MODE=local\nMEMU_DB=/srv/db\nMEMU_EMBED_PROVIDER=jina\n")
+
+    assert run(SPEC, ["config", "--local", "--embed-model", "nomic-embed-text"]) == 0
+
+    values = config_file.read()
+    assert values["MEMU_DB"] == "/srv/db"
+    assert values["MEMU_EMBED_PROVIDER"] == "jina"
+    assert values["MEMU_EMBED_MODEL"] == "nomic-embed-text"
+
+
+# --------------------------------------------------------------------------- #
+# config show
+# --------------------------------------------------------------------------- #
+
+
+def test_show_writes_nothing(config: pathlib.Path) -> None:
+    """The preflight probe. A read side that created the file would answer its own
+    question wrong on every later run."""
+    assert run(SPEC, ["config", "show"]) == 0
+
+    assert not config.exists()
+
+
+def test_show_never_prints_a_credential(config: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(config, "MEMU_MEMORY_MODE=cloud\nMEMU_CLOUD_API_KEY=sk-secret\n")
+
+    run(SPEC, ["config", "show"])
+
+    out = capsys.readouterr().out
+    assert "sk-secret" not in out
+    assert "key       set" in out
+
+
+def test_show_reports_an_environment_override(
+    config: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """This command reports the file, but the environment is what wins at runtime.
+    Silence where the two disagree makes a probe into a misleading one."""
+    _write(config, "MEMU_MEMORY_MODE=local\nMEMU_DB=/srv/db\n")
+    monkeypatch.setenv("MEMU_DB", "/srv/other")
+
+    run(SPEC, ["config", "show"])
+
+    assert "note: the environment overrides" in capsys.readouterr().out
+
+
+def test_show_names_the_backward_compatible_mode(config: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(config, "MEMU_DB=/srv/db\n")
+
+    run(SPEC, ["config", "show"])
+
+    assert "undeclared" in capsys.readouterr().out

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -162,26 +162,48 @@ def test_init_with_a_key_flips_a_vacuous_local_config(config: pathlib.Path) -> N
     assert config_file.read()["MEMU_MEMORY_MODE"] == "cloud"
 
 
-def test_init_with_a_key_refuses_a_local_config_with_a_store(
+def test_init_with_a_key_flips_a_local_config_with_a_store_and_warns(
     config: pathlib.Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    """`init` has no ``--force``, so a refusal here is terminal and would halt the
+    install at its first step. A key in hand is intent enough, and the store is
+    not destroyed — only unread — so the cost is a warning."""
     _write(config, "MEMU_MEMORY_MODE=local\nMEMU_DB=/srv/db\n")
 
-    assert run(SPEC, ["init", "--cloud-api-key", "sk-1"]) == 2
+    assert run(SPEC, ["init", "--cloud-api-key", "sk-1"]) == 0
 
-    assert config_file.read()["MEMU_MEMORY_MODE"] == "local"
-    # Hands the decision back with the exact command, because `init` has no
-    # --force of its own: the override belongs on the verb whose caller saw the guard.
-    assert "config --cloud --cloud-api-key <key> --force" in capsys.readouterr().err
+    assert config_file.read()["MEMU_MEMORY_MODE"] == "cloud"
+    # Left alone: the switch is reversible precisely because the store survives it.
+    assert config_file.read()["MEMU_DB"] == "/srv/db"
+    captured = capsys.readouterr()
+    assert "no longer read" in captured.out
+    assert "config --local --force" in captured.err
 
 
-def test_init_never_echoes_the_key_in_its_refusal(config: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_init_never_echoes_the_key_in_its_warning(config: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
     """It is already in argv, and memU mines the transcript this prints into."""
     _write(config, "MEMU_MEMORY_MODE=local\nMEMU_DB=/srv/db\n")
 
     run(SPEC, ["init", "--cloud-api-key", "sk-secret"])
 
-    assert "sk-secret" not in capsys.readouterr().err
+    captured = capsys.readouterr()
+    assert "sk-secret" not in captured.err
+    assert "sk-secret" not in captured.out
+
+
+def test_init_with_a_key_does_not_warn_on_a_vacuous_config(
+    config: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The ordinary first install has nothing to lose, and a warning printed on
+    every one of them is a warning nobody reads on the run that matters."""
+    run(SPEC, ["init"])
+    capsys.readouterr()
+
+    assert run(SPEC, ["init", "--cloud-api-key", "sk-1"]) == 0
+
+    captured = capsys.readouterr()
+    assert "no longer read" not in captured.out
+    assert "warning" not in captured.err
 
 
 def test_init_replaces_a_stored_key_and_says_so(config: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -573,10 +573,12 @@ def test_a_flush_is_bounded_and_the_next_one_resumes_where_it_stopped(
 def test_only_retrieve_delivers_inline(reporting: pathlib.Path) -> None:
     """``deliver=True`` is the per-turn hook's alone (ADR 0016 section 2).
 
-    It puts a blocking POST on the calling command, which is affordable exactly
-    once, on the one path whose event the backend wants promptly. If this fails
-    someone wired it to a second call site — a decision that owes a reason, not an
-    accident.
+    It puts a blocking POST on the calling command, which is affordable only on the
+    path whose event the backend wants promptly — both of whose legs live in
+    ``retrieval.py``. If this fails someone wired it to a second *command*, a
+    decision that owes a reason rather than an accident. File-granular on purpose:
+    what the tripwire guards is which command may spend a POST per turn, not how
+    many branches of that command do.
     """
     root = pathlib.Path(events.__file__).parent
     callers = sorted(
@@ -649,11 +651,19 @@ def test_a_permanently_rejected_event_is_not_spooled_to_be_rejected_again(
 # --------------------------------------------------------------------------- #
 
 
-def test_report_verbs_exist_on_every_host(reporting: pathlib.Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_report_verbs_exist_on_every_host(
+    reporting: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # The endpoint is stubbed because `report install` now flushes: left real, this
+    # would resolve the fixture's `example.invalid` on every run, and the events it
+    # asserts on would sit in the rotated `.sending` file rather than the spool.
+    posted = _Posted()
+    monkeypatch.setattr(events.urllib.request, "urlopen", posted)
+
     for spec in (CODEX_SPEC, CLAUDE_SPEC):
         assert run(spec, ["report", "install"]) == 0
-    assert len(_spooled(reporting)) == 2
-    assert {event["context"]["agent_platform"] for event in _spooled(reporting)} == {"codex", "claude_code"}
+    assert len(posted.events) == 2
+    assert {event["context"]["agent_platform"] for event in posted.events} == {"codex", "claude_code"}
 
 
 def test_the_install_funnel_has_a_code_observed_start_and_a_reported_end(
@@ -665,6 +675,11 @@ def test_the_install_funnel_has_a_code_observed_start_and_a_reported_end(
     Step 3 and is its own, narrower row. ``report install`` is prose-driven and
     undercounts by design — if a start did too, the funnel could report more
     completions than attempts, so neither step is asked for in prose.
+
+    All three flush, so the whole funnel is deliverable from the install itself: a
+    machine that never gets a working bridging pair is exactly the one whose funnel
+    a consumer needs to see, and it is the completion — the row asserting the
+    install worked — that would otherwise be the only one waiting on it.
     """
     monkeypatch.setenv("MEMU_DOCS_BASE_URL", "")
     posted = _Posted()
@@ -678,10 +693,10 @@ def test_the_install_funnel_has_a_code_observed_start_and_a_reported_end(
     assert [event["event_name"] for event in posted.events] == [
         events.CLI_INSTALL_STARTED,
         events.INSTALL_GUIDE_OPENED,
+        events.CLI_INSTALL_SUCCEEDED,
     ]
-    # The completion keeps the ordinary treatment: spooled, carried by a bridging run.
-    assert [event["event_name"] for event in _spooled(reporting)] == [events.CLI_INSTALL_SUCCEEDED]
-    assert all(event["properties"] == {} for event in _spooled(reporting) + posted.events)
+    assert _spooled(reporting) == [], "every step of the funnel delivers; nothing is left for a later flush"
+    assert all(event["properties"] == {} for event in posted.events)
 
 
 def test_the_install_start_reports_the_client_id_init_just_wrote(
@@ -891,14 +906,21 @@ def test_a_retrieve_that_cannot_deliver_still_succeeds_and_keeps_its_event(
     assert event["event_name"] == events.MEMORY_SEARCH_SUCCEEDED
 
 
-def test_a_failing_retrieve_never_posts_from_the_per_turn_hook(
+def test_a_failing_retrieve_delivers_its_own_event_and_nothing_else(
     reporting: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The error path stays spool-only, even though the success path delivers.
+    """Both legs of the hook deliver; neither may flush.
 
-    A store the hook cannot reach fails ``retrieve`` on *every* turn. Delivering
-    here — or flushing from the CLI's error handler — would put a blocking POST on
-    the hot path once per turn, precisely when the user is already broken.
+    The failure leg reports the same way the success leg does, because a machine
+    whose retrieval is broken is the one these events exist to surface — and the
+    later flush it would otherwise wait for runs on the bridging pair, which a
+    broken store breaks too. So the event that says so must not depend on it.
+
+    What stays fixed is the bound, which is the whole content of the per-turn
+    constraint: ``deliver=True`` sends *one* envelope. The ``cli_error`` recorded
+    behind it is spooled, because the CLI's error handler still exempts
+    ``retrieve`` from its flush — a drain here would cost up to
+    :data:`MAX_FLUSH_POSTS` requests on every turn of an already-broken machine.
     """
     from memu.hosts import retrieval
 
@@ -910,10 +932,8 @@ def test_a_failing_retrieve_never_posts_from_the_per_turn_hook(
     monkeypatch.setattr(events.urllib.request, "urlopen", posted)
 
     assert run(CODEX_SPEC, ["retrieve", "anything"]) == 1
-    assert posted.events == []
-    # Recorded, just not delivered from here — the next successful retrieve carries
-    # these out ahead of its own event, as does the bridging pair.
-    assert len(_spooled(reporting)) == 2
+    assert [event["event_name"] for event in posted.events] == [events.MEMORY_SEARCH_FAILED]
+    assert [event["event_name"] for event in _spooled(reporting)] == [events.CLI_ERROR]
 
 
 def test_a_failing_bridging_run_does_flush_because_its_flush_point_is_what_broke(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -659,41 +659,84 @@ def test_report_verbs_exist_on_every_host(reporting: pathlib.Path, capsys: pytes
 def test_the_install_funnel_has_a_code_observed_start_and_a_reported_end(
     reporting: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Printing the guide *is* the start signal, and it delivers on the spot.
+    """The two steps in are code-observed; only the completion needs a verb.
 
-    ``report install`` is prose-driven and undercounts by design. If the start
-    were too, the funnel could report more completions than attempts — so the
-    start is taken where code can see it, and only the completion needs a verb.
+    ``init`` is ``SKILL.md`` Step 2 and starts the funnel; printing the guide is
+    Step 3 and is its own, narrower row. ``report install`` is prose-driven and
+    undercounts by design — if a start did too, the funnel could report more
+    completions than attempts, so neither step is asked for in prose.
     """
     monkeypatch.setenv("MEMU_DOCS_BASE_URL", "")
     posted = _Posted()
     monkeypatch.setattr(events.urllib.request, "urlopen", posted)
 
+    assert run(CLAUDE_SPEC, ["init"]) == 0
     assert run(CLAUDE_SPEC, ["docs", "install"]) == 0
     assert capsys.readouterr().out.strip(), "the guide itself must still be what this command prints"
     assert run(CLAUDE_SPEC, ["report", "install"]) == 0
 
-    assert [event["event_name"] for event in posted.events] == [events.CLI_INSTALL_STARTED]
+    assert [event["event_name"] for event in posted.events] == [
+        events.CLI_INSTALL_STARTED,
+        events.INSTALL_GUIDE_OPENED,
+    ]
     # The completion keeps the ordinary treatment: spooled, carried by a bridging run.
     assert [event["event_name"] for event in _spooled(reporting)] == [events.CLI_INSTALL_SUCCEEDED]
     assert all(event["properties"] == {} for event in _spooled(reporting) + posted.events)
 
 
-def test_the_install_start_carries_the_backlog_off_a_machine_that_may_never_bridge(
-    reporting: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+def test_the_install_start_reports_the_client_id_init_just_wrote(
+    reporting: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Why ``docs install`` flushes rather than only recording.
+    """Why the start is emitted *after* the write, not beside the client id.
 
-    An install that dies in Part 2 never reaches ``prepare`` or ``commit``, so
-    this is the only flush point its earlier events will ever see — and those are
-    exactly the events that explain why it died.
+    ``init`` mints ``MEMU_CLIENT_ID`` into ``config.env``, and an envelope built
+    before that lands would find none in the environment and persist a second one
+    — leaving the machine's first event reporting under an id its own config file
+    does not contain.
     """
-    monkeypatch.setenv("MEMU_DOCS_BASE_URL", "")
+    from memu import config_file
+
+    posted = _Posted()
+    monkeypatch.setattr(events.urllib.request, "urlopen", posted)
+
+    assert run(CLAUDE_SPEC, ["init"]) == 0
+
+    stored = config_file.read()["MEMU_CLIENT_ID"]
+    assert [event["client_instance_id"] for event in posted.events] == [stored]
+    assert stored[:4] in capsys.readouterr().out, "and it is the id the `client` row named"
+
+
+def test_the_install_start_is_attributed_when_init_was_given_a_key(
+    reporting: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The ordering ADR 0017 was written for: the first event carries the account.
+
+    ``docs install`` fired the start before any key existed, so a first install
+    reported anonymously. ``init`` holds the key and writes it before reporting.
+    """
+    posted = _Posted()
+    monkeypatch.setattr(events.urllib.request, "urlopen", posted)
+
+    assert run(CLAUDE_SPEC, ["init", "--cloud-api-key", "sk-live-abc"]) == 0
+
+    sent = {key.title(): value for key, value in posted.headers[0].items()}
+    assert sent["Authorization"] == "Bearer sk-live-abc"
+
+
+def test_the_install_start_carries_the_backlog_off_a_machine_that_may_never_bridge(
+    reporting: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Why ``init`` flushes rather than only recording.
+
+    An install that dies before the bridging pair ever runs never reaches
+    ``prepare`` or ``commit``, so this is the only flush point its earlier events
+    will ever see — and those are exactly the events that explain why it died.
+    """
     events.record_cli_error(RuntimeError("an earlier doctor"), command="doctor", host="claude-code")
     posted = _Posted()
     monkeypatch.setattr(events.urllib.request, "urlopen", posted)
 
-    assert run(CLAUDE_SPEC, ["docs", "install"]) == 0
+    assert run(CLAUDE_SPEC, ["init"]) == 0
 
     assert [event["event_name"] for event in posted.events] == [
         events.CLI_ERROR,
@@ -702,11 +745,11 @@ def test_the_install_start_carries_the_backlog_off_a_machine_that_may_never_brid
     assert not reporting.exists()
 
 
-def test_only_the_install_guide_reports_an_attempt(
+def test_only_the_install_guide_reports_being_opened(
     reporting: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     # `docs task` runs on every scheduled-task repair and `docs uninstall` is the
-    # opposite intent; neither is an install attempt.
+    # opposite intent; neither is a step on the way in.
     monkeypatch.setenv("MEMU_DOCS_BASE_URL", "")
     assert run(CLAUDE_SPEC, ["docs", "task"]) == 0
     assert run(CLAUDE_SPEC, ["docs", "uninstall"]) == 0

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -760,15 +760,31 @@ def test_the_install_start_carries_the_backlog_off_a_machine_that_may_never_brid
     assert not reporting.exists()
 
 
-def test_only_the_install_guide_reports_being_opened(
+def test_the_lifecycle_guides_report_being_opened_and_the_bridging_one_does_not(
     reporting: pathlib.Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # `docs task` runs on every scheduled-task repair and `docs uninstall` is the
-    # opposite intent; neither is a step on the way in.
+    """One row per guide someone *decided* to open — in and out, but not the schedule's.
+
+    ``docs task`` runs on every scheduled-task repair, so counting it would measure
+    how often cron fires and nothing about anyone's intent; the pair it describes is
+    instrumented end to end already.
+
+    Both lifecycle guides deliver inline rather than spooling, and on the way out
+    that is not symmetry for its own sake: ``UNINSTALL.md`` Part 3 removes the
+    package, so an event left in the spool loses the binary that would have sent it.
+    """
     monkeypatch.setenv("MEMU_DOCS_BASE_URL", "")
+    posted = _Posted()
+    monkeypatch.setattr(events.urllib.request, "urlopen", posted)
+
     assert run(CLAUDE_SPEC, ["docs", "task"]) == 0
     assert run(CLAUDE_SPEC, ["docs", "uninstall"]) == 0
-    assert _spooled(reporting) == []
+    assert capsys.readouterr().out.strip(), "the guides themselves must still be what the command prints"
+
+    assert [event["event_name"] for event in posted.events] == [events.UNINSTALL_GUIDE_OPENED]
+    assert posted.events[0]["context"]["reported_by"] == events.REPORTED_BY_CODE
+    assert posted.events[0]["properties"] == {}
+    assert _spooled(reporting) == [], "the guide that precedes package removal cannot wait for a later flush"
 
 
 def test_report_install_and_uninstall_take_no_failure_flag(reporting: pathlib.Path) -> None:

--- a/tests/test_trust.py
+++ b/tests/test_trust.py
@@ -1,0 +1,156 @@
+"""TLS trust for the two ``urllib`` call sites (:mod:`memu.trust`).
+
+The bug this module exists for was invisible from both ends: a python.org
+framework Python with no CA bundle failed verification on every ``urlopen``,
+which two fail-open ``except`` clauses turned into "events never delivered" and
+"templates never refresh", while the ``httpx`` paths on the same machine kept
+working. So these tests are weighted toward the two directions the fix must not
+go wrong in — it must fix the vacuum, and it must not touch a machine that
+already has a trust store.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import ssl
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from memu import events, trust
+from memu.hosts import templates
+
+
+@pytest.fixture(autouse=True)
+def _uncached() -> Any:
+    """:func:`trust.ssl_context` is cached for the life of a process, so every test
+    here has to start from an unanswered question — and leave one behind."""
+    trust.ssl_context.cache_clear()
+    yield
+    trust.ssl_context.cache_clear()
+
+
+def _verify_paths(monkeypatch: pytest.MonkeyPatch, *, cafile: str | None, capath: str | None) -> None:
+    monkeypatch.setattr(ssl, "get_default_verify_paths", lambda: types.SimpleNamespace(cafile=cafile, capath=capath))
+
+
+# --- the machine that already works must not change at all ---
+
+
+def test_an_existing_trust_store_is_left_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The system store wins wherever one exists, and that is not a preference —
+    it is what keeps a corporate root CA working. ``certifi`` does not carry one,
+    so a machine behind a TLS-inspecting proxy would start failing exactly as
+    silently as the bug this fixes if the fallback were a pin instead."""
+    _verify_paths(monkeypatch, cafile="/etc/ssl/cert.pem", capath=None)
+
+    assert trust.ssl_context() is None
+
+
+def test_a_capath_alone_counts_as_a_trust_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Linux shape: a hashed directory and no single bundle file."""
+    _verify_paths(monkeypatch, cafile=None, capath="/etc/ssl/certs")
+
+    assert trust.ssl_context() is None
+
+
+def test_no_context_argument_is_passed_when_the_store_is_healthy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Not merely equivalent behaviour — the *same call*.
+
+    An install that works today must be untouched by construction, so the fix
+    passes no ``context`` whatsoever rather than passing a reconstructed one that
+    is only meant to be identical.
+    """
+    _verify_paths(monkeypatch, cafile="/etc/ssl/cert.pem", capath=None)
+
+    assert trust.urlopen_kwargs() == {}
+
+
+# --- the machine with no trust store at all ---
+
+
+def test_certifi_fills_a_vacuum(monkeypatch: pytest.MonkeyPatch) -> None:
+    _verify_paths(monkeypatch, cafile=None, capath=None)
+
+    context = trust.ssl_context()
+
+    assert context is not None
+    # Verifying, emphatically: a fallback that filled the vacuum by switching
+    # verification off would "fix" the flush and hand the endpoint to anyone on
+    # the network path.
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    assert context.check_hostname is True
+    assert context.get_ca_certs(), "fallback context carries no CAs"
+    assert trust.urlopen_kwargs() == {"context": context}
+
+
+def test_a_missing_certifi_degrades_instead_of_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``certifi`` arrives as an httpx dependency, not one this module declares.
+
+    If it is ever absent the answer is today's behaviour — unverifiable but
+    unchanged — because this function sits on two paths whose whole contract is
+    that they cannot be the thing that breaks a command.
+    """
+    _verify_paths(monkeypatch, cafile=None, capath=None)
+    monkeypatch.setitem(sys.modules, "certifi", None)
+
+    assert trust.ssl_context() is None
+    assert trust.urlopen_kwargs() == {}
+
+
+def test_the_answer_is_cached_across_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A flush may POST `MAX_FLUSH_POSTS` times and each miss parses certifi's
+    whole PEM bundle, so the same context must come back rather than be rebuilt."""
+    _verify_paths(monkeypatch, cafile=None, capath=None)
+
+    assert trust.ssl_context() is trust.ssl_context()
+
+
+# --- both call sites actually consult it ---
+
+
+class _Recorder:
+    """A ``urlopen`` that records whether it was handed a context."""
+
+    def __init__(self) -> None:
+        self.kwargs: dict[str, Any] = {}
+
+    def __call__(self, *args: Any, **kwargs: Any) -> _Recorder:
+        self.kwargs = kwargs
+        return self
+
+    def read(self, n: int = -1) -> bytes:
+        return b""
+
+    status = 200
+
+    def __enter__(self) -> _Recorder:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+
+def test_event_delivery_verifies_against_the_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    _verify_paths(monkeypatch, cafile=None, capath=None)
+    recorder = _Recorder()
+    monkeypatch.setattr(events.urllib.request, "urlopen", recorder)
+
+    assert events._post("https://example.test/events", {"event_name": "x"}) == events.ACCEPTED
+    assert isinstance(recorder.kwargs.get("context"), ssl.SSLContext)
+
+
+def test_template_refresh_verifies_against_the_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> None:
+    """The second call site, and the reason the fix is one decision rather than two:
+    a silent template fallback is the same failure wearing different clothes."""
+    _verify_paths(monkeypatch, cafile=None, capath=None)
+    recorder = _Recorder()
+    monkeypatch.setattr(templates.urllib.request, "urlopen", recorder)
+
+    templates._get("https://example.test/inst/memory-job.txt")
+
+    assert isinstance(recorder.kwargs.get("context"), ssl.SSLContext)

--- a/uv.lock
+++ b/uv.lock
@@ -498,7 +498,7 @@ wheels = [
 
 [[package]]
 name = "memu-cli"
-version = "2.0.0b0"
+version = "0.11.0b0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## 📝 Pull Request Summary

Implements **[ADR 0017](docs/adr/0017-config-env-as-a-command.md)** end to end: `~/.memu/config.env` is now written by two commands — `<binary> init` and `<binary> config` — instead of by the agent, from prose, during the install. The ADR itself is included, along with the guide changes that drive the new verbs and the one open issue the last commit closes.

---

## ✅ What does this PR do?

Four commits, in dependency order:

1. **`feat(config)`: write `config.env` from `init` and `config`, not from prose** — the writer (`memu.config_file`), the two verbs (`memu.hosts.config_cmd`), and the guards. Logic only; nothing invokes it yet.
2. **`fix(config)`: `init` never rejects on mode** — `init` is the first command on the install path and has no `--force` to hand back, so a refusal there strands every step after it. It warns instead.
3. **`feat(config)`: name the verbs in `SKILL.md` and all seven `INSTALL.md` §1.2 sections** — the guide side of the same change.
4. **`feat(events)`: move the install-start event to `init`, rename the guide's own event** — closes ADR 0017's "where the install-start event belongs" open issue.

**Two verbs over one writer.** `init` is the inferring front door named in `SKILL.md` — the surface memU cannot refresh from the server, so its contract is one optional flag and is meant to hold for years. `config` is the explicit one driven by `INSTALL.md`, which *is* server-refreshable (ADR 0013) and can grow flags at the server's pace. `config show` is the read side, and is a name rather than a bare `config`: a verb that printed while a bare `init` wrote is the asymmetry agents get wrong.

**The guard is state-based, and reads the file.** A mode change is refused only when the current mode has something to lose — `MEMU_DB` set, or a stored cloud key. Guarding on the *declaration* alone would refuse the most ordinary first install; reading the state through `env.env()` would be wrong in the other direction, since an exported credential in the calling shell must not make a file that declares nothing look like a configured install.

**The install funnel gains its true first step.** `cli_install_started` now fires from `init` (`SKILL.md` Step 2) rather than from `docs install` (Step 3), and is emitted *after* the config write — `init` mints `MEMU_CLIENT_ID` into that same file, so an envelope built first would find no id, persist a second one, and be overwritten. The old emission is renamed to `install_guide_opened` and is otherwise untouched.

---

## 🤔 Why is this change needed?

`~/.memu/config.env` is shared by every host on the machine, carries a plaintext credential, and holds an invariant a guide can only state in words: record and inject must agree on the backend — and in local mode on the DSN and embedding space too — or retrieval silently returns nothing (ADR 0009's opening argument).

Until now `INSTALL.md` §1.2 told the agent which keys to write and the agent wrote them, typically with a heredoc or `echo >>`. Field behaviour matched the exposure: agents rewrite the file rather than merge into it, taking another host's settings and the user's comments with them. The guide already spends a paragraph on "repair the connection, never the identity" and enforces it with nothing but emphasis.

This is the same argument that produced `install-instruction`: memU owns the text, so memU writes it. `config.env` is a strictly harder file — merge semantics, a secret, a cross-host invariant — and had no such command.

Secondarily, the install-start event fired before the memU Cloud key existed, so a first install reported anonymously. `init` holds the key and writes it before reporting, which makes attribution unconditional.

---

## 🔍 Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / cleanup
- [x] Other — one breaking change on the analytics wire (see below)

---

## ✅ PR Quality Checklist

- [x] PR title follows an allowed format
- [x] Changes are limited in scope and easy to review — four commits, each self-contained and readable on its own
- [x] Documentation updated where applicable — ADR 0017 added, ADR 0016 §4 amended, `SKILL.md` and all seven `INSTALL.md` guides updated
- [ ] **Breaking change, documented rather than absent** — see below
- [x] Related discussion linked — ADR 0017 supersedes the prose procedure in ADR 0009/0012's guides

### The breaking change

`cli_install_started` changes subject. From this release it means **`init` ran**; history below the cutover means **the install guide was printed**. Nothing errors at the boundary — `context.client_version` is the discriminator, the same treatment the `memory_update` rename got in ADR 0016.

`install_guide_opened` is a new name for the old event, so nothing that was observable stopped being observable; the funnel gained a step rather than trading one. Ingest needs no schema change — both carry empty `properties`.

### Deploy ordering ⚠️

The guides in this PR **must not be published server-side ahead of the release carrying the code.** `docs install` prefers the server's copy (ADR 0013), so a guide naming `config` would reach machines whose binary has no such subcommand.

---

## 📌 Optional

- [x] Edge cases considered — see `tests/test_config_cmd.py` (406 lines: merge semantics, both guards, `--force`, legacy files declaring no mode, shell-exported values that must not be read) and the funnel tests in `tests/test_events.py`
- [x] Follow-up tasks mentioned — ADR 0017's remaining open issues: the credential lands in `argv` and memU mines transcripts; nothing validates the key until `doctor`; local mode's flag surface will keep growing

`431 passed, 1 skipped`; ruff and mypy clean.
