### PR TITLE
fix(agentic): embed before writing, batch requests, retry transient failures

### DIFF
--- a/src/memu/app/agentic.py
+++ b/src/memu/app/agentic.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import json
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
@@ -46,6 +47,90 @@ async def _embed_one(embed_client: Any, text: str) -> list[float]:
     vectors: list[list[float]]
     vectors, _ = await embed_client.embed([text])
     return vectors[0]
+
+
+_UNRESOLVED_TICKET = "embedding ticket redeemed without a planned vector"
+_VECTOR_COUNT_MISMATCH = "embedding provider returned the wrong number of vectors"
+
+
+class _EmbeddingBatch:
+    """Collects every text a commit needs vectorized, then resolves them at once.
+
+    Planning registers a text and gets back a ticket; the write phase redeems
+    the ticket for a vector. That indirection is what lets a commit do all of
+    its embedding in a single provider round-trip, before it has written
+    anything — see :meth:`AgenticMixin.commit_results`. Identical texts share a
+    ticket, so a line repeated across files is paid for once.
+    """
+
+    def __init__(self) -> None:
+        self._tickets: dict[str, int] = {}
+        self._texts: list[str] = []
+        self._vectors: list[list[float]] = []
+
+    def request(self, text: str) -> int:
+        ticket = self._tickets.get(text)
+        if ticket is None:
+            ticket = len(self._texts)
+            self._tickets[text] = ticket
+            self._texts.append(text)
+        return ticket
+
+    async def resolve(self, embed_client: Any) -> None:
+        """Embed every registered text — the one fallible step of a commit.
+
+        A commit with nothing to embed (a re-commit whose descriptions and
+        content are all unchanged) must not call the provider at all.
+        """
+        if not self._texts:
+            return
+        vectors, _ = await embed_client.embed(self._texts)
+        if len(vectors) != len(self._texts):
+            raise ValueError(_VECTOR_COUNT_MISMATCH)
+        self._vectors = vectors
+
+    def vector(self, ticket: int | None) -> list[float]:
+        """Redeem a ticket. ``None`` means planning and writing disagree."""
+        if ticket is None:
+            raise ValueError(_UNRESOLVED_TICKET)
+        return self._vectors[ticket]
+
+
+@dataclass
+class _ResourcePlan:
+    """One resource's pending write, its caption vector already requested."""
+
+    url: str
+    caption: str | None
+    caption_ticket: int | None
+    stale_ids: list[str]
+
+
+@dataclass
+class _SegmentPlan:
+    """One file's segment reconciliation: which to drop, which to insert."""
+
+    stale_ids: list[str]
+    additions: list[tuple[str, int]]
+
+
+@dataclass
+class _RecallFilePlan:
+    """One recall file's pending write.
+
+    ``create_ticket`` is set exactly when the file is new (it carries the
+    file-level vector the row is created with); ``description_ticket`` exactly
+    when an existing file's description changed and needs re-embedding.
+    """
+
+    name: str
+    track: str
+    description: str
+    content: str
+    existing: RecallFile | None
+    create_ticket: int | None
+    description_ticket: int | None
+    segments: _SegmentPlan
 
 
 class AgenticMixin:
@@ -241,169 +326,272 @@ class AgenticMixin:
         - ``recall_files`` — a list of ``{name, track, description, content}`` records. Each
           is a :class:`RecallFile` keyed by ``name`` within its ``track`` (``memory``/``skill``),
           with the same track-specific segment (re)generation as the workspace path.
+
+        A commit that cannot reach the embedding provider writes nothing at all, so
+        callers may retry it wholesale — which is what makes the bridging pipeline's
+        "advance state on durable success, not intent" (#518) hold. Storage failures
+        carry no such guarantee; only the embedding step is hoisted clear of the writes.
         """
         store = self._get_database()
         user_scope = self.user_model(**user).model_dump() if user is not None else None
         embed_client = self._get_embedding_client("embedding")
+        user_data = dict(user_scope or {})
 
-        committed_resources = await self._commit_resources(
-            resource or [], store=store, user_scope=user_scope, embed_client=embed_client
-        )
-        committed_files = await self._commit_recall_files(
-            recall_files or [], store=store, user_scope=user_scope, embed_client=embed_client
-        )
+        # Plan, embed, write — strictly in that order, never interleaved. Each
+        # repo call commits its own transaction, so there is no rollback to fall
+        # back on: anything written before a failure stays written. Embedding is
+        # the only step here that can fail (a rate limit, a dead provider), so
+        # hoisting all of it ahead of the first write is what makes a failed
+        # commit a no-op rather than a half-applied one. Planning reads freely —
+        # reads leave nothing behind.
+        batch = _EmbeddingBatch()
+        resource_plans = self._plan_resources(resource or [], store=store, user_scope=user_scope, batch=batch)
+        file_plans = self._plan_recall_files(recall_files or [], store=store, user_data=user_data, batch=batch)
+
+        await batch.resolve(embed_client)
+
+        committed_resources = self._write_resources(resource_plans, store=store, user_data=user_data, batch=batch)
+        committed_files = self._write_recall_files(file_plans, store=store, user_data=user_data, batch=batch)
         return {
             "resources": [self._model_dump_without_embeddings(r) for r in committed_resources],
             "recall_files": [self._model_dump_without_embeddings(f) for f in committed_files],
         }
 
-    async def _commit_resources(
+    def _plan_resources(
         self,
         resources: list[dict[str, Any]],
         *,
         store: Database,
         user_scope: dict[str, Any] | None,
-        embed_client: Any,
+        batch: _EmbeddingBatch,
+    ) -> list[_ResourcePlan]:
+        """Resolve each ``{path, description}`` against the store and request its vector.
+
+        Reads and requests only — see :meth:`commit_results` for why no write
+        may happen here. Repeated paths within one payload collapse to their
+        last occurrence: every plan is built against the same pre-commit
+        snapshot, so two plans for one url would each miss the other's write and
+        leave a duplicate behind.
+        """
+        deduped: dict[str, dict[str, Any]] = {}
+        for item in resources:
+            url = (item.get("path") or "").strip()
+            if url:
+                deduped[url] = item
+        if not deduped:
+            return []
+
+        # One listing for the whole payload; this used to be re-read per item.
+        existing = list(store.resource_repo.list_resources(where=user_scope or None).values())
+        plans: list[_ResourcePlan] = []
+        for url, item in deduped.items():
+            caption = (item.get("description") or "").strip() or None
+            plans.append(
+                _ResourcePlan(
+                    url=url,
+                    caption=caption,
+                    caption_ticket=batch.request(caption) if caption else None,
+                    stale_ids=[res.id for res in existing if res.url == url],
+                )
+            )
+        return plans
+
+    def _write_resources(
+        self,
+        plans: list[_ResourcePlan],
+        *,
+        store: Database,
+        user_data: dict[str, Any],
+        batch: _EmbeddingBatch,
     ) -> list[Resource]:
-        """Create-or-update each ``{path, description}`` as a ``Resource`` keyed by url.
+        """Apply the planned resource writes, every vector already in hand.
 
         ``ResourceRepo`` has no in-place update, so an "update" is a delete-then-create:
         any existing resource sharing this url is dropped before the fresh record is created.
         """
-        where = user_scope or None
         committed: list[Resource] = []
-        for item in resources:
-            url = (item.get("path") or "").strip()
-            if not url:
-                continue
-            caption = (item.get("description") or "").strip() or None
-
-            # Create-or-update keyed by url: drop any prior resource for this url first.
-            stale = [res for res in store.resource_repo.list_resources(where=where).values() if res.url == url]
-            for res in stale:
-                store.resource_repo.delete_resource(res.id)
-
-            caption_embedding = await _embed_one(embed_client, caption) if caption else None
-            res = store.resource_repo.create_resource(
-                url=url,
-                local_path=url,
-                caption=caption,
-                embedding=caption_embedding,
-                user_data=dict(user_scope or {}),
-                # progressive_retrieve's resource layer filters on track="workspace";
-                # commit is now the only resource writer, so tag it accordingly.
-                track="workspace",
+        for plan in plans:
+            for stale_id in plan.stale_ids:
+                store.resource_repo.delete_resource(stale_id)
+            committed.append(
+                store.resource_repo.create_resource(
+                    url=plan.url,
+                    local_path=plan.url,
+                    caption=plan.caption,
+                    embedding=batch.vector(plan.caption_ticket) if plan.caption_ticket is not None else None,
+                    user_data=dict(user_data),
+                    # progressive_retrieve's resource layer filters on track="workspace";
+                    # commit is now the only resource writer, so tag it accordingly.
+                    track="workspace",
+                )
             )
-            committed.append(res)
         return committed
 
-    async def _commit_recall_files(
+    def _plan_recall_files(
         self,
         recall_files: list[dict[str, Any]],
         *,
         store: Database,
-        user_scope: dict[str, Any] | None,
-        embed_client: Any,
-    ) -> list[RecallFile]:
-        """Create-or-update each ``{name, track, description, content}`` as a ``RecallFile``.
+        user_data: dict[str, Any],
+        batch: _EmbeddingBatch,
+    ) -> list[_RecallFilePlan]:
+        """Resolve each ``{name, track, description, content}`` and request its vectors.
 
         Keyed by ``name`` within the record's ``track`` (``memory``/``skill``). New files embed
         their ``name: description`` for file-level recall. Existing files always take the new
         content and re-embed only when the description actually changed — commit always carries
-        a description (read from the local file), but it's usually unchanged. Segments are then
-        reconciled per track.
+        a description (read from the local file), but it's usually unchanged.
+
+        Reads and requests only (see :meth:`commit_results`). Repeated ``(track, name)`` pairs
+        collapse to their last occurrence, for the same reason paths do in
+        :meth:`_plan_resources`.
         """
-        user_data = dict(user_scope or {})
-        committed: list[RecallFile] = []
+        deduped: dict[tuple[str, str], dict[str, Any]] = {}
         for item in recall_files:
             name = (item.get("name") or "").strip()
-            if not name:
-                continue
-            file_track = item.get("track") or "memory"
+            if name:
+                deduped[(item.get("track") or "memory", name)] = item
+
+        # One listing per distinct track; this used to be re-read per file.
+        existing_by_track: dict[str, dict[str, RecallFile]] = {
+            track: {
+                f.name: f
+                for f in store.recall_file_repo.list_recall_files(where={**user_data, "track": track}).values()
+            }
+            for track in {track for track, _ in deduped}
+        }
+
+        plans: list[_RecallFilePlan] = []
+        for (track, name), item in deduped.items():
             description = (item.get("description") or "").strip()
             content = (item.get("content") or "").strip()
+            existing = existing_by_track[track].get(name)
 
-            existing = store.recall_file_repo.list_recall_files(where={**user_data, "track": file_track})
-            file = {f.name: f for f in existing.values()}.get(name)
-            if file is None:
-                emb_text = f"{name}: {description}" if description else name
-                embedding = await _embed_one(embed_client, emb_text)
-                file = store.recall_file_repo.get_or_create_recall_file(
+            create_ticket = None
+            description_ticket = None
+            if existing is None:
+                create_ticket = batch.request(f"{name}: {description}" if description else name)
+            elif description and description != existing.description:
+                description_ticket = batch.request(f"{name}: {description}")
+
+            # The description the row will hold *after* the write — which is what the
+            # skill track builds its segment text from, so it must be resolved here
+            # rather than read back off a freshly-updated file.
+            # ``description_ticket is not None``, never a truthiness test: ticket 0 is
+            # a perfectly good ticket and the first one every commit hands out.
+            settled_description = (
+                description if existing is None or description_ticket is not None else existing.description
+            )
+            plans.append(
+                _RecallFilePlan(
                     name=name,
+                    track=track,
                     description=description,
-                    embedding=embedding,
-                    user_data=user_data,
-                    track=file_track,
+                    content=content,
+                    existing=existing,
+                    create_ticket=create_ticket,
+                    description_ticket=description_ticket,
+                    segments=self._plan_segments(
+                        name=name,
+                        description=settled_description,
+                        content=content,
+                        file_track=track,
+                        existing=existing,
+                        store=store,
+                        batch=batch,
+                    ),
                 )
-            # Commit always carries a description (read from the local file), so re-embed the
-            # file-level ``name: description`` vector only when it actually changed; otherwise
-            # leave the description/embedding untouched and just take the new content.
-            description_changed = bool(description) and description != file.description
-            new_embedding = await _embed_one(embed_client, f"{name}: {description}") if description_changed else None
+            )
+        return plans
+
+    def _plan_segments(
+        self,
+        *,
+        name: str,
+        description: str,
+        content: str,
+        file_track: str,
+        existing: RecallFile | None,
+        store: Database,
+        batch: _EmbeddingBatch,
+    ) -> _SegmentPlan:
+        """Diff a file's stored segments against the texts it will have after the write.
+
+        Drop-and-add on the difference only: segments whose text disappeared are deleted and
+        only genuinely new texts are embedded and inserted, so unchanged lines keep their
+        embedding.
+        """
+        new_texts = self._commit_segment_texts_for_file(
+            name=name, description=description, content=content, file_track=file_track
+        )
+        # A file that does not exist yet cannot have stored segments, so it needs no read.
+        stored = store.recall_file_segment_repo.list_segments_for_file(existing.id) if existing else []
+        stored_texts = {seg.text for seg in stored}
+        new_set = set(new_texts)
+        return _SegmentPlan(
+            stale_ids=[seg.id for seg in stored if seg.text not in new_set],
+            additions=[(text, batch.request(text)) for text in new_texts if text not in stored_texts],
+        )
+
+    def _write_recall_files(
+        self,
+        plans: list[_RecallFilePlan],
+        *,
+        store: Database,
+        user_data: dict[str, Any],
+        batch: _EmbeddingBatch,
+    ) -> list[RecallFile]:
+        """Apply the planned recall-file and segment writes, every vector already in hand."""
+        committed: list[RecallFile] = []
+        for plan in plans:
+            file = plan.existing
+            if file is None:
+                file = store.recall_file_repo.get_or_create_recall_file(
+                    name=plan.name,
+                    description=plan.description,
+                    embedding=batch.vector(plan.create_ticket),
+                    user_data=user_data,
+                    track=plan.track,
+                )
+            redescribed = plan.description_ticket is not None
             file = store.recall_file_repo.update_recall_file(
                 recall_file_id=file.id,
-                description=description if description_changed else None,
-                embedding=new_embedding,
-                content=content,
+                description=plan.description if redescribed else None,
+                embedding=batch.vector(plan.description_ticket) if redescribed else None,
+                content=plan.content,
             )
-            await self._commit_sync_file_segments(
-                file=file,
-                file_track=file_track,
-                store=store,
-                user_scope=user_data,
-                embed_client=embed_client,
-            )
+            for stale_id in plan.segments.stale_ids:
+                store.recall_file_segment_repo.delete_segment(stale_id)
+            for text, ticket in plan.segments.additions:
+                store.recall_file_segment_repo.create_segment(
+                    recall_file_id=file.id,
+                    track=plan.track,
+                    text=text,
+                    embedding=batch.vector(ticket),
+                    user_data=dict(user_data),
+                )
             committed.append(file)
         return committed
 
     @staticmethod
-    def _commit_segment_texts_for_file(file: RecallFile, file_track: str) -> list[str]:
+    def _commit_segment_texts_for_file(*, name: str, description: str, content: str, file_track: str) -> list[str]:
         """Compute a file's searchable segment texts (ADR 0007 L2 items), track-specific.
+
+        Takes the values the file will hold once written rather than a persisted
+        :class:`RecallFile`, so the texts — and their embeddings — can be settled before
+        anything is written.
 
         - ``skill``: a single ``name: ...\\ndescription: ...`` segment for the whole skill.
         - ``memory``: one segment per content line, skipping blank lines and markdown
           headings, de-duplicated while preserving order.
         """
         if file_track == "skill":
-            return [f"name: {file.name}\ndescription: {file.description}"]
+            return [f"name: {name}\ndescription: {description}"]
 
         texts: list[str] = []
-        for line in (file.content or "").split("\n"):
+        for line in (content or "").split("\n"):
             stripped = line.strip()
             if not stripped or stripped.startswith("#"):
                 continue
             texts.append(stripped)
         return list(dict.fromkeys(texts))
-
-    async def _commit_sync_file_segments(
-        self,
-        *,
-        file: RecallFile,
-        file_track: str,
-        store: Database,
-        user_scope: dict[str, Any],
-        embed_client: Any,
-    ) -> None:
-        """Reconcile a file's stored segments with its freshly computed segment texts.
-
-        Drop-and-add on the difference only: segments whose text disappeared are deleted and
-        only genuinely new texts are embedded and inserted, so unchanged lines keep their
-        embedding.
-        """
-        new_texts = self._commit_segment_texts_for_file(file, file_track)
-        existing = store.recall_file_segment_repo.list_segments_for_file(file.id)
-        existing_texts = {seg.text for seg in existing}
-        new_set = set(new_texts)
-
-        for seg in existing:
-            if seg.text not in new_set:
-                store.recall_file_segment_repo.delete_segment(seg.id)
-
-        to_add = [text for text in new_texts if text not in existing_texts]
-        if not to_add:
-            return
-        vecs, _ = await embed_client.embed(to_add)
-        for text, vec in zip(to_add, vecs, strict=True):
-            store.recall_file_segment_repo.create_segment(
-                recall_file_id=file.id, track=file_track, text=text, embedding=vec, user_data=dict(user_scope)
-            )

--- a/src/memu/app/agentic.py
+++ b/src/memu/app/agentic.py
@@ -79,8 +79,8 @@ class _EmbeddingBatch:
     async def resolve(self, embed_client: Any) -> None:
         """Embed every registered text — the one fallible step of a commit.
 
-        A commit with nothing to embed (a re-commit whose descriptions and
-        content are all unchanged) must not call the provider at all.
+        A commit with nothing to embed (a re-commit whose descriptions, captions
+        and content are all unchanged) must not call the provider at all.
         """
         if not self._texts:
             return
@@ -98,11 +98,19 @@ class _EmbeddingBatch:
 
 @dataclass
 class _ResourcePlan:
-    """One resource's pending write, its caption vector already requested."""
+    """One resource's pending write, its caption vector already requested.
+
+    ``existing`` is the row the write updates in place, ``None`` for a url the
+    store has never seen. ``caption_ticket`` is set only when a vector actually
+    has to be fetched, so an unchanged caption keeps the one already stored.
+    ``stale_ids`` are surplus rows for the same url, dropped after the survivor
+    is written.
+    """
 
     url: str
     caption: str | None
     caption_ticket: int | None
+    existing: Resource | None
     stale_ids: list[str]
 
 
@@ -367,6 +375,11 @@ class AgenticMixin:
     ) -> list[_ResourcePlan]:
         """Resolve each ``{path, description}`` against the store and request its vector.
 
+        A url the store already holds is planned as an in-place update, and its caption
+        re-embedded only when it actually changed — the same rule the recall-file path
+        applies to descriptions. A row that somehow carries a caption but no vector is
+        re-embedded regardless, so a legacy or half-written row heals on recommit.
+
         Reads and requests only — see :meth:`commit_results` for why no write
         may happen here. Repeated paths within one payload collapse to their
         last occurrence: every plan is built against the same pre-commit
@@ -386,12 +399,22 @@ class AgenticMixin:
         plans: list[_ResourcePlan] = []
         for url, item in deduped.items():
             caption = (item.get("description") or "").strip() or None
+            # The first row for this url is the one the write keeps; any others are
+            # duplicates an older commit path left behind.
+            matches = [res for res in existing if res.url == url]
+            current = matches[0] if matches else None
+
+            caption_ticket = None
+            if caption is not None and (current is None or current.caption != caption or not current.embedding):
+                caption_ticket = batch.request(caption)
+
             plans.append(
                 _ResourcePlan(
                     url=url,
                     caption=caption,
-                    caption_ticket=batch.request(caption) if caption else None,
-                    stale_ids=[res.id for res in existing if res.url == url],
+                    caption_ticket=caption_ticket,
+                    existing=current,
+                    stale_ids=[res.id for res in matches[1:]],
                 )
             )
         return plans
@@ -406,25 +429,48 @@ class AgenticMixin:
     ) -> list[Resource]:
         """Apply the planned resource writes, every vector already in hand.
 
-        ``ResourceRepo`` has no in-place update, so an "update" is a delete-then-create:
-        any existing resource sharing this url is dropped before the fresh record is created.
+        A url the store already holds is updated in place, so its ``id`` and
+        ``created_at`` survive a recommit the way a recall file's do; only a genuinely
+        new url creates a row. Nothing is deleted to make room for a write — surplus
+        duplicates go after the survivor is written, so no failure can leave a url with
+        no row at all.
         """
         committed: list[Resource] = []
         for plan in plans:
-            for stale_id in plan.stale_ids:
-                store.resource_repo.delete_resource(stale_id)
-            committed.append(
-                store.resource_repo.create_resource(
+            embedding: list[float] | None
+            if plan.caption_ticket is not None:
+                embedding = batch.vector(plan.caption_ticket)
+            elif plan.caption and plan.existing is not None:
+                # Caption unchanged, so no vector was fetched: carry the stored one over.
+                embedding = plan.existing.embedding
+            else:
+                # No caption, nothing to rank on. Clears whatever the row held.
+                embedding = None
+
+            if plan.existing is None:
+                written = store.resource_repo.create_resource(
                     url=plan.url,
                     local_path=plan.url,
                     caption=plan.caption,
-                    embedding=batch.vector(plan.caption_ticket) if plan.caption_ticket is not None else None,
+                    embedding=embedding,
                     user_data=dict(user_data),
                     # progressive_retrieve's resource layer filters on track="workspace";
                     # commit is now the only resource writer, so tag it accordingly.
                     track="workspace",
                 )
-            )
+            else:
+                written = store.resource_repo.update_resource(
+                    resource_id=plan.existing.id,
+                    local_path=plan.url,
+                    caption=plan.caption,
+                    embedding=embedding,
+                    # Re-tagged on every write, not only on create: a row an earlier
+                    # writer left on another track has to become findable again.
+                    track="workspace",
+                )
+            for stale_id in plan.stale_ids:
+                store.resource_repo.delete_resource(stale_id)
+            committed.append(written)
         return committed
 
     def _plan_recall_files(

--- a/src/memu/app/settings.py
+++ b/src/memu/app/settings.py
@@ -31,8 +31,13 @@ class EmbeddingConfig(BaseModel):
         description="Embedding model used for vectorization.",
     )
     embed_batch_size: int = Field(
-        default=1,
-        description="Maximum batch size for embedding API calls (used by the SDK client backend).",
+        default=64,
+        ge=1,
+        description=(
+            "Maximum number of texts per embedding request. Longer input lists are split into "
+            "that many sequential requests. 64 is well under every supported provider's input "
+            "limit (OpenAI/Jina 2048, Voyage 128); lower it only for a provider that rejects it."
+        ),
     )
     client_backend: str = Field(
         default="sdk",

--- a/src/memu/cloud.py
+++ b/src/memu/cloud.py
@@ -2,18 +2,17 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
-from email.utils import parsedate_to_datetime
 from typing import Any
 
 import httpx
 
 from memu.embedding.http_client import proxy_bypass_mounts
 from memu.env import env
+from memu.retry import RETRYABLE_STATUS_CODES, retry_delay
 
 DEFAULT_CLOUD_BASE_URL = "https://api.memu.so/api/v4/memory/"
 DEFAULT_SCOPE = "default"
 
-_RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504}
 _USER_FIELDS = {"user_id", "agent_id", "user_name", "agent_name"}
 _WHERE_FIELDS = {"user_id", "agent_id"}
 
@@ -218,12 +217,12 @@ class CloudMemoryClient:
                     response = await client.request(method, request_target, params=params, json=json)
                 except (httpx.TimeoutException, httpx.TransportError) as exc:
                     if attempt < self.max_attempts:
-                        await asyncio.sleep(self._retry_delay(attempt))
+                        await asyncio.sleep(retry_delay(attempt))
                         continue
                     raise CloudTransportError.from_transport(exc) from exc
 
-                if response.status_code in _RETRYABLE_STATUS_CODES and attempt < self.max_attempts:
-                    await asyncio.sleep(self._retry_delay(attempt, response))
+                if response.status_code in RETRYABLE_STATUS_CODES and attempt < self.max_attempts:
+                    await asyncio.sleep(retry_delay(attempt, response))
                     continue
                 if response.is_error:
                     raise self._response_error(response)
@@ -236,22 +235,6 @@ class CloudMemoryClient:
                 return data
 
         raise CloudServiceError.unreachable_retry_state()
-
-    @staticmethod
-    def _retry_delay(attempt: int, response: httpx.Response | None = None) -> float:
-        if response is not None:
-            retry_after = response.headers.get("Retry-After")
-            if retry_after:
-                try:
-                    return min(max(float(retry_after), 0.0), 30.0)
-                except ValueError:
-                    try:
-                        retry_at = parsedate_to_datetime(retry_after)
-                        now = parsedate_to_datetime(response.headers.get("Date", ""))
-                        return float(min(max((retry_at - now).total_seconds(), 0.0), 30.0))
-                    except (TypeError, ValueError, OverflowError):
-                        pass
-        return float(min(0.25 * (2 ** (attempt - 1)), 2.0))
 
     @staticmethod
     def _response_error(response: httpx.Response) -> CloudMemoryError:

--- a/src/memu/database/inmemory/repositories/resource_repo.py
+++ b/src/memu/database/inmemory/repositories/resource_repo.py
@@ -4,6 +4,8 @@ import uuid
 from collections.abc import Mapping
 from typing import Any
 
+import pendulum
+
 from memu.database.inmemory.repositories.filter import matches_where
 from memu.database.inmemory.state import InMemoryState
 from memu.database.models import Resource
@@ -56,6 +58,28 @@ class InMemoryResourceRepository(ResourceRepoProtocol):
             **user_data,
         )
         self.resources[rid] = res
+        return res
+
+    def update_resource(
+        self,
+        *,
+        resource_id: str,
+        local_path: str,
+        caption: str | None,
+        embedding: list[float] | None,
+        track: str | None = None,
+    ) -> Resource:
+        """Overwrite an existing resource's mutable fields (see :class:`ResourceRepo`)."""
+        res = self.resources.get(resource_id)
+        if res is None:
+            msg = f"Resource with id {resource_id} not found"
+            raise KeyError(msg)
+
+        res.local_path = local_path
+        res.caption = caption
+        res.embedding = embedding
+        res.track = track
+        res.updated_at = pendulum.now("UTC")
         return res
 
     def vector_search_resources(

--- a/src/memu/database/postgres/repositories/resource_repo.py
+++ b/src/memu/database/postgres/repositories/resource_repo.py
@@ -100,6 +100,38 @@ class PostgresResourceRepo(PostgresRepoBase, ResourceRepo):
 
         return self._cache_resource(res)
 
+    def update_resource(
+        self,
+        *,
+        resource_id: str,
+        local_path: str,
+        caption: str | None,
+        embedding: list[float] | None,
+        track: str | None = None,
+    ) -> Resource:
+        """Overwrite an existing resource's mutable fields (see :class:`ResourceRepo`)."""
+        from sqlmodel import select
+
+        with self._sessions.session() as session:
+            row = session.scalars(
+                select(self._sqla_models.Resource).where(self._sqla_models.Resource.id == resource_id)
+            ).first()
+            if row is None:
+                msg = f"Resource with id {resource_id} not found"
+                raise KeyError(msg)
+
+            row.local_path = local_path
+            row.caption = caption
+            row.embedding = self._prepare_embedding(embedding)
+            row.track = track
+            row.updated_at = self._now()
+
+            session.add(row)
+            session.commit()
+            session.refresh(row)
+            row.embedding = self._normalize_embedding(row.embedding)
+            return self._cache_resource(row)
+
     def vector_search_resources(
         self,
         query_vec: list[float],

--- a/src/memu/database/repositories/resource.py
+++ b/src/memu/database/repositories/resource.py
@@ -29,6 +29,27 @@ class ResourceRepo(Protocol):
         track: str | None = None,
     ) -> Resource: ...
 
+    def update_resource(
+        self,
+        *,
+        resource_id: str,
+        local_path: str,
+        caption: str | None,
+        embedding: list[float] | None,
+        track: str | None = None,
+    ) -> Resource:
+        """Overwrite a resource's mutable fields in place, keeping ``id`` and ``created_at``.
+
+        Unlike :meth:`RecallFileRepo.update_recall_file`, every field is written as
+        given: ``None`` clears the column rather than leaving it alone. A resource is
+        wholly defined by the record that carries it, so a record with no description
+        drops the stored caption along with its vector.
+
+        Raises:
+            KeyError: If no resource has that id.
+        """
+        ...
+
     def vector_search_resources(
         self,
         query_vec: list[float],

--- a/src/memu/database/sqlite/repositories/resource_repo.py
+++ b/src/memu/database/sqlite/repositories/resource_repo.py
@@ -195,6 +195,62 @@ class SQLiteResourceRepo(SQLiteRepoBase, ResourceRepo):
         self.resources[row.id] = res
         return res
 
+    def update_resource(
+        self,
+        *,
+        resource_id: str,
+        local_path: str,
+        caption: str | None,
+        embedding: list[float] | None,
+        track: str | None = None,
+    ) -> Resource:
+        """Overwrite an existing resource's mutable fields (see :class:`ResourceRepo`).
+
+        Args:
+            resource_id: ID of the resource to update.
+            local_path: Local file path.
+            caption: Caption text, or ``None`` to clear it.
+            embedding: Embedding vector, or ``None`` to clear it.
+            track: Workspace track to (re)tag the row with.
+
+        Returns:
+            Updated Resource object.
+
+        Raises:
+            KeyError: If no resource has that id.
+        """
+        with self._sessions.session() as session:
+            stmt = select(self._resource_model).where(self._resource_model.id == resource_id)
+            row = session.exec(stmt).first()
+
+            if row is None:
+                msg = f"Resource with id {resource_id} not found"
+                raise KeyError(msg)
+
+            row.local_path = local_path
+            row.caption = caption
+            row.embedding = self._prepare_embedding(embedding)
+            row.track = track
+            row.updated_at = self._now()
+
+            session.add(row)
+            session.commit()
+            session.refresh(row)
+
+        res = Resource(
+            id=row.id,
+            url=row.url,
+            local_path=row.local_path,
+            caption=row.caption,
+            embedding=embedding,
+            track=row.track,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+            **self._scope_kwargs_from(row),
+        )
+        self.resources[row.id] = res
+        return res
+
     def vector_search_resources(
         self,
         query_vec: list[float],

--- a/src/memu/embedding/gateway.py
+++ b/src/memu/embedding/gateway.py
@@ -34,6 +34,7 @@ def _build_httpx_client(cfg: EmbeddingConfig) -> Any:
         embed_model=cfg.embed_model,
         provider=cfg.provider,
         endpoint_overrides=cfg.endpoint_overrides,
+        embed_batch_size=cfg.embed_batch_size,
     )
 
 

--- a/src/memu/embedding/http_client.py
+++ b/src/memu/embedding/http_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import logging
 import os
@@ -15,6 +16,7 @@ from memu.embedding.backends.jina import JinaEmbeddingBackend
 from memu.embedding.backends.openai import OpenAIEmbeddingBackend
 from memu.embedding.backends.openrouter import OpenRouterEmbeddingBackend
 from memu.embedding.backends.voyage import VoyageEmbeddingBackend
+from memu.retry import DEFAULT_MAX_ATTEMPTS, RETRYABLE_STATUS_CODES, retry_delay
 
 
 def is_loopback_url(url: str) -> bool:
@@ -67,6 +69,10 @@ def _load_proxy(base_url: str) -> str | None:
 
 logger = logging.getLogger(__name__)
 
+# The retry loop always returns or raises on its final attempt; this only exists
+# so the fall-through is a loud failure rather than an implicit ``None``.
+_UNREACHABLE_RETRY = "embedding retry loop exited without a response"
+
 # Providers with a non-OpenAI endpoint/payload are registered explicitly; any
 # other provider is treated as OpenAI-compatible (see ``_load_backend``).
 EMBEDDING_BACKENDS: dict[str, Callable[[], EmbeddingBackend]] = {
@@ -91,6 +97,7 @@ class HTTPEmbeddingClient:
         endpoint_overrides: dict[str, str] | None = None,
         timeout: int = 60,
         embed_batch_size: int = 64,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
     ):
         # Ensure base_url ends with "/" so httpx doesn't discard the path
         # component when joining with endpoint paths.
@@ -111,6 +118,7 @@ class HTTPEmbeddingClient:
         self.embedding_endpoint = raw_embedding_ep.lstrip("/")
         self.timeout = timeout
         self.embed_batch_size = max(1, embed_batch_size)
+        self.max_attempts = max(1, max_attempts)
         self.proxy = _load_proxy(self.base_url)
         # httpx falls back to env proxies even when proxy=None, so a loopback
         # target explicitly unmounts them (host-specifically — see
@@ -143,15 +151,42 @@ class HTTPEmbeddingClient:
             base_url=self.base_url, timeout=self.timeout, proxy=self.proxy, mounts=self.mounts
         ) as client:
             for start in range(0, len(inputs), self.embed_batch_size):
-                payload = self.backend.build_embedding_payload(
-                    inputs=inputs[start : start + self.embed_batch_size], embed_model=self.embed_model
-                )
-                resp = await client.post(self.embedding_endpoint, json=payload, headers=self._headers())
-                resp.raise_for_status()
-                data = resp.json()
+                batch = inputs[start : start + self.embed_batch_size]
+                data = await self._post_embeddings(client, batch)
                 logger.debug("HTTP embedding response: %s", data)
                 vectors.extend(self.backend.parse_embedding_response(data))
         return vectors, data
+
+    async def _post_embeddings(self, client: httpx.AsyncClient, batch: list[str]) -> dict[str, Any]:
+        """POST one batch, retrying the failures a retry can actually fix.
+
+        Rate limits and provider 5xx are transient by nature, and an embedding
+        call sits on the critical path of a commit that has already done work —
+        letting a single 429 abort the whole thing wastes every embedding
+        already paid for. Terminal failures (401, unknown model) still surface
+        on the first attempt via ``raise_for_status``.
+        """
+        payload = self.backend.build_embedding_payload(inputs=batch, embed_model=self.embed_model)
+        for attempt in range(1, self.max_attempts + 1):
+            try:
+                resp = await client.post(self.embedding_endpoint, json=payload, headers=self._headers())
+            except httpx.TransportError:
+                # Connection resets, DNS failures and timeouts alike
+                # (TimeoutException is a TransportError).
+                if attempt == self.max_attempts:
+                    raise
+                await asyncio.sleep(retry_delay(attempt))
+                continue
+            if resp.status_code in RETRYABLE_STATUS_CODES and attempt < self.max_attempts:
+                logger.debug("embedding request returned %s; retry %s/%s", resp.status_code, attempt, self.max_attempts)
+                await asyncio.sleep(retry_delay(attempt, resp))
+                continue
+            # The last attempt falls through here whatever its status, so an
+            # exhausted retry still raises the provider's real error.
+            resp.raise_for_status()
+            json_data: dict[str, Any] = resp.json()
+            return json_data
+        raise AssertionError(_UNREACHABLE_RETRY)
 
     async def embed_multimodal(
         self,

--- a/src/memu/embedding/http_client.py
+++ b/src/memu/embedding/http_client.py
@@ -90,6 +90,7 @@ class HTTPEmbeddingClient:
         provider: str = "openai",
         endpoint_overrides: dict[str, str] | None = None,
         timeout: int = 60,
+        embed_batch_size: int = 64,
     ):
         # Ensure base_url ends with "/" so httpx doesn't discard the path
         # component when joining with endpoint paths.
@@ -109,6 +110,7 @@ class HTTPEmbeddingClient:
         # Strip leading "/" so httpx resolves relative to base_url
         self.embedding_endpoint = raw_embedding_ep.lstrip("/")
         self.timeout = timeout
+        self.embed_batch_size = max(1, embed_batch_size)
         self.proxy = _load_proxy(self.base_url)
         # httpx falls back to env proxies even when proxy=None, so a loopback
         # target explicitly unmounts them (host-specifically — see
@@ -126,17 +128,30 @@ class HTTPEmbeddingClient:
         Returns:
             Tuple of (list of embedding vectors, raw response dict). The raw
             response carries provider ``usage`` so callers/interceptors can
-            track token consumption.
+            track token consumption. Inputs beyond ``embed_batch_size`` are sent
+            as several sequential requests, in which case only the last raw
+            response is returned (the same contract as the SDK client).
         """
-        payload = self.backend.build_embedding_payload(inputs=inputs, embed_model=self.embed_model)
+        if not inputs:
+            return [], {}
+
+        vectors: list[list[float]] = []
+        data: dict[str, Any] = {}
+        # One client for every batch: each request otherwise pays its own TLS
+        # handshake, which on a many-segment commit dominates the wall clock.
         async with httpx.AsyncClient(
             base_url=self.base_url, timeout=self.timeout, proxy=self.proxy, mounts=self.mounts
         ) as client:
-            resp = await client.post(self.embedding_endpoint, json=payload, headers=self._headers())
-            resp.raise_for_status()
-            data = resp.json()
-        logger.debug("HTTP embedding response: %s", data)
-        return self.backend.parse_embedding_response(data), data
+            for start in range(0, len(inputs), self.embed_batch_size):
+                payload = self.backend.build_embedding_payload(
+                    inputs=inputs[start : start + self.embed_batch_size], embed_model=self.embed_model
+                )
+                resp = await client.post(self.embedding_endpoint, json=payload, headers=self._headers())
+                resp.raise_for_status()
+                data = resp.json()
+                logger.debug("HTTP embedding response: %s", data)
+                vectors.extend(self.backend.parse_embedding_response(data))
+        return vectors, data
 
     async def embed_multimodal(
         self,

--- a/src/memu/embedding/openai_sdk.py
+++ b/src/memu/embedding/openai_sdk.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 class OpenAIEmbeddingSDKClient:
     """OpenAI embedding client that relies on the official Python SDK."""
 
-    def __init__(self, *, base_url: str, api_key: str, embed_model: str, batch_size: int = 1):
+    def __init__(self, *, base_url: str, api_key: str, embed_model: str, batch_size: int = 64):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key or ""
         self.embed_model = embed_model

--- a/src/memu/retry.py
+++ b/src/memu/retry.py
@@ -1,0 +1,52 @@
+"""Shared retry policy for memU's outbound HTTP clients.
+
+Every client that talks to a third party over HTTP — the cloud memory transport
+and the embedding transports — faces the same transient failures: a dropped
+connection, a rate limit, a provider 5xx. Encoding "which of those are worth
+retrying, and how long to wait" once keeps the clients from drifting into
+separate dialects, so a ``Retry-After`` honoured in one place is honoured
+everywhere.
+"""
+
+from __future__ import annotations
+
+from email.utils import parsedate_to_datetime
+
+import httpx
+
+# Statuses a retry can plausibly fix. Everything else — 401 on a bad key, 400 on
+# an unknown model, 404 on a wrong endpoint — fails identically on every attempt,
+# so retrying only delays the error the caller needs to see.
+RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504}
+
+DEFAULT_MAX_ATTEMPTS = 3
+
+# A provider asking for a multi-minute pause is asking for more than any caller
+# here is willing to block for; past this we give up rather than hang.
+_MAX_RETRY_AFTER = 30.0
+_BASE_BACKOFF = 0.25
+_MAX_BACKOFF = 2.0
+
+
+def retry_delay(attempt: int, response: httpx.Response | None = None) -> float:
+    """Seconds to wait before retrying, after ``attempt`` (1-based) failed.
+
+    A provider's own ``Retry-After`` wins when it sends one — it knows when its
+    rate-limit window reopens and we do not — in either of the header's two
+    forms (delta-seconds or an HTTP-date, the latter read against the response's
+    own ``Date`` so a skewed local clock cannot turn into a wild sleep). Absent
+    or unparseable, fall back to capped exponential backoff.
+    """
+    if response is not None:
+        retry_after = response.headers.get("Retry-After")
+        if retry_after:
+            try:
+                return min(max(float(retry_after), 0.0), _MAX_RETRY_AFTER)
+            except ValueError:
+                try:
+                    retry_at = parsedate_to_datetime(retry_after)
+                    now = parsedate_to_datetime(response.headers.get("Date", ""))
+                    return float(min(max((retry_at - now).total_seconds(), 0.0), _MAX_RETRY_AFTER))
+                except (TypeError, ValueError, OverflowError):
+                    pass
+    return float(min(_BASE_BACKOFF * (2 ** (attempt - 1)), _MAX_BACKOFF))

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -264,6 +264,42 @@ async def test_repeated_path_in_one_payload_commits_once(service: MemoryService)
     assert [r["caption"] for r in found["resources"]] == ["second"]
 
 
+async def test_recommit_updates_the_resource_row_in_place(service: MemoryService) -> None:
+    """A url keeps its row across recommits, and an unchanged caption is not re-embedded.
+
+    Delete-then-create churned the id and created_at on every commit — unlike the
+    recall-file path, which updates in place — and paid the provider for a caption
+    vector each time, because a recreated row has no stored vector to keep.
+    """
+    counter = CountingEmbeddingClient()
+    service._embedding_pool._cache["embedding"] = counter
+
+    record = {"path": "/workspace/notes.md", "description": "meeting notes"}
+    original = (await service.commit_results(resource=[record]))["resources"][0]
+
+    counter.calls = 0
+    again = (await service.commit_results(resource=[dict(record)]))["resources"][0]
+    assert counter.calls == 0
+    assert again["id"] == original["id"]
+    assert again["created_at"] == original["created_at"]
+
+    # A changed caption is re-embedded, and lands on that same row.
+    counter.calls = 0
+    changed = (await service.commit_results(resource=[{**record, "description": "deploy notes"}]))["resources"][0]
+    assert counter.calls == 1
+    assert changed["id"] == original["id"]
+    assert changed["caption"] == "deploy notes"
+    found = await service.progressive_retrieve("deploy notes")
+    assert [r["url"] for r in found["resources"]] == ["/workspace/notes.md"]
+
+    # A record with no description clears the caption and its vector: the commit
+    # payload is authoritative for a resource, and an unranked row cannot be recalled.
+    cleared = (await service.commit_results(resource=[{"path": "/workspace/notes.md"}]))["resources"][0]
+    assert cleared["id"] == original["id"]
+    assert cleared["caption"] is None
+    assert (await service.progressive_retrieve("deploy notes"))["resources"] == []
+
+
 async def test_where_scope_filters_and_rejects_unknown_fields(service: MemoryService) -> None:
     await service.commit_results(
         recall_files=[{"name": "A", "track": "memory", "description": "d", "content": "alpha"}],

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -181,6 +181,89 @@ async def test_recommit_updates_skill_description_and_segment(service: MemorySer
     assert "name: deploy-checklist\ndescription: how to deploy" not in seg_texts
 
 
+class EmbeddingProviderDown(RuntimeError):
+    """What a rate limit or a dead provider looks like to ``commit_results``."""
+
+
+class FailingEmbeddingClient(FakeEmbeddingClient):
+    """Fails the way a rate-limited or unreachable provider does."""
+
+    def __init__(self, *, fail_on_call: int = 1) -> None:
+        self.calls = 0
+        self._fail_on_call = fail_on_call
+
+    async def embed(self, inputs: list[str]) -> tuple[list[list[float]], None]:
+        self.calls += 1
+        if self.calls == self._fail_on_call:
+            raise EmbeddingProviderDown
+        return await super().embed(inputs)
+
+
+async def test_failed_embedding_leaves_the_store_untouched(service: MemoryService) -> None:
+    """A commit that cannot embed must write nothing — not even the items before the failure.
+
+    Each repo call commits its own transaction, so a write reached before the
+    failing embed would be permanent. This is the guarantee that makes a failed
+    commit safe to simply retry.
+    """
+    await _seed(service)
+    before = await service.list_all_recall_files()
+    baseline = await service.progressive_retrieve("coffee")
+
+    service._embedding_pool._cache["embedding"] = FailingEmbeddingClient()
+    with pytest.raises(EmbeddingProviderDown):
+        await service.commit_results(
+            recall_files=[
+                {"name": "Profile", "track": "memory", "description": "changed", "content": "# P\nlikes tea"},
+                {"name": "brand-new", "track": "memory", "description": "new", "content": "unseen line"},
+            ],
+            resource=[{"path": "/workspace/notes.md", "description": "rewritten caption"}],
+        )
+
+    after = await service.list_all_recall_files()
+    assert after["recall_files"] == before["recall_files"]
+
+    # The pre-existing resource survived: its caption embed failed, and the old
+    # record must not have been dropped in anticipation of a replacement.
+    service._embedding_pool._cache["embedding"] = FakeEmbeddingClient()
+    assert await service.progressive_retrieve("coffee") == baseline
+
+
+async def test_commit_embeds_everything_in_one_batched_call(service: MemoryService) -> None:
+    """Files, resources and segments share a single provider round-trip."""
+    counter = CountingEmbeddingClient()
+    service._embedding_pool._cache["embedding"] = counter
+
+    await service.commit_results(
+        recall_files=[
+            {"name": "A", "track": "memory", "description": "d", "content": "one\ntwo"},
+            {"name": "B", "track": "skill", "description": "e", "content": "step"},
+        ],
+        resource=[{"path": "/w/a.md", "description": "cap a"}, {"path": "/w/b.md", "description": "cap b"}],
+    )
+    assert counter.calls == 1
+
+
+async def test_repeated_path_in_one_payload_commits_once(service: MemoryService) -> None:
+    """Two records for one url collapse to one, in the response as well as the store.
+
+    The store always ended up with a single row, but the returned list used to
+    carry the superseded record too — so ``memu commit`` printed an inflated
+    count and filed it to telemetry.
+    """
+    committed = await service.commit_results(
+        resource=[
+            {"path": "/workspace/dup.md", "description": "first"},
+            {"path": "/workspace/dup.md", "description": "second"},
+        ]
+    )
+    assert len(committed["resources"]) == 1
+
+    found = await service.progressive_retrieve("second")
+    assert [r["url"] for r in found["resources"]] == ["/workspace/dup.md"]
+    assert [r["caption"] for r in found["resources"]] == ["second"]
+
+
 async def test_where_scope_filters_and_rejects_unknown_fields(service: MemoryService) -> None:
     await service.commit_results(
         recall_files=[{"name": "A", "track": "memory", "description": "d", "content": "alpha"}],

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -20,6 +20,7 @@ if str(src_path) not in sys.path:
     sys.path.insert(0, str(src_path))
 
 import pytest  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
 
 from memu.app.settings import EmbeddingConfig  # noqa: E402
 from memu.embedding.backends import (  # noqa: E402
@@ -104,6 +105,80 @@ async def test_http_client_embed_returns_vectors_and_raw(monkeypatch):
     assert captured["endpoint"] == "embeddings"  # leading slash stripped
     assert captured["headers"] == {"Authorization": "Bearer key"}
     assert captured["json"] == {"model": "voyage-3.5", "input": ["hello"]}
+
+
+async def test_http_client_splits_inputs_into_batches(monkeypatch):
+    """A list longer than ``embed_batch_size`` becomes several requests, one client."""
+    posted: list[list[str]] = []
+    clients: list[object] = []
+
+    class _FakeResponse:
+        def __init__(self, count: int):
+            self._count = count
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"data": [{"embedding": [float(i)]} for i in range(self._count)]}
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            clients.append(self)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, endpoint, json, headers):
+            posted.append(json["input"])
+            return _FakeResponse(len(json["input"]))
+
+    import memu.embedding.http_client as http_mod
+
+    monkeypatch.setattr(http_mod.httpx, "AsyncClient", _FakeAsyncClient)
+
+    client = HTTPEmbeddingClient(base_url="https://x/v1", api_key="k", embed_model="m", embed_batch_size=2)
+    vectors, _ = await client.embed(["a", "b", "c", "d", "e"])
+
+    assert posted == [["a", "b"], ["c", "d"], ["e"]]
+    assert len(vectors) == 5
+    assert len(clients) == 1  # every batch shares one connection pool
+
+
+async def test_http_client_embed_of_nothing_makes_no_request(monkeypatch):
+    """An empty commit must not post an empty ``input`` the provider would reject."""
+
+    built = False
+
+    class _RecordingAsyncClient:
+        def __init__(self, *args, **kwargs):
+            nonlocal built
+            built = True
+
+    import memu.embedding.http_client as http_mod
+
+    monkeypatch.setattr(http_mod.httpx, "AsyncClient", _RecordingAsyncClient)
+
+    client = HTTPEmbeddingClient(base_url="https://x/v1", api_key="k", embed_model="m")
+    assert await client.embed([]) == ([], {})
+    assert not built
+
+
+def test_embed_batch_size_defaults_to_batching_and_is_plumbed_to_both_backends():
+    # A default of 1 silently turned each batched call into N sequential requests.
+    assert EmbeddingConfig().embed_batch_size == 64
+
+    httpx_client = build_embedding_client(EmbeddingConfig(client_backend="httpx", embed_batch_size=8))
+    assert httpx_client.embed_batch_size == 8
+
+    sdk = build_embedding_client(EmbeddingConfig(client_backend="sdk", embed_batch_size=8))
+    assert sdk.batch_size == 8
+
+    with pytest.raises(ValidationError):
+        EmbeddingConfig(embed_batch_size=0)
 
 
 def test_gateway_builds_sdk_and_httpx_clients():

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -19,6 +19,7 @@ src_path = Path(__file__).parent.parent / "src"
 if str(src_path) not in sys.path:
     sys.path.insert(0, str(src_path))
 
+import httpx  # noqa: E402
 import pytest  # noqa: E402
 from pydantic import ValidationError  # noqa: E402
 
@@ -69,6 +70,8 @@ async def test_http_client_embed_returns_vectors_and_raw(monkeypatch):
     captured: dict = {}
 
     class _FakeResponse:
+        status_code = 200
+
         def raise_for_status(self):
             return None
 
@@ -113,6 +116,8 @@ async def test_http_client_splits_inputs_into_batches(monkeypatch):
     clients: list[object] = []
 
     class _FakeResponse:
+        status_code = 200
+
         def __init__(self, count: int):
             self._count = count
 
@@ -165,6 +170,91 @@ async def test_http_client_embed_of_nothing_makes_no_request(monkeypatch):
     client = HTTPEmbeddingClient(base_url="https://x/v1", api_key="k", embed_model="m")
     assert await client.embed([]) == ([], {})
     assert not built
+
+
+class _StubResponse:
+    """Minimal httpx.Response stand-in for the retry tests."""
+
+    def __init__(self, status_code: int, *, headers: dict | None = None):
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            request = httpx.Request("POST", "https://x/v1/embeddings")
+            raise httpx.HTTPStatusError(
+                str(self.status_code),
+                request=request,
+                response=httpx.Response(self.status_code, request=request),
+            )
+
+    def json(self):
+        return {"data": [{"embedding": [1.0]}]}
+
+
+def _client_over(responses, monkeypatch, **kwargs):
+    """Build an HTTPEmbeddingClient whose POSTs replay ``responses`` in order."""
+    attempts: list = []
+
+    class _FakeAsyncClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, endpoint, json, headers):
+            outcome = responses[len(attempts)]
+            attempts.append(outcome)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+    import memu.embedding.http_client as http_mod
+
+    monkeypatch.setattr(http_mod.httpx, "AsyncClient", _FakeAsyncClient)
+    monkeypatch.setattr(http_mod.asyncio, "sleep", _no_sleep)
+    return HTTPEmbeddingClient(base_url="https://x/v1", api_key="k", embed_model="m", **kwargs), attempts
+
+
+async def _no_sleep(_seconds):
+    return None
+
+
+async def test_embed_retries_rate_limit_then_succeeds(monkeypatch):
+    client, attempts = _client_over([_StubResponse(429, headers={"Retry-After": "0"}), _StubResponse(200)], monkeypatch)
+    vectors, _ = await client.embed(["a"])
+
+    assert vectors == [[1.0]]
+    assert len(attempts) == 2
+
+
+async def test_embed_retries_transport_errors(monkeypatch):
+    client, attempts = _client_over([httpx.ConnectError("boom"), _StubResponse(200)], monkeypatch)
+    vectors, _ = await client.embed(["a"])
+
+    assert vectors == [[1.0]]
+    assert len(attempts) == 2
+
+
+async def test_embed_does_not_retry_terminal_failures(monkeypatch):
+    """A 401 fails the same way every time; burning attempts only delays it."""
+    client, attempts = _client_over([_StubResponse(401)] * 3, monkeypatch)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.embed(["a"])
+    assert len(attempts) == 1
+
+
+async def test_embed_surfaces_the_provider_error_once_retries_are_exhausted(monkeypatch):
+    client, attempts = _client_over([_StubResponse(503)] * 3, monkeypatch, max_attempts=3)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.embed(["a"])
+    assert len(attempts) == 3
 
 
 def test_embed_batch_size_defaults_to_batching_and_is_plumbed_to_both_backends():


### PR DESCRIPTION
## 📝 Pull Request Summary

Four fixes along the embedding path that `commit_results` depends on: a failed embedding no longer leaves the store half-written, a resource is updated in place instead of being destroyed and recreated, transient provider failures are retried, and a commit's embeddings travel in one batched request instead of one request per text.

---

## ✅ What does this PR do?

Four commits, each independently reviewable.

**`perf(embedding): batch embedding requests instead of de-batching them`**

`embed_batch_size` defaulted to `1`. The one call site that genuinely batched — `_commit_sync_file_segments` handing every new segment text to `embed()` at once — was therefore *unwound* by the SDK client into N sequential single-text requests. A 30-line memory file cost 30 serial round-trips.

- Default `embed_batch_size` to 64, well under every supported provider's input limit (OpenAI/Jina 2048, Voyage 128), and validate `ge=1`.
- Plumb it into `HTTPEmbeddingClient`, which ignored the field entirely and posted whatever list it was handed as one unbounded request. Both backends now chunk identically.
- Reuse a single `AsyncClient` across batches rather than paying a TLS handshake per request.
- Return early on an empty input list instead of posting an `input: []` most providers reject.

**`feat(embedding): retry transient failures in the HTTP embedding client`**

The HTTP backend had no retries at all, so one 429 or provider 5xx aborted an entire commit — while the SDK backend quietly retried the same failures twice. Identical config behaved differently depending on `client_backend`.

- Retry in the transport, not at the call site: only there is the response available to distinguish a retryable 429/5xx from a terminal 401, and only there can a provider's `Retry-After` be honoured. Retrying in `_embed_one` instead would have stacked on top of the SDK's own retries and forced callers to sniff two unrelated exception hierarchies.
- Extract the delay policy and retryable-status set into `memu.retry`, shared with the cloud transport that already implemented them, so the two clients cannot drift into separate dialects.
- No new configuration surface: attempts are a constructor argument, and the SDK already exposes `max_retries`.

**`fix(agentic): make a commit embed everything before it writes anything`**

Every repo call commits its own transaction, so there is no rollback behind `commit_results` — whatever was written before a failure stayed written. The commit loops interleaved a fallible embed with durable writes:

- `_commit_resources` deleted the record it was replacing *before* embedding its caption, so a failed embed lost a resource outright.
- `_commit_sync_file_segments` deleted a file's stale segments before embedding their successors, leaving the file unfindable through the segment layer.
- Resources were committed before recall files, so a resource-side failure meant zero recall files were written despite being the more valuable payload.

Split the commit into **plan → embed → write**. Planning reads the store and registers the texts needing vectors, writing nothing; a single batched `embed` resolves them all; only then does anything reach storage.

Falling out of the restructure:

- One embed call per commit rather than one per file, description and segment set; one store read per track rather than one per file (`list_recall_files` was previously re-read for every file, and `list_resources` for every resource).
- Repeated paths — or `(track, name)` pairs — within one payload collapse to their last occurrence. The store already held a single row, but the returned list carried the superseded record too, so `memu commit` printed an inflated count and filed that number to telemetry via `_record_commit`.
- A provider returning the wrong number of vectors raises a named error instead of surfacing as a misaligned `zip` or an `IndexError`.

**`fix(agentic): update a resource in place instead of recreating it`** — closes #645

Hoisting the embed ahead of the writes closes the window #645 reports, but `_write_resources` still implemented create-or-update-by-url as delete-then-create, and the pair is still two separate transactions with no rollback behind them. A failing `create_resource` — a locked SQLite file, a dropped connection — or a process killed between the two calls leaves the url with no row at all, and in a multi-resource payload it takes the rows already written with it. `_commit_recall_files` never had this shape: it has always had a real in-place `update_recall_file`.

Give `ResourceRepo` the `update_resource` its recall-file counterpart already had — implemented for all three backends — and write through it. Falling out of that:

- **Stable identity.** A recommitted url keeps its `id` and `created_at`, the way a recall file does. They used to churn on every commit, so an id handed back by `progressive_retrieve` went stale as soon as the next commit ran, and no foreign key to `Resource` could ever be added.
- **An unchanged caption is no longer re-embedded.** The recall-file path already skipped unchanged descriptions; resources could not, because a recreated row has no stored vector to keep. The bridging pipeline recommits the same workspace resources every run, so this was a provider call per resource per run, forever.
- **Deletes happen after the surviving row is written**, and only for surplus duplicate rows, so no failure can empty a url.

`update_resource` writes every field as given rather than treating `None` as "leave alone": the commit record is authoritative for a resource, so a record with no description drops the caption and its vector, exactly as delete-then-create did. `track` is rewritten on every commit too, so a row an earlier writer left on another track becomes findable again — the re-tagging that delete-then-create used to do implicitly.

---

## 🤔 Why is this change needed?

`memu commit` is the terminal step of the bridging record seam, and `pipeline.commit()` is deliberately ordered so that the session cursor and memory snapshot advance only after the store accepts a submission — "state advances on durable success, not on intent" (#518). That contract assumes a failed commit is safe to retry wholesale.

It was not. A rate limit partway through a payload left resources deleted with no replacement and files updated with gutted segments, and since `resources.md` is rewritten each run by the resource job, a resource lost that way was not guaranteed to be re-offered. Hoisting every embedding ahead of the first write is what makes the retry assumption actually true; making the resource write a real update is what removes the last write-ordering hazard behind it.

The batching and retry commits address the same failure from the other side: fewer requests mean fewer chances to fail, and the ones that do fail transiently now recover instead of aborting work already paid for.

---

## 🔍 Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor / cleanup
- [ ] Other (please explain)

---

## ✅ PR Quality Checklist

- [x] PR title follows an allowed format
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated where applicable (no user-facing documentation change is needed)
- [x] No breaking changes *for callers* — but see the `ResourceRepo` note below for out-of-tree backends
- [x] Related issues or discussions linked (closes #645; supersedes #646)

### Behaviour changes worth a reviewer's attention

- **`ResourceRepo` gained a required method.** All three in-tree backends implement `update_resource`, but any out-of-tree implementation of the `Database` protocol has to add it before upgrading, or the first recommit of a known url raises `AttributeError`. The protocol is `@runtime_checkable` but nothing ever `isinstance`-checks it, so there is no startup signal — worth calling out in release notes.
- A recommitted resource now keeps its `id` and `created_at`. Anything that assumed a fresh id per commit (nothing in-tree does) changes behaviour.
- `embed_batch_size` defaults to 64 instead of 1. This only affects configurations that never set it, for which it is strictly fewer requests. Lower it for any provider that rejects a 64-input request — **Doubao's text-embedding input limit is worth confirming before merge**; if it is below 64, that is the point at which a per-provider default belongs in `memu.embedding.defaults` alongside the existing endpoint/model tables.
- `_commit_segment_texts_for_file` now takes the values a file will hold rather than a persisted `RecallFile`, since segment texts must be settled before the row is written. Private method, no external callers.
- The commit response no longer lists superseded duplicates, so reported resource counts may drop for payloads that contained repeated paths. The count is now correct.

---

## 🧪 Testing instructions

Run `make check` and `make test`.

Validated locally:

- `make check` — `uv lock --locked`, `pre-commit run -a`, `mypy` (140 source files), `deptry src`, all clean
- `make test` — 494 passed, 1 failed. The failure is `tests/test_cache_segment_duplicates.py::test_postgres_list_segments_deduplicates_cache`, which is unrelated to this branch and **already fixed on `main` by #652**; it only surfaces here because the branch predates that commit, and only in environments where `pgvector` is installed (elsewhere the test skips). It passes on `main` and disappears on rebase.

New coverage:

- `tests/test_agentic.py` — a failed embedding leaves the store byte-identical; a whole commit embeds in one call; repeated paths commit once; a recommitted url keeps its row (`id`/`created_at` preserved, unchanged caption costs zero provider calls, changed caption costs exactly one and lands on the same row, an empty description clears the caption and drops the row out of recall). Both the inmemory and sqlite backends.
- `tests/test_embedding.py` — batch splitting, empty-input short-circuit, retry on 429 and on transport errors, no retry on 401, provider error surfaced once attempts are exhausted, `embed_batch_size` plumbed to both backends

Each new `test_agentic.py` test was confirmed to **fail against the previous implementation**, so they pin the fixes rather than the refactor.

Not covered by tests: the postgres `update_resource`, since the suite skips postgres without `pgvector`. It is verified by inspection against the sqlite implementation, whose semantics it mirrors.

---

## 📌 Optional

- [ ] Screenshots or examples added (not applicable)
- [x] Edge cases considered (embedding ticket `0` is a valid ticket and must not be truthiness-tested; empty payloads must not call the provider; duplicate keys within one payload; a stored row that carries a caption but no vector is re-embedded rather than trusted, so a legacy or half-written row heals on recommit)
- [x] Follow-up tasks mentioned

### Relationship to #646

#646 fixes #645 by computing the embedding before deleting the stale row. The ordering half of that is already implied here — nothing is written until every embedding resolves — and the fourth commit now supplies the `update_resource` half as well, so this PR fully supersedes #646. `_ResourcePlan.stale_ids` survives, but only in its narrow remaining sense: surplus duplicate rows for one url, deleted after the survivor is written, never before.
