### PR TITLE
fix(hosts): write instructions atomically

### DIFF
--- a/src/memu/hosts/instruction.py
+++ b/src/memu/hosts/instruction.py
@@ -34,7 +34,6 @@ full text inline and no skill folder, because for it there is nowhere to put one
 from __future__ import annotations
 
 import argparse
-import contextlib
 import difflib
 import os
 import re
@@ -219,20 +218,20 @@ def _write(path: Path, updated: str, *, backup: bool, dry_run: bool) -> tuple[bo
     if updated == current or dry_run:
         return False, diff
 
-    path.parent.mkdir(parents=True, exist_ok=True)
+    target = path.resolve() if path.is_symlink() else path
+    target.parent.mkdir(parents=True, exist_ok=True)
     if backup and current:
         shutil.copyfile(path, path.with_suffix(path.suffix + ".bak"))
-    fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=".tmp-", suffix=path.suffix)
+    fd, temporary_name = tempfile.mkstemp(dir=target.parent, prefix=".tmp-", suffix=target.suffix)
+    temporary = Path(temporary_name)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(updated)
-        if path.exists():
-            shutil.copymode(path, temporary)
-        os.replace(temporary, path)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            os.unlink(temporary)
-        raise
+        if target.exists():
+            shutil.copymode(target, temporary)
+        temporary.replace(target)
+    finally:
+        temporary.unlink(missing_ok=True)
     return True, diff
 
 

--- a/src/memu/hosts/instruction.py
+++ b/src/memu/hosts/instruction.py
@@ -34,9 +34,12 @@ full text inline and no skill folder, because for it there is nowhere to put one
 from __future__ import annotations
 
 import argparse
+import contextlib
 import difflib
+import os
 import re
 import shutil
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -219,7 +222,17 @@ def _write(path: Path, updated: str, *, backup: bool, dry_run: bool) -> tuple[bo
     path.parent.mkdir(parents=True, exist_ok=True)
     if backup and current:
         shutil.copyfile(path, path.with_suffix(path.suffix + ".bak"))
-    path.write_text(updated, encoding="utf-8")
+    fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=".tmp-", suffix=path.suffix)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(updated)
+        if path.exists():
+            shutil.copymode(path, temporary)
+        os.replace(temporary, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(temporary)
+        raise
     return True, diff
 
 

--- a/tests/test_host_instruction.py
+++ b/tests/test_host_instruction.py
@@ -134,6 +134,19 @@ def test_rewrite_failure_leaves_the_instruction_file_intact(monkeypatch, tmp_pat
     assert not list(tmp_path.glob(".tmp-*"))
 
 
+def test_rewrite_preserves_an_instruction_symlink(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / "dotfiles" / "AGENTS.md"
+    target.parent.mkdir()
+    target.write_text("# My rules\n", encoding="utf-8")
+    path = tmp_path / "AGENTS.md"
+    path.symlink_to(target)
+
+    instruction.install(path, BINARY)
+
+    assert path.is_symlink()
+    assert instruction.instruction(BINARY) in target.read_text(encoding="utf-8")
+
+
 def test_cli_defaults_to_the_codex_instruction_file() -> None:
     args = build_parser().parse_args(["install-instruction"])
     assert args.path == AGENTS_MD

--- a/tests/test_host_instruction.py
+++ b/tests/test_host_instruction.py
@@ -118,6 +118,22 @@ def test_dry_run_writes_nothing(tmp_path: pathlib.Path) -> None:
     assert not (tmp_path / "AGENTS.md.bak").exists()
 
 
+def test_rewrite_failure_leaves_the_instruction_file_intact(monkeypatch, tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "AGENTS.md"
+    path.write_text("# My rules\n", encoding="utf-8")
+
+    def fail_replace(source: str, destination: pathlib.Path) -> None:
+        raise OSError
+
+    monkeypatch.setattr(instruction.os, "replace", fail_replace)
+
+    with pytest.raises(OSError):
+        instruction._write(path, "# Updated rules\n", backup=False, dry_run=False)
+
+    assert path.read_text(encoding="utf-8") == "# My rules\n"
+    assert not list(tmp_path.glob(".tmp-*"))
+
+
 def test_cli_defaults_to_the_codex_instruction_file() -> None:
     args = build_parser().parse_args(["install-instruction"])
     assert args.path == AGENTS_MD


### PR DESCRIPTION
## 📝 Pull Request Summary

Prevent user-owned host instruction files from being left empty or partial when an instruction update is interrupted.

---

## ✅ What does this PR do?

- Replaces direct `Path.write_text()` overwrites with a same-directory temporary-file write followed by `os.replace()`.
- Preserves the existing `.bak` backup behavior and the existing file mode.
- Adds a regression test: if replacement fails, the original instruction file remains intact and the temporary file is removed.

---

## 🤔 Why is this change needed?

`Path.write_text()` truncates AGENTS.md, CLAUDE.md, and similar host instruction files before it completes the new write. An interruption can therefore destroy or tear the user instructions.

Fixes #642.

---

## 🔍 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (please explain)

---

## ✅ PR Quality Checklist

- [x] PR title follows an allowed format
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable (no user-facing documentation change is needed)
- [x] No breaking changes
- [x] Related issues or discussions linked

---

## 🧪 Testing instructions

Run `make check` and `make test`.

Validated locally in the system environment:

- `pre-commit run -a`
- `mypy`
- `deptry src`
- `pytest --cov --cov-config=pyproject.toml --cov-report=xml` — 412 passed, 1 skipped

Note: `uv lock --locked` reports the existing base lockfile as stale despite no dependency-file change in this PR.

---

## 📌 Optional

- [ ] Screenshots or examples added (not applicable)
- [x] Edge cases considered (replacement failure and temporary-file cleanup)
- [ ] Follow-up tasks mentioned