### PR TITLE
fix(sqlite): always read the DB in SQLiteResourceRepo.list_resources

### DIFF
--- a/src/memu/database/sqlite/repositories/resource_repo.py
+++ b/src/memu/database/sqlite/repositories/resource_repo.py
@@ -58,10 +58,6 @@ class SQLiteResourceRepo(SQLiteRepoBase, ResourceRepo):
         Returns:
             Dictionary of resource ID to Resource mapping.
         """
-        # Prefer cached data if available and no filter
-        if not where and self.resources:
-            return dict(self.resources)
-
         with self._sessions.session() as session:
             stmt = select(self._resource_model)
             filters = self._build_filters(self._resource_model, where)

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -320,3 +320,29 @@ async def test_where_scope_filters_and_rejects_unknown_fields(service: MemorySer
 async def test_progressive_retrieve_rejects_empty_query(service: MemoryService) -> None:
     with pytest.raises(ValueError, match="empty_query"):
         await service.progressive_retrieve("   ")
+
+
+async def test_sqlite_resource_commit_sees_writes_from_another_instance(tmp_path: Any) -> None:
+    """Two SQLiteStore instances on the same DB file share ground truth, matching
+    PostgresResourceRepo's always-fresh reads: an unfiltered ``list_resources`` must
+    not shortcut to a per-instance cache once that cache is non-empty, or a sibling
+    instance's later write becomes invisible and a same-url recommit duplicates it.
+    """
+    dsn = f"sqlite:///{tmp_path}/memu.sqlite3"
+    service_a = make_service({"metadata_store": {"provider": "sqlite", "dsn": dsn}})
+    service_b = make_service({"metadata_store": {"provider": "sqlite", "dsn": dsn}})
+
+    await service_a.commit_results(resource=[{"path": "/workspace/notes.md", "description": "v1"}])
+    # First unfiltered read on a fresh instance always hits the DB, so this warms
+    # service_b's cache with notes.md too.
+    await service_b.commit_results(resource=[{"path": "/workspace/other.md", "description": "other"}])
+
+    await service_a.commit_results(resource=[{"path": "/workspace/extra.md", "description": "a's version"}])
+    committed = await service_b.commit_results(resource=[{"path": "/workspace/extra.md", "description": "b's version"}])
+    assert len(committed["resources"]) == 1
+
+    fresh = make_service({"metadata_store": {"provider": "sqlite", "dsn": dsn}})
+    rows = fresh._get_database().resource_repo.list_resources()
+    matches = [r for r in rows.values() if r.url == "/workspace/extra.md"]
+    assert len(matches) == 1
+    assert matches[0].caption == "b's version"


### PR DESCRIPTION
## What does this PR do?
`SQLiteResourceRepo.list_resources` short-circuited to a per-instance dict cache whenever it was non-empty and no `where` filter was given, instead of reading the database. `PostgresResourceRepo.list_resources` has no such shortcut and always hits the DB. This drops the cache-first branch so SQLite matches it.

## Why is this change needed?
Two `SQLiteStore` instances on the same DB file (two processes, or two `MemoryService` objects sharing a DSN) diverge once one of them has a warm cache: it stops seeing rows a sibling instance wrote. `AgenticMixin._plan_resources`, which decides create-vs-update by URL, then treats an already-existing URL as new and creates a duplicate row instead of updating it. Fixes #664.

## Verification
- New regression test `test_sqlite_resource_commit_sees_writes_from_another_instance` (`tests/test_agentic.py`): two `MemoryService` instances share a DSN; instance A writes a URL, instance B (with an already-warm cache) recommits the same URL, and a fresh third instance's `list_resources()` must see exactly one row. Fails on main (finds two rows), passes on this branch, run in Docker on both `python:3.11-slim` and `python:3.13-slim`.
- Full suite (`uv run python -m pytest`) green on both Python versions: 585 passed, 8 skipped.
- `uv run pre-commit run -a`, `uv run mypy`, `uv run deptry src` all clean.
- Not verified against the Postgres backend directly, only by reading its `list_resources` (it has no cache shortcut, so this brings SQLite in line with it).

## Type of Change
- [x] Bug fix
