### PR TITLE
feat: materialize developer conversation input

### DIFF
--- a/src/memu/app/__init__.py
+++ b/src/memu/app/__init__.py
@@ -1,9 +1,11 @@
 from memu.app.memorize import (
     ConversationItem,
+    MaterializedConversation,
     MemorizeInput,
     MessageInput,
     ToolCallInput,
     ToolResultInput,
+    materialize_memorize_input,
     project_memory,
     project_skill,
 )
@@ -23,6 +25,7 @@ __all__ = [
     "DefaultUserModel",
     "EmbeddingConfig",
     "EmbeddingProfilesConfig",
+    "MaterializedConversation",
     "MemorizeInput",
     "MemoryService",
     "MessageInput",
@@ -30,6 +33,7 @@ __all__ = [
     "ToolCallInput",
     "ToolResultInput",
     "UserConfig",
+    "materialize_memorize_input",
     "project_memory",
     "project_skill",
 ]

--- a/src/memu/app/memorize/__init__.py
+++ b/src/memu/app/memorize/__init__.py
@@ -7,13 +7,16 @@ from memu.app.memorize.input import (
     project_memory,
     project_skill,
 )
+from memu.app.memorize.materialize import MaterializedConversation, materialize_memorize_input
 
 __all__ = [
     "ConversationItem",
+    "MaterializedConversation",
     "MemorizeInput",
     "MessageInput",
     "ToolCallInput",
     "ToolResultInput",
+    "materialize_memorize_input",
     "project_memory",
     "project_skill",
 ]

--- a/src/memu/app/memorize/materialize.py
+++ b/src/memu/app/memorize/materialize.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import tempfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import JsonValue
+
+from memu.app.memorize.input import MemorizeInput, SkillInputItem, project_memory, project_skill
+
+
+@dataclass(frozen=True)
+class MaterializedConversation:
+    """The transcript pair produced for one developer-supplied session."""
+
+    memory_path: Path
+    skill_path: Path
+
+
+def _dump_item(item: SkillInputItem) -> dict[str, JsonValue]:
+    optional_none = {
+        name
+        for name, field in type(item).model_fields.items()
+        if getattr(item, name) is None and not field.is_required()
+    }
+    return item.model_dump(mode="json", exclude=optional_none)
+
+
+def _serialize_items(items: Sequence[SkillInputItem]) -> str:
+    return "".join(
+        json.dumps(
+            _dump_item(item),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        + "\n"
+        for item in items
+    )
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    fd, temporary_name = tempfile.mkstemp(dir=path.parent, prefix=".tmp-", suffix=path.suffix)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(content)
+        os.replace(temporary_name, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(temporary_name)
+        raise
+
+
+def materialize_memorize_input(
+    memorize_input: MemorizeInput,
+    out_dir: Path,
+) -> MaterializedConversation:
+    """Write the memory and skill JSONL inputs for one session."""
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for stale in out_dir.glob("*.jsonl"):
+        stale.unlink()
+
+    memory_path = out_dir / "1.jsonl"
+    skill_path = out_dir / "1_full.jsonl"
+    _atomic_write_text(memory_path, _serialize_items(project_memory(memorize_input)))
+    _atomic_write_text(skill_path, _serialize_items(project_skill(memorize_input)))
+    return MaterializedConversation(
+        memory_path=memory_path,
+        skill_path=skill_path,
+    )

--- a/tests/test_memorize_materialization.py
+++ b/tests/test_memorize_materialization.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from memu.app.memorize import materialize as materialize_module
+from memu.app.memorize.input import MemorizeInput, MessageInput, ToolCallInput, ToolResultInput
+from memu.app.memorize.materialize import materialize_memorize_input
+
+
+def _read_jsonl(path: Path) -> list[dict[str, object]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_materializes_one_session_to_fixed_transcript_pair(tmp_path: Path) -> None:
+    memorize_input = MemorizeInput(
+        items=[
+            MessageInput(role="user", content="First"),
+            MessageInput(role="assistant", content="Second"),
+        ],
+    )
+
+    result = materialize_memorize_input(memorize_input, tmp_path)
+
+    assert (result.memory_path.name, result.skill_path.name) == ("1.jsonl", "1_full.jsonl")
+    assert [item["content"] for item in _read_jsonl(result.memory_path)] == ["First", "Second"]
+
+
+def test_memory_excludes_tools_while_skill_preserves_item_order(tmp_path: Path) -> None:
+    memorize_input = MemorizeInput(
+        items=[
+            MessageInput(role="user", content="Write it"),
+            ToolCallInput(name="write_file", arguments={"path": "profile.json"}),
+            ToolResultInput(name="write_file", content="ok"),
+            MessageInput(role="assistant", content="Done"),
+        ],
+    )
+
+    result = materialize_memorize_input(memorize_input, tmp_path)
+
+    assert [item["type"] for item in _read_jsonl(result.memory_path)] == ["message", "message"]
+    assert [item["type"] for item in _read_jsonl(result.skill_path)] == [
+        "message",
+        "tool_call",
+        "tool_result",
+        "message",
+    ]
+
+
+def test_message_only_session_produces_equivalent_views(tmp_path: Path) -> None:
+    memorize_input = MemorizeInput(
+        items=[
+            MessageInput(role="user", content="Hello"),
+            MessageInput(role="assistant", content="Hi"),
+        ],
+    )
+
+    result = materialize_memorize_input(memorize_input, tmp_path)
+
+    assert result.memory_path.read_bytes() == result.skill_path.read_bytes()
+
+
+def test_serializes_unicode_structured_values(tmp_path: Path) -> None:
+    memorize_input = MemorizeInput(
+        items=[
+            MessageInput(role="user", content="记住深烘咖啡"),
+            ToolCallInput(name="store", arguments={"nested": [1, True, None, {"中文": "值"}]}),
+            ToolResultInput(content=None, is_error=None),
+        ],
+    )
+
+    result = materialize_memorize_input(memorize_input, tmp_path)
+    items = _read_jsonl(result.skill_path)
+
+    assert "记住深烘咖啡" in result.skill_path.read_text(encoding="utf-8")
+    assert items[1]["arguments"] == {"nested": [1, True, None, {"中文": "值"}]}
+    assert items[2]["content"] is None
+    assert "is_error" not in items[2]
+
+
+def test_replaces_stale_jsonl_and_preserves_other_files(tmp_path: Path) -> None:
+    (tmp_path / "1.jsonl").write_text("stale", encoding="utf-8")
+    (tmp_path / "8_full.jsonl").write_text("stale", encoding="utf-8")
+    marker = tmp_path / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    memorize_input = MemorizeInput(items=[MessageInput(role="user", content="Fresh")])
+
+    materialize_memorize_input(memorize_input, tmp_path)
+
+    assert sorted(path.name for path in tmp_path.glob("*.jsonl")) == ["1.jsonl", "1_full.jsonl"]
+    assert _read_jsonl(tmp_path / "1.jsonl")[0]["content"] == "Fresh"
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
+def test_materialization_does_not_modify_input_and_returns_requested_paths(tmp_path: Path) -> None:
+    memorize_input = MemorizeInput(items=[MessageInput(role="user", content="Hello")])
+    original = memorize_input.model_dump()
+
+    result = materialize_memorize_input(memorize_input, tmp_path / "nested" / "input")
+
+    assert memorize_input.model_dump() == original
+    assert result.memory_path == tmp_path / "nested" / "input" / "1.jsonl"
+    assert result.skill_path == tmp_path / "nested" / "input" / "1_full.jsonl"
+
+
+def test_atomic_write_failure_preserves_existing_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "1.jsonl"
+    target.write_text("old\n", encoding="utf-8")
+
+    def fail_replace(source: str, destination: Path) -> None:
+        del source, destination
+        msg = "replace failed"
+        raise OSError(msg)
+
+    monkeypatch.setattr(materialize_module.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="replace failed"):
+        materialize_module._atomic_write_text(target, "new\n")
+
+    assert target.read_text(encoding="utf-8") == "old\n"
+    assert list(tmp_path.glob(".tmp-*")) == []


### PR DESCRIPTION
## 📝 Pull Request Summary

将 #669 定义的 developer conversation input materialize 为现有 self-evolve jobs 使用的两份编号 JSONL transcript。

---

## ✅ What does this PR do?

- 按 batch 中的 conversation 顺序生成 `<idx>.jsonl` 和 `<idx>_full.jsonl`。
- Memory view 保留 `user` / `assistant` 消息；full view 额外保留已提供的 tool calls/results。
- 使用紧凑的 UTF-8 JSONL，每个 item 一行并保持原始顺序。
- 保留结构化 JSON 值和必需字段中显式提交的 `null`。
- 省略未提供的可选元数据，例如 item ID、timestamp 和未知的 tool-result 状态。
- 逐文件原子替换 transcript，并清理目标目录中旧的 JSONL 文件。
- 返回 conversation ID、编号与两个文件路径的稳定映射，供下一层 evolving lifecycle 使用。
- 增加 filesystem、serialization、projection、cleanup 和失败路径测试。

---

## 🤔 Why is this change needed?

 #669 已定义 developer input 和 memory/skill projections。本 PR 将该契约接到现有 self-evolve job template 已经理解的 prepared-transcript seam，同时保持 materialization 与 backend mirror、job generation 和 commit 相互独立，便于单独 review 和验证。

关联 #666。

