### PR TITLE
feat: define developer conversation input

### DIFF
--- a/src/memu/app/__init__.py
+++ b/src/memu/app/__init__.py
@@ -1,3 +1,12 @@
+from memu.app.memorize import (
+    ConversationItem,
+    MemorizeInput,
+    MessageInput,
+    ToolCallInput,
+    ToolResultInput,
+    project_memory,
+    project_skill,
+)
 from memu.app.service import MemoryService
 from memu.app.settings import (
     DatabaseConfig,
@@ -9,11 +18,18 @@ from memu.app.settings import (
 )
 
 __all__ = [
+    "ConversationItem",
     "DatabaseConfig",
     "DefaultUserModel",
     "EmbeddingConfig",
     "EmbeddingProfilesConfig",
+    "MemorizeInput",
     "MemoryService",
+    "MessageInput",
     "ProgressiveRetrieveConfig",
+    "ToolCallInput",
+    "ToolResultInput",
     "UserConfig",
+    "project_memory",
+    "project_skill",
 ]

--- a/src/memu/app/memorize/__init__.py
+++ b/src/memu/app/memorize/__init__.py
@@ -1,0 +1,19 @@
+from memu.app.memorize.input import (
+    ConversationItem,
+    MemorizeInput,
+    MessageInput,
+    ToolCallInput,
+    ToolResultInput,
+    project_memory,
+    project_skill,
+)
+
+__all__ = [
+    "ConversationItem",
+    "MemorizeInput",
+    "MessageInput",
+    "ToolCallInput",
+    "ToolResultInput",
+    "project_memory",
+    "project_skill",
+]

--- a/src/memu/app/memorize/input.py
+++ b/src/memu/app/memorize/input.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Annotated, Literal, Self, TypeAlias
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
+
+
+class InputModel(BaseModel):
+    """Strict base for the versioned developer-input contract."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MessageInput(InputModel):
+    """A user or assistant message considered by memory and skill evolution."""
+
+    type: Literal["message"] = "message"
+    role: Literal["user", "assistant"]
+    content: str = Field(min_length=1)
+
+
+class ToolCallInput(InputModel):
+    """Optional tool activity considered only by skill evolution."""
+
+    type: Literal["tool_call"] = "tool_call"
+    name: str = Field(min_length=1)
+    arguments: JsonValue = Field(default_factory=dict)
+
+
+class ToolResultInput(InputModel):
+    """An optional result from a tool call, considered only by skill evolution."""
+
+    type: Literal["tool_result"] = "tool_result"
+    content: JsonValue
+    name: str | None = Field(default=None, min_length=1)
+    is_error: bool | None = None
+
+
+ConversationItem: TypeAlias = Annotated[
+    MessageInput | ToolCallInput | ToolResultInput,
+    Field(discriminator="type"),
+]
+
+
+class MemorizeInput(InputModel):
+    """One ordered developer-supplied session for memory and skill evolution."""
+
+    schema_version: Literal["1.0"] = "1.0"
+    items: list[ConversationItem] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_message(self) -> Self:
+        if not any(isinstance(item, MessageInput) for item in self.items):
+            msg = "memorize input must contain at least one message"
+            raise ValueError(msg)
+        return self
+
+
+MemoryInputItem: TypeAlias = MessageInput
+SkillInputItem: TypeAlias = MessageInput | ToolCallInput | ToolResultInput
+
+
+def project_memory(memorize_input: MemorizeInput) -> list[MemoryInputItem]:
+    """Return the user and assistant messages used for memory evolution."""
+
+    return [item for item in memorize_input.items if isinstance(item, MessageInput)]
+
+
+def project_skill(memorize_input: MemorizeInput) -> list[SkillInputItem]:
+    """Return all ordered items used for skill evolution."""
+
+    return list(memorize_input.items)
+
+
+__all__ = [
+    "ConversationItem",
+    "MemorizeInput",
+    "MessageInput",
+    "ToolCallInput",
+    "ToolResultInput",
+    "project_memory",
+    "project_skill",
+]

--- a/tests/test_memorize_input.py
+++ b/tests/test_memorize_input.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from memu.app.memorize.input import (
+    MemorizeInput,
+    MessageInput,
+    ToolCallInput,
+    ToolResultInput,
+    project_memory,
+    project_skill,
+)
+
+
+def _message_payload(**overrides: object) -> dict[str, object]:
+    return {"type": "message", "role": "user", "content": "Remember this", **overrides}
+
+
+def test_minimal_message_only_input_uses_version_1_0() -> None:
+    memorize_input = MemorizeInput.model_validate({"items": [_message_payload()]})
+
+    assert memorize_input.schema_version == "1.0"
+    assert memorize_input.items == [MessageInput(role="user", content="Remember this")]
+
+
+def test_memorize_input_parses_ordered_messages_and_optional_tool_activity() -> None:
+    memorize_input = MemorizeInput.model_validate({
+        "items": [
+            _message_payload(role="user", content="Save the config"),
+            _message_payload(role="assistant", content="I will write it."),
+            {"type": "tool_call", "name": "write_file", "arguments": {"path": "profile.json"}},
+            {
+                "type": "tool_result",
+                "name": "write_file",
+                "content": "ok",
+                "is_error": False,
+            },
+        ],
+    })
+
+    assert [type(item) for item in memorize_input.items] == [
+        MessageInput,
+        MessageInput,
+        ToolCallInput,
+        ToolResultInput,
+    ]
+    assert [item.type for item in memorize_input.items] == ["message", "message", "tool_call", "tool_result"]
+
+
+def test_projections_separate_memory_from_skill_without_mutating_input() -> None:
+    memorize_input = MemorizeInput(
+        items=[
+            MessageInput(role="user", content="Save the config"),
+            ToolCallInput(name="write_file", arguments={"path": "profile.json"}),
+            ToolResultInput(name="write_file", content="ok"),
+            MessageInput(role="assistant", content="Saved."),
+        ],
+    )
+    original = memorize_input.model_dump()
+
+    memory = project_memory(memorize_input)
+    skill = project_skill(memorize_input)
+
+    assert [item.content for item in memory] == ["Save the config", "Saved."]
+    assert [item.type for item in skill] == ["message", "tool_call", "tool_result", "message"]
+    assert skill is not memorize_input.items
+    assert memorize_input.model_dump() == original
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        _message_payload(id="message-1"),
+        _message_payload(created_at="2026-08-26T07:30:00Z"),
+        {"type": "tool_call", "id": "call-1", "name": "write_file"},
+        {"type": "tool_result", "tool_call_id": "call-1", "content": "ok"},
+    ],
+)
+def test_items_reject_identity_and_timestamp_metadata(item: dict[str, object]) -> None:
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        MemorizeInput.model_validate({"items": [_message_payload(), item]})
+
+
+@pytest.mark.parametrize(
+    "payload,match",
+    [
+        ({"items": []}, "at least 1 item"),
+        (
+            {"items": [{"type": "tool_call", "name": "search"}]},
+            "at least one message",
+        ),
+        (
+            {"items": [_message_payload(role="system")]},
+            "user.*assistant",
+        ),
+        (
+            {"items": [{"type": "attachment", "content": "x"}]},
+            "union_tag_invalid",
+        ),
+        (
+            {"items": [_message_payload(extra="unexpected")]},
+            "extra_forbidden",
+        ),
+        (
+            {"items": [_message_payload()], "batch_id": "batch-1"},
+            "extra_forbidden",
+        ),
+        (
+            {"items": [_message_payload()], "conversations": []},
+            "extra_forbidden",
+        ),
+    ],
+)
+def test_memorize_input_rejects_invalid_shapes(payload: dict[str, object], match: str) -> None:
+    with pytest.raises(ValidationError, match=match):
+        MemorizeInput.model_validate(payload)
+
+
+def test_memorize_input_json_round_trip_and_schema() -> None:
+    memorize_input = MemorizeInput(items=[MessageInput(role="user", content="Hello")])
+
+    restored = MemorizeInput.model_validate_json(memorize_input.model_dump_json())
+    schema = MemorizeInput.model_json_schema()
+
+    assert restored == memorize_input
+    assert schema["properties"]["schema_version"]["const"] == "1.0"
+    assert schema["properties"]["items"]["minItems"] == 1
+    assert "batch_id" not in schema["properties"]
+    assert "conversations" not in schema["properties"]


### PR DESCRIPTION
## 📝 Pull Request Summary

定义第一层面向开发者的 memorize 输入契约：使用严格的 Pydantic v2 模型描述 conversation，并以确定性 projection 区分 memory 与 skill 输入。

---

## ✅ What does this PR do?

- 新增版本化的 `MemorizeInput`，支持按顺序提交多段 conversation。
- 定义 `user` / `assistant` 消息，以及可选的 tool call 和 tool result。
- 将 source ID 和 timestamp 作为可选字段，并以列表位置作为 v1.0 的顺序契约。
- 明确定义两种 projection：memory 只保留消息，skill 保留消息与已提供的工具活动。
- 从 `memu.app` 导出输入模型和 projection helpers。
- 增加输入校验、projection、JSON round-trip 与 JSON Schema 测试。

---

## 🤔 Why is this change needed?

自研应用目前缺少一套可直接向 memU 提交 conversation 的类型化契约。这是 developer direct-input 链路的第一层：先稳定“输入是什么”以及“哪些内容进入 memory/skill”，后续 PR 再负责 materialization 和 evolving 生命周期接入。

关联 #666。

