### PR TITLE
feat(database): let a backend answer segment recall from its own vector index

### DIFF
--- a/src/memu/app/agentic.py
+++ b/src/memu/app/agentic.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
-from memu.vector import cosine_topk
-
 if TYPE_CHECKING:
     from memu.app.settings import ProgressiveRetrieveConfig
     from memu.database.interfaces import Database
@@ -137,9 +135,15 @@ class AgenticMixin:
     ) -> tuple[list[tuple[str, float]], dict[str, Any]]:
         """Rank :class:`RecallFileSegment` slices by embedding similarity.
 
-        The segment repo has no vector search, so the stored segment embeddings
-        are ranked directly, optionally scoped to the configured tracks via the
-        denormalized ``track``.
+        The ranking belongs to the repo (:meth:`RecallFileSegmentRepo.vector_search_segments`),
+        which is what lets a backend with a native vector index answer from one
+        indexed query; backends without one inherit a brute-force scan of the
+        same scope. Either way the scope is optionally narrowed to the
+        configured tracks via the denormalized ``track``.
+
+        The returned pool holds only the hits — everything downstream
+        (:meth:`_collect_files`, :meth:`_materialize_hits`) looks up hit ids and
+        nothing else, so there is no reason to carry the full corpus along.
         """
         if not enabled:
             return [], {}
@@ -148,13 +152,12 @@ class AgenticMixin:
         tracks = self.progressive_retrieve_config.file.tracks
         if tracks:
             segment_where["track__in"] = list(tracks)
-        segment_pool = {seg.id: seg for seg in store.recall_file_segment_repo.list_segments(segment_where)}
-        segment_hits = cosine_topk(
+        hits = store.recall_file_segment_repo.vector_search_segments(
             query_vector,
-            [(sid, seg.embedding) for sid, seg in segment_pool.items()],
-            k=self.progressive_retrieve_config.file.top_k,
+            self.progressive_retrieve_config.file.top_k,
+            where=segment_where,
         )
-        return segment_hits, segment_pool
+        return [(seg.id, score) for seg, score in hits], {seg.id: seg for seg, _ in hits}
 
     def _collect_files(
         self,

--- a/src/memu/database/inmemory/repositories/recall_file_segment_repo.py
+++ b/src/memu/database/inmemory/repositories/recall_file_segment_repo.py
@@ -8,7 +8,6 @@ from memu.database.inmemory.repositories.filter import matches_where
 from memu.database.inmemory.state import InMemoryState
 from memu.database.models import RecallFileSegment
 from memu.database.repositories.recall_file_segment import RecallFileSegmentRepo
-from memu.vector import cosine_topk
 
 
 class InMemoryFileSegmentRepository(RecallFileSegmentRepo):
@@ -22,16 +21,8 @@ class InMemoryFileSegmentRepository(RecallFileSegmentRepo):
             return list(self.segments)
         return [seg for seg in self.segments if matches_where(seg, where)]
 
-    def vector_search_segments(
-        self,
-        query_vec: list[float],
-        top_k: int,
-        where: Mapping[str, Any] | None = None,
-    ) -> list[tuple[RecallFileSegment, float]]:
-        pool = self.list_segments(where)
-        by_id = {seg.id: seg for seg in pool}
-        ranked = cosine_topk(query_vec, [(seg.id, seg.embedding) for seg in pool], k=top_k)
-        return [(by_id[seg_id], score) for seg_id, score in ranked]
+    # ``vector_search_segments`` is the protocol's Python scan, which is already
+    # exactly what an in-memory store would do by hand.
 
     def list_segments_for_file(self, recall_file_id: str) -> list[RecallFileSegment]:
         return [seg for seg in self.segments if seg.recall_file_id == recall_file_id]

--- a/src/memu/database/inmemory/repositories/recall_file_segment_repo.py
+++ b/src/memu/database/inmemory/repositories/recall_file_segment_repo.py
@@ -8,6 +8,7 @@ from memu.database.inmemory.repositories.filter import matches_where
 from memu.database.inmemory.state import InMemoryState
 from memu.database.models import RecallFileSegment
 from memu.database.repositories.recall_file_segment import RecallFileSegmentRepo
+from memu.vector import cosine_topk
 
 
 class InMemoryFileSegmentRepository(RecallFileSegmentRepo):
@@ -20,6 +21,17 @@ class InMemoryFileSegmentRepository(RecallFileSegmentRepo):
         if not where:
             return list(self.segments)
         return [seg for seg in self.segments if matches_where(seg, where)]
+
+    def vector_search_segments(
+        self,
+        query_vec: list[float],
+        top_k: int,
+        where: Mapping[str, Any] | None = None,
+    ) -> list[tuple[RecallFileSegment, float]]:
+        pool = self.list_segments(where)
+        by_id = {seg.id: seg for seg in pool}
+        ranked = cosine_topk(query_vec, [(seg.id, seg.embedding) for seg in pool], k=top_k)
+        return [(by_id[seg_id], score) for seg_id, score in ranked]
 
     def list_segments_for_file(self, recall_file_id: str) -> list[RecallFileSegment]:
         return [seg for seg in self.segments if seg.recall_file_id == recall_file_id]

--- a/src/memu/database/postgres/postgres.py
+++ b/src/memu/database/postgres/postgres.py
@@ -84,6 +84,10 @@ class PostgresStore(Database):
             sqla_models=self._sqla_models,
             sessions=self._sessions,
             scope_fields=self._scope_fields,
+            # Honour an explicit non-pgvector ``vector_index.provider``: the column
+            # type is ``VECTOR`` regardless, but a deployment that asked for
+            # brute force gets brute force.
+            use_vector=self._use_vector_type,
         )
 
         self.resources = self._state.resources

--- a/src/memu/database/postgres/repositories/recall_file_segment_repo.py
+++ b/src/memu/database/postgres/repositories/recall_file_segment_repo.py
@@ -19,8 +19,15 @@ class PostgresRecallFileSegmentRepo(PostgresRepoBase, RecallFileSegmentRepo):
         sqla_models: Any,
         sessions: SessionManager,
         scope_fields: list[str],
+        use_vector: bool = True,
     ) -> None:
-        super().__init__(state=state, sqla_models=sqla_models, sessions=sessions, scope_fields=scope_fields)
+        super().__init__(
+            state=state,
+            sqla_models=sqla_models,
+            sessions=sessions,
+            scope_fields=scope_fields,
+            use_vector=use_vector,
+        )
         self._recall_file_segment_model = recall_file_segment_model
         self.segments: list[RecallFileSegment] = self._state.segments
 
@@ -52,6 +59,41 @@ class PostgresRecallFileSegmentRepo(PostgresRepoBase, RecallFileSegmentRepo):
 
     def list_segments_for_file(self, recall_file_id: str) -> list[RecallFileSegment]:
         return self.list_segments({"recall_file_id": recall_file_id})
+
+    def vector_search_segments(
+        self,
+        query_vec: list[float],
+        top_k: int,
+        where: Mapping[str, Any] | None = None,
+    ) -> list[tuple[RecallFileSegment, float]]:
+        """Rank segments with pgvector, inside the database.
+
+        Postgres does the ordering and the truncation, so only ``top_k`` rows
+        cross the wire instead of every segment in scope — the one thing the
+        inherited Python scan cannot do.
+
+        A deployment that asked for a non-pgvector index (``vector_index.provider``)
+        gets the inherited scan instead, even though the column type is ``VECTOR``
+        either way.
+        """
+        if top_k <= 0:
+            return []
+        if not self._use_vector:
+            return super().vector_search_segments(query_vec, top_k, where)
+
+        from sqlmodel import select
+
+        model = self._sqla_models.RecallFileSegment
+        # ``<=>`` yields cosine *distance*; the contract is similarity, hence
+        # ``1 - distance`` below. Rows without an embedding are filtered out
+        # rather than left to sort to whichever end NULLs land on.
+        distance = model.embedding.cosine_distance(query_vec)
+        filters = [*self._build_filters(model, where), model.embedding.is_not(None)]
+        with self._sessions.session() as session:
+            rows = session.exec(
+                select(model, distance.label("distance")).where(*filters).order_by(distance).limit(top_k)
+            ).all()
+            return [(self._cache_segment(row), 1.0 - float(dist)) for row, dist in rows]
 
     def create_segment(
         self,

--- a/src/memu/database/repositories/recall_file_segment.py
+++ b/src/memu/database/repositories/recall_file_segment.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Any, Protocol, runtime_checkable
 
 from memu.database.models import RecallFileSegment
+from memu.vector import cosine_topk
 
 
 @runtime_checkable
@@ -26,8 +27,16 @@ class RecallFileSegmentRepo(Protocol):
         ``top_k`` of them.
 
         The segments themselves come back, not their ids.
+
+        This default scans the scoped pool in Python. It is the fallback every
+        backend gets for free; a backend whose store can rank natively should
+        override it, and may call back here via ``super()`` when its index is
+        unavailable.
         """
-        ...
+        pool = self.list_segments(where)
+        by_id = {seg.id: seg for seg in pool}
+        ranked = cosine_topk(query_vec, [(seg.id, seg.embedding) for seg in pool], k=top_k)
+        return [(by_id[seg_id], score) for seg_id, score in ranked]
 
     def list_segments_for_file(self, recall_file_id: str) -> list[RecallFileSegment]:
         """Return all segments belonging to a given file."""

--- a/src/memu/database/repositories/recall_file_segment.py
+++ b/src/memu/database/repositories/recall_file_segment.py
@@ -14,6 +14,21 @@ class RecallFileSegmentRepo(Protocol):
 
     def list_segments(self, where: Mapping[str, Any] | None = None) -> list[RecallFileSegment]: ...
 
+    def vector_search_segments(
+        self,
+        query_vec: list[float],
+        top_k: int,
+        where: Mapping[str, Any] | None = None,
+    ) -> list[tuple[RecallFileSegment, float]]:
+        """Rank segments by cosine similarity of their stored embeddings.
+
+        Returns ``(segment, score)`` pairs ordered by descending score, at most
+        ``top_k`` of them.
+
+        The segments themselves come back, not their ids.
+        """
+        ...
+
     def list_segments_for_file(self, recall_file_id: str) -> list[RecallFileSegment]:
         """Return all segments belonging to a given file."""
         ...

--- a/src/memu/database/sqlite/repositories/recall_file_segment_repo.py
+++ b/src/memu/database/sqlite/repositories/recall_file_segment_repo.py
@@ -14,6 +14,7 @@ from memu.database.sqlite.repositories.base import SQLiteRepoBase
 from memu.database.sqlite.schema import SQLiteSQLAModels
 from memu.database.sqlite.session import SQLiteSessionManager
 from memu.database.state import DatabaseState
+from memu.vector import cosine_topk
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +67,17 @@ class SQLiteRecallFileSegmentRepo(SQLiteRepoBase, RecallFileSegmentRepo):
             if not any(s.id == seg.id for s in self.segments):
                 self.segments.append(seg)
         return result
+
+    def vector_search_segments(
+        self,
+        query_vec: list[float],
+        top_k: int,
+        where: Mapping[str, Any] | None = None,
+    ) -> list[tuple[RecallFileSegment, float]]:
+        pool = self.list_segments(where)
+        by_id = {seg.id: seg for seg in pool}
+        ranked = cosine_topk(query_vec, [(seg.id, seg.embedding) for seg in pool], k=top_k)
+        return [(by_id[seg_id], score) for seg_id, score in ranked]
 
     def list_segments_for_file(self, recall_file_id: str) -> list[RecallFileSegment]:
         return self.list_segments({"recall_file_id": recall_file_id})

--- a/src/memu/database/sqlite/repositories/recall_file_segment_repo.py
+++ b/src/memu/database/sqlite/repositories/recall_file_segment_repo.py
@@ -14,7 +14,6 @@ from memu.database.sqlite.repositories.base import SQLiteRepoBase
 from memu.database.sqlite.schema import SQLiteSQLAModels
 from memu.database.sqlite.session import SQLiteSessionManager
 from memu.database.state import DatabaseState
-from memu.vector import cosine_topk
 
 logger = logging.getLogger(__name__)
 
@@ -68,16 +67,8 @@ class SQLiteRecallFileSegmentRepo(SQLiteRepoBase, RecallFileSegmentRepo):
                 self.segments.append(seg)
         return result
 
-    def vector_search_segments(
-        self,
-        query_vec: list[float],
-        top_k: int,
-        where: Mapping[str, Any] | None = None,
-    ) -> list[tuple[RecallFileSegment, float]]:
-        pool = self.list_segments(where)
-        by_id = {seg.id: seg for seg in pool}
-        ranked = cosine_topk(query_vec, [(seg.id, seg.embedding) for seg in pool], k=top_k)
-        return [(by_id[seg_id], score) for seg_id, score in ranked]
+    # ``vector_search_segments`` is the protocol's Python scan: SQLite has no
+    # vector index to rank with, so there is nothing to override it with.
 
     def list_segments_for_file(self, recall_file_id: str) -> list[RecallFileSegment]:
         return self.list_segments({"recall_file_id": recall_file_id})

--- a/tests/test_cache_segment_duplicates.py
+++ b/tests/test_cache_segment_duplicates.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -64,17 +65,14 @@ def test_postgres_list_segments_deduplicates_cache() -> None:
     """Test PostgresRecallFileSegmentRepo list_segments deduplication logic directly with a stub session."""
     pytest.importorskip("pgvector")
 
-    from memu.database.postgres.models import RecallFileSegment as SQLARecallFileSegment
     from memu.database.postgres.repositories.recall_file_segment_repo import PostgresRecallFileSegmentRepo
-    from memu.database.postgres.schema import SQLAModels
+    from memu.database.postgres.schema import get_sqlalchemy_models
     from memu.database.state import DatabaseState
 
     state = DatabaseState()
-    sqla_models = SQLAModels(
-        Resource=MagicMock(),
-        RecallFile=MagicMock(),
-        RecallFileSegment=SQLARecallFileSegment,
-    )
+    sqla_models = get_sqlalchemy_models(scope_model=DefaultUserModel)
+
+    stamp = datetime(2026, 1, 1, tzinfo=UTC)
 
     row1 = MagicMock()
     row1.id = "seg-1"
@@ -82,8 +80,7 @@ def test_postgres_list_segments_deduplicates_cache() -> None:
     row1.track = "memory"
     row1.text = "text 1"
     row1.embedding = [0.1, 0.2]
-    row1.created_at = None
-    row1.updated_at = None
+    row1.created_at = row1.updated_at = stamp
 
     row2 = MagicMock()
     row2.id = "seg-2"
@@ -91,15 +88,14 @@ def test_postgres_list_segments_deduplicates_cache() -> None:
     row2.track = "memory"
     row2.text = "text 2"
     row2.embedding = [0.3, 0.4]
-    row2.created_at = None
-    row2.updated_at = None
+    row2.created_at = row2.updated_at = stamp
 
     canned_rows = [row1, row2]
     sessions = StubSessionManager(canned_rows)
 
     repo = PostgresRecallFileSegmentRepo(
         state=state,
-        recall_file_segment_model=MagicMock(),
+        recall_file_segment_model=sqla_models.RecallFileSegment,
         sqla_models=sqla_models,
         sessions=sessions,  # type: ignore[arg-type]
         scope_fields=[],

--- a/tests/test_segment_vector_search.py
+++ b/tests/test_segment_vector_search.py
@@ -1,0 +1,238 @@
+"""``RecallFileSegmentRepo.vector_search_segments`` — the contract and its two paths.
+
+Every backend inherits the protocol's Python scan; Postgres overrides it with
+pgvector. Both owe the caller the same thing: ``(segment, score)`` pairs, best
+first, score a cosine *similarity*. These tests pin the shared contract on the
+backends the suite can run, then pin the pgvector override against a stub
+session, since scoring in SQL is precisely what cannot be checked in Python.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from memu.app import MemoryService
+from memu.app.settings import DatabaseConfig, DefaultUserModel
+from memu.database.factory import build_database
+from memu.database.interfaces import Database
+
+USER = {"user_id": "u1"}
+
+
+@pytest.fixture(params=["inmemory", "sqlite"])
+def db_backend(request: pytest.FixtureRequest, tmp_path: Any) -> Database:
+    if request.param == "inmemory":
+        config = DatabaseConfig.model_validate({"metadata_store": {"provider": "inmemory"}})
+    else:
+        config = DatabaseConfig.model_validate({
+            "metadata_store": {"provider": "sqlite", "dsn": f"sqlite:///{tmp_path}/memu.sqlite3"}
+        })
+    return build_database(config=config, user_model=DefaultUserModel)
+
+
+def _seed(db: Database, segments: list[tuple[str, list[float] | None, str]]) -> None:
+    """Create one file and hang ``(text, embedding, track)`` segments off it."""
+    file = db.recall_file_repo.get_or_create_recall_file(
+        name="file1", description="desc", embedding=[1.0, 0.0], user_data=dict(USER)
+    )
+    for text, embedding, track in segments:
+        db.recall_file_segment_repo.create_segment(
+            recall_file_id=file.id, text=text, embedding=embedding, user_data=dict(USER), track=track
+        )
+
+
+def test_returns_segments_best_first(db_backend: Database) -> None:
+    _seed(db_backend, [("east", [1.0, 0.0], "memory"), ("north", [0.0, 1.0], "memory")])
+
+    hits = db_backend.recall_file_segment_repo.vector_search_segments([1.0, 0.0], 2)
+
+    # Segments, not ids: the caller needs ``recall_file_id``/``text`` off the hit.
+    assert [seg.text for seg, _ in hits] == ["east", "north"]
+    assert hits[0][1] == pytest.approx(1.0, abs=1e-3)
+    assert hits[0][1] > hits[1][1]
+
+
+def test_truncates_to_top_k(db_backend: Database) -> None:
+    _seed(db_backend, [("east", [1.0, 0.0], "memory"), ("north", [0.0, 1.0], "memory")])
+
+    hits = db_backend.recall_file_segment_repo.vector_search_segments([1.0, 0.0], 1)
+
+    assert [seg.text for seg, _ in hits] == ["east"]
+
+
+def test_nonpositive_top_k_returns_nothing(db_backend: Database) -> None:
+    _seed(db_backend, [("east", [1.0, 0.0], "memory")])
+
+    assert db_backend.recall_file_segment_repo.vector_search_segments([1.0, 0.0], 0) == []
+    assert db_backend.recall_file_segment_repo.vector_search_segments([1.0, 0.0], -1) == []
+
+
+def test_skips_segments_without_an_embedding(db_backend: Database) -> None:
+    _seed(db_backend, [("unembedded", None, "memory"), ("east", [1.0, 0.0], "memory")])
+
+    # top_k covers both, so an unembedded segment could only show up by being
+    # ranked — it must be excluded outright, not sorted to the bottom.
+    hits = db_backend.recall_file_segment_repo.vector_search_segments([1.0, 0.0], 5)
+
+    assert [seg.text for seg, _ in hits] == ["east"]
+
+
+def test_scopes_to_where_including_track_in(db_backend: Database) -> None:
+    _seed(db_backend, [("east", [1.0, 0.0], "memory"), ("skill east", [1.0, 0.0], "skill")])
+
+    hits = db_backend.recall_file_segment_repo.vector_search_segments(
+        [1.0, 0.0], 5, where={**USER, "track__in": ["skill"]}
+    )
+
+    assert [seg.text for seg, _ in hits] == ["skill east"]
+
+
+class _FakeEmbeddingClient:
+    embed_model = "fake"
+
+    async def embed(self, inputs: list[str]) -> tuple[list[list[float]], None]:
+        return [[1.0 if "coffee" in text.lower() else 0.0, 0.0] for text in inputs], None
+
+
+async def test_progressive_retrieve_takes_the_repo_shortcut() -> None:
+    """The app layer must delegate ranking, not re-rank a pool of its own."""
+    service = MemoryService(database_config={"metadata_store": {"provider": "inmemory"}})
+    fake = _FakeEmbeddingClient()
+    service._embedding_pool._cache["default"] = fake
+    service._embedding_pool._cache["embedding"] = fake
+    await service.commit_results(
+        recall_files=[{"name": "Profile", "track": "memory", "description": "d", "content": "likes coffee\nlikes tea"}]
+    )
+
+    repo = service._get_database().recall_file_segment_repo
+    native_calls: list[int] = []
+    scans = 0
+    real_list_segments = repo.list_segments
+
+    def counting_list_segments(where: Any = None) -> Any:
+        nonlocal scans
+        scans += 1
+        return real_list_segments(where)
+
+    def native_search(query_vec: list[float], top_k: int, where: Any = None) -> Any:
+        native_calls.append(top_k)
+        # A backend-native answer the Python scan would never produce: one hit,
+        # the *worse* match, at an impossible score.
+        return [(next(seg for seg in real_list_segments(where) if seg.text == "likes tea"), 42.0)]
+
+    repo.list_segments = counting_list_segments  # type: ignore[method-assign]
+    repo.vector_search_segments = native_search  # type: ignore[method-assign]
+
+    result = await service.progressive_retrieve("coffee")
+
+    # The override's answer is what came back, verbatim — so nothing re-ranked it.
+    assert native_calls == [service.progressive_retrieve_config.file.top_k]
+    assert [seg["text"] for seg in result["segments"]] == ["likes tea"]
+    assert result["segments"][0]["score"] == pytest.approx(42.0)
+    # And no full-corpus scan happened behind the override's back.
+    assert scans == 0
+
+
+class _StubSession:
+    """Captures the statement it is handed and replays canned rows."""
+
+    def __init__(self, rows: list[Any], seen: list[Any]) -> None:
+        self._rows = rows
+        self._seen = seen
+
+    def exec(self, stmt: Any) -> _StubSession:
+        self._seen.append(stmt)
+        return self
+
+    def scalars(self, stmt: Any) -> _StubSession:
+        self._seen.append(stmt)
+        return self
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+
+class _StubSessionManager:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+        self.seen: list[Any] = []
+
+    @contextmanager
+    def session(self) -> Any:
+        yield _StubSession(self._rows, self.seen)
+
+
+def _row(seg_id: str, text: str, embedding: list[float]) -> Any:
+    row = MagicMock()
+    row.id = seg_id
+    row.recall_file_id = "file-1"
+    row.track = "memory"
+    row.text = text
+    row.embedding = embedding
+    row.created_at = row.updated_at = datetime(2026, 1, 1, tzinfo=UTC)
+    return row
+
+
+def _postgres_repo(rows: list[Any], *, use_vector: bool) -> tuple[Any, _StubSessionManager]:
+    """A Postgres repo over a stub session, on the real ORM models.
+
+    The models must be the real ones: ``embedding`` has to be an actual pgvector
+    column for ``cosine_distance`` to compile, which is the half of this that a
+    mock would quietly fake.
+    """
+    from memu.database.postgres.repositories.recall_file_segment_repo import PostgresRecallFileSegmentRepo
+    from memu.database.postgres.schema import get_sqlalchemy_models
+    from memu.database.state import DatabaseState
+
+    sqla_models = get_sqlalchemy_models(scope_model=DefaultUserModel)
+    sessions = _StubSessionManager(rows)
+    repo = PostgresRecallFileSegmentRepo(
+        state=DatabaseState(),
+        recall_file_segment_model=sqla_models.RecallFileSegment,
+        sqla_models=sqla_models,
+        sessions=sessions,  # type: ignore[arg-type]
+        scope_fields=[],
+        use_vector=use_vector,
+    )
+    return repo, sessions
+
+
+def test_postgres_ranks_and_truncates_in_sql() -> None:
+    pytest.importorskip("pgvector")
+
+    repo, sessions = _postgres_repo([(_row("seg-1", "east", [1.0, 0.0]), 0.25)], use_vector=True)
+
+    hits = repo.vector_search_segments([1.0, 0.0], 3, where={"track__in": ["memory"]})
+
+    sql = str(sessions.seen[0])
+    assert "<=>" in sql  # ordered by pgvector's cosine operator...
+    assert "LIMIT" in sql  # ...and truncated by the database, not by Python.
+    assert "IS NOT NULL" in sql  # unembedded rows never enter the ranking
+    # pgvector returns a distance; the contract is similarity, so 1 - 0.25.
+    assert hits[0][0].text == "east"
+    assert hits[0][1] == pytest.approx(0.75)
+
+
+def test_postgres_caches_hits_like_a_listing() -> None:
+    pytest.importorskip("pgvector")
+
+    repo, _ = _postgres_repo([(_row("seg-1", "east", [1.0, 0.0]), 0.25)], use_vector=True)
+
+    repo.vector_search_segments([1.0, 0.0], 3)
+
+    assert [seg.id for seg in repo.segments] == ["seg-1"]
+
+
+def test_postgres_native_path_honours_nonpositive_top_k() -> None:
+    pytest.importorskip("pgvector")
+
+    repo, sessions = _postgres_repo([], use_vector=True)
+
+    # ``LIMIT 0``/``LIMIT -1`` is not a query worth sending.
+    assert repo.vector_search_segments([1.0, 0.0], 0) == []
+    assert sessions.seen == []

--- a/tests/test_segment_vector_search.py
+++ b/tests/test_segment_vector_search.py
@@ -228,6 +228,26 @@ def test_postgres_caches_hits_like_a_listing() -> None:
     assert [seg.id for seg in repo.segments] == ["seg-1"]
 
 
+def test_postgres_without_pgvector_falls_back_to_the_python_scan() -> None:
+    """``use_vector=False`` must still answer, via the protocol's scan."""
+    # The ORM models carry a ``VECTOR`` column either way, so building the repo
+    # needs pgvector even on the path that never ranks with it.
+    pytest.importorskip("pgvector")
+
+    repo, sessions = _postgres_repo(
+        [_row("seg-1", "north", [0.0, 1.0]), _row("seg-2", "east", [1.0, 0.0])], use_vector=False
+    )
+
+    hits = repo.vector_search_segments([1.0, 0.0], 2)
+
+    assert [seg.text for seg, _ in hits] == ["east", "north"]
+    assert hits[0][1] == pytest.approx(1.0, abs=1e-3)
+    # Ranking happened in Python, so no ordering or truncation went to the database.
+    sql = str(sessions.seen[0])
+    assert "<=>" not in sql
+    assert "LIMIT" not in sql
+
+
 def test_postgres_native_path_honours_nonpositive_top_k() -> None:
     pytest.importorskip("pgvector")
 


### PR DESCRIPTION
## Why

`progressive_retrieve` ranked segments by pulling **every** segment in scope into Python and running `cosine_topk` over it. That is the one thing a backend with a real vector index can do better, and the app layer left it no way in — the repo contract had no ranked search at all, so `_recall_segments` had to do it by hand.

## What

`RecallFileSegmentRepo` now owns segment ranking.

**The interface** (`src/memu/database/repositories/recall_file_segment.py`):

```python
def vector_search_segments(
    self,
    query_vec: list[float],
    top_k: int,
    where: Mapping[str, Any] | None = None,
) -> list[tuple[RecallFileSegment, float]]: ...
```

Optionality is expressed by giving the protocol a **working default body** — the same Python scan the app used to run — rather than a stub plus a capability check. Every concrete repo explicitly subclasses the Protocol, so a backend without a vector index inherits the default and is complete as-is, and the caller never branches on which kind of backend it got.

**It returns the segments, not their ids.** The caller ranks in order to then *read* the hits (`recall_file_id`, `text`), so handing back ids would force it to hold the whole pool anyway and the native path would save nothing. With objects coming back, the segment pool in `_recall_segments` shrinks from the full corpus to `top_k`.

**Two contract points that would otherwise fail silently**, both stated in the docstring and covered by tests:

- The score is a cosine **similarity**, higher-is-better. A backend whose operator yields a distance must convert. Rank on the distance instead and nothing raises — the result order just inverts, along with `_collect_files`' max-rollup.
- Rows without an embedding are **excluded**, not left to sort to whichever end NULLs land on.

**Postgres overrides it** with pgvector: `ORDER BY embedding <=> q LIMIT top_k`, so ordering and truncation happen in the database and only `top_k` rows cross the wire. Hits are cached through `_cache_segment` exactly like a listing.

**`vector_index.provider` finally reaches a repo.** `PostgresStore._use_vector_type` was computed and delivered nowhere (`PostgresRepoBase.use_vector` just defaulted to `True`), so a deployment that explicitly asked for brute force would have got the native path regardless. Now plumbed, and the native path defers to the inherited scan when it is off.

## Tests

`tests/test_segment_vector_search.py`, 15 cases:

- the shared contract on inmemory + sqlite — ordering, `top_k` truncation, `top_k <= 0`, unembedded segments, `where` incl. `track__in`
- a delegation test: `progressive_retrieve` returns an override's answer **verbatim**, with zero full-corpus scans behind its back
- the pgvector path against a stub session — asserts `<=>`, `LIMIT` and `IS NOT NULL` in the emitted SQL, the distance→similarity conversion, hit caching, and the `use_vector=False` fallback

Full suite green (495 passed), ruff + mypy clean.

## Out of scope — `vector_search_resources` still needs settling

`ResourceRepo.vector_search_resources` returns `list[tuple[str, float]]` — ids — and that is why `_recall_resources` **reads the resource pool twice per query**: once via `list_resources` to hydrate the hits, and again inside `vector_search_resources`, which calls `list_resources` itself. All three backends brute-force it, so there is no native resource path today and the double read is the whole cost.

The fix is the same shape as this PR: return `(resource, score)` pairs, drop the caller's separate `list_resources`. Left out deliberately so this PR stays one contract change on one repo — the resource layer's signature change should be argued on its own. Filing/telling separately.

## Note for reviewers

Running the pgvector tests needs the declared `postgres` extra (`pip install -e '.[postgres]'`); without it they skip. Installing it surfaced a **pre-existing** failure in `test_cache_segment_duplicates.py` — the test had rotted while permanently skipped (`SQLAModels` grew a required `Base`; `RecallFileSegment` rejects `None` timestamps). Confirmed it fails on `main` too, and repaired in its own commit (`a53dc27`) so it can be split out if you would rather take it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
