### PR TITLE
fix(agentic): validate RecallFile pagination inputs

### DIFF
--- a/src/memu/app/agentic.py
+++ b/src/memu/app/agentic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import json
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -30,8 +31,15 @@ def _decode_cursor(cursor: str | None) -> tuple[str, str, str] | None:
     """Inverse of :func:`_encode_cursor`; a blank/absent cursor starts at the top."""
     if not cursor:
         return None
-    track, name, _id = json.loads(base64.urlsafe_b64decode(cursor.encode()))
-    return (track, name, _id)
+    try:
+        decoded = json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
+    except (binascii.Error, ValueError) as exc:
+        msg = "invalid cursor"
+        raise ValueError(msg) from exc
+    if not isinstance(decoded, list) or len(decoded) != 3 or not all(isinstance(value, str) for value in decoded):
+        msg = "invalid cursor"
+        raise ValueError(msg)
+    return (decoded[0], decoded[1], decoded[2])
 
 
 async def _embed_one(embed_client: Any, text: str) -> list[float]:
@@ -165,6 +173,9 @@ class AgenticMixin:
         within a scope, immutable under commit) is what makes that walk skip- and
         duplicate-free.
         """
+        if limit < 1:
+            msg = "limit must be greater than zero"
+            raise ValueError(msg)
         store = self._get_database()
         where_filters = self._normalize_where(where)
         recall_files, next_after = store.recall_file_repo.list_recall_files_page(

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -105,6 +105,17 @@ async def test_list_all_recall_files_paginates_by_track_name_id(service: MemoryS
     assert pages == 3  # 8 files / page size 3 -> 3,3,2
 
 
+async def test_list_all_recall_files_rejects_nonpositive_limit(service: MemoryService) -> None:
+    with pytest.raises(ValueError, match="limit must be greater than zero"):
+        await service.list_all_recall_files(limit=0)
+
+
+@pytest.mark.parametrize("cursor", ["not-a-cursor", "WyJ0b28iLCAic2hvcnQiXQ==", "WzEsIDIsIDNd"])
+async def test_list_all_recall_files_rejects_malformed_cursor(service: MemoryService, cursor: str) -> None:
+    with pytest.raises(ValueError, match="invalid cursor"):
+        await service.list_all_recall_files(cursor=cursor)
+
+
 async def test_progressive_retrieve_ranks_all_three_layers(service: MemoryService) -> None:
     await _seed(service)
     result = await service.progressive_retrieve("coffee")


### PR DESCRIPTION
Fixes #662

## Summary

Validate RecallFile pagination inputs at the shared AgenticMixin service boundary before repository access.

## Root cause

The pagination feature added `_decode_cursor()` and forwarded `limit` directly to `list_recall_files_page()`. Malformed cursors leaked decoder and tuple-unpacking exceptions, while `limit=0` reached backend implementations without a shared contract.

## Changes

- Reject `limit < 1` with `ValueError("limit must be greater than zero")`.
- Normalize malformed Base64, UTF-8, JSON, shape, and field-type failures to `ValueError("invalid cursor")`.
- Add regression coverage for InMemory and SQLite backends.
- Keep the change in the shared service entry point; no repository-specific changes or new dependencies.

## Validation

- `tests/test_agentic.py -q`: 32 passed
- Ruff check: passed
- mypy for `src/memu/app/agentic.py`: passed
- `git diff --check`: passed

This PR is based on the latest upstream `main` at commit `37d2efa`.