### PR TITLE
fix(agentic): embed before deleting the stale resource row

### DIFF
--- a/src/memu/app/agentic.py
+++ b/src/memu/app/agentic.py
@@ -269,6 +269,8 @@ class AgenticMixin:
 
         ``ResourceRepo`` has no in-place update, so an "update" is a delete-then-create:
         any existing resource sharing this url is dropped before the fresh record is created.
+        The embedding is computed first so a failing embed call leaves the prior resource
+        in place instead of deleting it with nothing to replace it.
         """
         where = user_scope or None
         committed: list[Resource] = []
@@ -278,12 +280,13 @@ class AgenticMixin:
                 continue
             caption = (item.get("description") or "").strip() or None
 
+            caption_embedding = await _embed_one(embed_client, caption) if caption else None
+
             # Create-or-update keyed by url: drop any prior resource for this url first.
             stale = [res for res in store.resource_repo.list_resources(where=where).values() if res.url == url]
             for res in stale:
                 store.resource_repo.delete_resource(res.id)
 
-            caption_embedding = await _embed_one(embed_client, caption) if caption else None
             res = store.resource_repo.create_resource(
                 url=url,
                 local_path=url,

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -201,3 +201,33 @@ async def test_where_scope_filters_and_rejects_unknown_fields(service: MemorySer
 async def test_progressive_retrieve_rejects_empty_query(service: MemoryService) -> None:
     with pytest.raises(ValueError, match="empty_query"):
         await service.progressive_retrieve("   ")
+
+
+class FlakyEmbeddingClient(FakeEmbeddingClient):
+    """Raises on the Nth ``embed`` call, succeeding on every other one."""
+
+    def __init__(self, fail_on_call: int) -> None:
+        self.fail_on_call = fail_on_call
+        self.calls = 0
+
+    async def embed(self, inputs: list[str]) -> tuple[list[list[float]], None]:
+        self.calls += 1
+        if self.calls == self.fail_on_call:
+            raise TimeoutError("timeout")
+        return await super().embed(inputs)
+
+
+async def test_recommit_resource_survives_embed_failure(service: MemoryService) -> None:
+    # Create-or-update is delete-then-create; a re-caption embed call that raises must not
+    # take the existing resource down with it (it has nothing to replace it with).
+    flaky = FlakyEmbeddingClient(fail_on_call=2)
+    service._embedding_pool._cache["default"] = flaky
+    service._embedding_pool._cache["embedding"] = flaky
+
+    await service.commit_results(resource=[{"path": "/workspace/notes.md", "description": "meeting notes"}])
+
+    with pytest.raises(TimeoutError):
+        await service.commit_results(resource=[{"path": "/workspace/notes.md", "description": "revised notes"}])
+
+    result = await service.progressive_retrieve("notes")
+    assert [(r["url"], r["caption"]) for r in result["resources"]] == [("/workspace/notes.md", "meeting notes")]


### PR DESCRIPTION
Fixes #645

## Root cause

`_commit_resources` implements create-or-update-by-url as delete-then-create: it deletes any existing `Resource` row for the incoming url, then calls the embedding provider to build the new caption embedding, then creates the replacement. The delete runs before the network call, so a raised exception from the embed step (timeout, rate limit, transient network error) leaves the url with no resource at all: the old row is gone and the new one was never created.

## Fix

Compute the caption embedding first, then delete the stale row, then create. If the embed call raises, nothing has been deleted yet.

## Verification

- New regression test (`test_recommit_resource_survives_embed_failure`, parametrized across the `inmemory` and `sqlite` backends): fails on `main` (the resource list is empty after a failed recommit) and passes with the fix.
- Full suite: `uv run python -m pytest`: 413 passed, 1 skipped, on both Python 3.11 and 3.13 (the CI matrix).
- `uv run pre-commit run -a`, `uv run mypy`, `uv run deptry src` all clean.
- Not verified against a live `postgres` backend (no instance available here); its `ResourceRepo` implementation has the same unconditional delete/create pair with no spanning transaction, so it is affected by inspection but not exercised by this test.