### PR TITLE
fix(agentic): reject unknown user scope fields

### DIFF
--- a/src/memu/app/agentic.py
+++ b/src/memu/app/agentic.py
@@ -243,6 +243,10 @@ class AgenticMixin:
           with the same track-specific segment (re)generation as the workspace path.
         """
         store = self._get_database()
+        unknown_scope_fields = sorted(set(user or {}) - set(self.user_model.model_fields))
+        if unknown_scope_fields:
+            msg = f"Unknown user scope field(s): {', '.join(unknown_scope_fields)}"
+            raise ValueError(msg)
         user_scope = self.user_model(**user).model_dump() if user is not None else None
         embed_client = self._get_embedding_client("embedding")
 

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -198,6 +198,14 @@ async def test_where_scope_filters_and_rejects_unknown_fields(service: MemorySer
         await service.list_all_recall_files(where={"nope": "x"})
 
 
+async def test_commit_rejects_unknown_user_scope_fields(service: MemoryService) -> None:
+    with pytest.raises(ValueError, match="Unknown user scope field"):
+        await service.commit_results(
+            recall_files=[{"name": "A", "track": "memory", "description": "d", "content": "alpha"}],
+            user={"user_idd": "u1"},
+        )
+
+
 async def test_progressive_retrieve_rejects_empty_query(service: MemoryService) -> None:
     with pytest.raises(ValueError, match="empty_query"):
         await service.progressive_retrieve("   ")


### PR DESCRIPTION
## 📝 Pull Request Summary

Reject unknown keys in the local `commit_results()` user scope before any records are written.

Fixes #648

---

## ✅ What does this PR do?

- Compares supplied `user` keys with the configured `UserConfig.model` fields.
- Raises a clear `ValueError` listing unsupported scope fields.
- Adds an end-to-end regression test through `MemoryService.commit_results()` for both InMemory and SQLite.

---

## 🤔 Why is this change needed?

Pydantic ignores extra fields by default, so a typo such as `user_idd` was silently discarded and the record could be written with `user_id=None`. Local behavior should match the existing strict validation on `where` filters and the cloud client.

---

## 🔍 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other

---

## ✅ PR Quality Checklist

- [x] PR title follows an allowed format
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable (not needed; invalid input now fails explicitly)
- [x] No breaking changes (invalid, previously ignored fields now raise an error)
- [x] Related issues or discussions linked

---

## Testing

- Red test confirmed on InMemory and SQLite before the implementation.
- `tests/test_agentic.py`: 18 passed.
- Full suite: 413 passed, 1 skipped.
- pre-commit: passed.
- Ruff, mypy, and deptry: passed.
- `make check` cannot pass its first `uv lock --locked` step on the unmodified base because the committed `uv.lock` currently needs an upstream refresh; all subsequent checks were run directly and passed.

---

## 📌 Optional

- [x] Edge cases considered: all unknown keys are reported in deterministic sorted order.
- [ ] Follow-up tasks mentioned
