### PR TITLE
feat: expose developer memorize CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ mode, and a live retrieval.
 
 Adding another host means implementing one `TranscriptSource` (where its session logs live, how its records are shaped) plus a `HostSpec`-sized CLI — the pipeline, verbs, and instruction text are shared.
 
+## Developer integration
+
+Applications that already own their conversation history can use `memu memorize`
+to prepare self-evolve jobs for an external agent and commit the resulting memory,
+skill, and resource changes. See [Developer integration](docs/developer.md) for the
+canonical input contract and the complete prepare → agent → commit workflow.
+
 ## CLI
 
 With memU Cloud, sign in at [memu.so](https://memu.so) to view your memory files. With a local installation, memory lives in the shared store configured by `MEMU_DB` in `~/.memu/config.env` — typically `~/.memu/memu.sqlite3` for local SQLite, or a Postgres DSN.

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,0 +1,302 @@
+# Developer integration
+
+Applications that already own their conversation history can submit one completed session to memU without implementing a host adapter. The application decides when a session is ready, converts it to the canonical input, runs one external evolve executor, and commits the executor's result to the configured Local or Cloud backend.
+
+This is an application integration contract. It starts with a completed session supplied by the application; selecting facts from an ongoing conversation or inventing a conversation on an agent's behalf is outside the v1 interface.
+
+## Lifecycle
+
+```text
+completed application session
+  → memu memorize prepare
+  → one external executor processes all jobs serially
+  → memu memorize commit
+  → configured Local or Cloud backend
+```
+
+`prepare` and `commit` are the deterministic parts of the lifecycle. The middle step is real agent work: the executor reads the session, compares it with existing memory and skill files, and makes create, patch, or no-op decisions.
+
+The default working directory is `~/.memu/developer`. Applications should prefer a dedicated workspace for each run and pass the same `--workspace` value to `prepare` and `commit`:
+
+```text
+<workspace>/
+├── input/                     projected session transcripts
+├── jobs/                      numbered executor instructions
+├── memory/                    writable mirror of memory RecallFiles
+├── skill/                     writable mirror of skill RecallFiles
+├── .memorize_manifest.json    pre-evolve content snapshot
+├── .memorize_run.json         active-run marker
+├── .resource.tmp              files logged by the skill job, when any
+└── resources.md               verified resource descriptions, when any
+```
+
+The configured backend is authoritative. `memory/` and `skill/` are temporary, writable working copies used by the executor; committed changes are persisted as RecallFiles in the backend.
+
+## 1. Build one canonical session
+
+A payload represents one completed session. Its `items` must remain in the order in which the activity occurred.
+
+Use source activity faithfully:
+
+- preserve the actual user and assistant message text;
+- include tool activity when it is available and useful for skill evolution;
+- do not synthesize messages, tool calls, results, or user facts to force a memory outcome;
+- do not concatenate unrelated sessions into one payload;
+- omit credentials, tokens, and other secrets before submission;
+- retain the original JSON value and relative position of any tool activity that is included.
+
+The application owns the session boundary and input size. Version 1.0 does not select turns or truncate long sessions automatically. Tool activity is optional, so an application may submit a faithful message-only view when full tool traces are unavailable or unsuitable for persistence.
+
+### Top-level fields
+
+| Field | Type | Required | Contract |
+|---|---|---:|---|
+| `schema_version` | `"1.0"` | No | Defaults to `"1.0"`; no other version is accepted. |
+| `items` | array | Yes | Non-empty ordered list containing at least one `message`. |
+
+### Item fields
+
+| Item | Field | Type | Required | Contract |
+|---|---|---|---:|---|
+| `message` | `type` | `"message"` | Yes | Discriminator. |
+| `message` | `role` | `"user"` or `"assistant"` | Yes | System messages are not part of the canonical model. |
+| `message` | `content` | string | Yes | Non-empty message text. |
+| `tool_call` | `type` | `"tool_call"` | Yes | Discriminator. |
+| `tool_call` | `name` | string | Yes | Non-empty tool name. |
+| `tool_call` | `arguments` | any JSON value | No | Defaults to `{}`. |
+| `tool_result` | `type` | `"tool_result"` | Yes | Discriminator. |
+| `tool_result` | `content` | any JSON value | Yes | May be an object, array, scalar, or JSON `null`. |
+| `tool_result` | `name` | string | No | Non-empty when present. |
+| `tool_result` | `is_error` | boolean | No | Whether the tool execution failed. |
+
+The model is strict. Unknown fields such as message IDs, timestamps, tool-call IDs, `batch_id`, or `conversations` are rejected rather than ignored. Provider-native OpenAI or Anthropic records must be converted to this canonical shape before calling the CLI.
+
+### Minimal message-only example
+
+```json
+{
+  "schema_version": "1.0",
+  "items": [
+    {
+      "type": "message",
+      "role": "user",
+      "content": "Please remember that I prefer dark-roast coffee."
+    },
+    {
+      "type": "message",
+      "role": "assistant",
+      "content": "Understood."
+    }
+  ]
+}
+```
+
+### Example with tool activity
+
+```json
+{
+  "schema_version": "1.0",
+  "items": [
+    {
+      "type": "message",
+      "role": "user",
+      "content": "Save my dark-roast coffee preference to profile.json."
+    },
+    {
+      "type": "tool_call",
+      "name": "write_file",
+      "arguments": {"path": "/workspace/profile.json"}
+    },
+    {
+      "type": "tool_result",
+      "name": "write_file",
+      "content": "ok",
+      "is_error": false
+    },
+    {
+      "type": "message",
+      "role": "assistant",
+      "content": "Saved."
+    }
+  ]
+}
+```
+
+memU creates two projections from the same ordered input:
+
+| Projection | Receives | Purpose |
+|---|---|---|
+| Memory | `message` items only | Durable user facts, preferences, project context, and working style. |
+| Skill | All supplied items | Repeatable workflows learned from messages and tool activity. |
+
+Tool activity does not become user memory. It gives the skill job evidence about how the original task was performed. Resource discovery is best-effort: files referenced by the supplied activity must still exist and be readable in the executor's environment to become resources.
+
+## 2. Prepare the run
+
+Configure Local or Cloud mode once through the shared `MEMU_*` environment or `~/.memu/config.env`, so `prepare`, the executor, `commit`, and later retrieval all use the same backend. The returned `next_command` preserves the workspace argument, but does not repeat local backend override flags such as `--db` or `--provider`. If an application uses those flags instead of shared configuration, it must pass the same values to `commit` itself.
+
+Write the payload as UTF-8 JSON and run:
+
+```bash
+memu memorize prepare session.json --workspace /tmp/memu-runs/session-42 --json
+```
+
+Use `-` instead of a file path to read one payload from stdin.
+
+`prepare` performs the following work before returning:
+
+1. validates the canonical payload;
+2. writes the message-only and full JSONL projections;
+3. lists the current RecallFiles from the configured backend and writes them into the workspace's `memory/` and `skill/` directories;
+4. snapshots the working copies by content hash;
+5. creates three numbered jobs and the active-run marker.
+
+A successful JSON response has this shape (paths depend on the platform and selected workspace):
+
+```json
+{
+  "workspace": "/tmp/memu-runs/session-42",
+  "transcript": {
+    "memory_path": "/tmp/memu-runs/session-42/input/1.jsonl",
+    "skill_path": "/tmp/memu-runs/session-42/input/1_full.jsonl"
+  },
+  "jobs": [
+    "/tmp/memu-runs/session-42/jobs/1.txt",
+    "/tmp/memu-runs/session-42/jobs/2.txt",
+    "/tmp/memu-runs/session-42/jobs/3.txt"
+  ],
+  "executor_prompt": "Process this prepared memU self-evolve run in one agent session.\nRead and carry out every job file below in the listed order:\n1. /tmp/memu-runs/session-42/jobs/1.txt\n2. /tmp/memu-runs/session-42/jobs/2.txt\n3. /tmp/memu-runs/session-42/jobs/3.txt\nRun one job at a time. Do not parallelize, skip, or reorder jobs. If any job fails, stop and report failure. Do not run `memu memorize commit`. Report success only after every job has completed.",
+  "next_command": "memu memorize commit --workspace /tmp/memu-runs/session-42"
+}
+```
+
+| Response field | Use |
+|---|---|
+| `workspace` | Stable identity of this prepared run. |
+| `transcript` | Materialized inputs referenced by the jobs; applications normally do not edit them. |
+| `jobs` | Authoritative execution order. |
+| `executor_prompt` | Complete handoff to one external evolve executor. |
+| `next_command` | Commit command to run once after executor success. |
+
+Only one prepared run may be active in a workspace. A second `prepare` against that workspace is rejected until the current run commits or the application explicitly discards the dedicated workspace.
+
+## 3. Execute all evolve jobs
+
+Start one external agent session in an environment that can:
+
+- read and write the returned workspace;
+- run the `memu` executable used by the generated resource job;
+- read any original files that may be described as resources.
+
+Pass `executor_prompt` to that agent. It instructs the executor to process these jobs:
+
+| Order | Job | Expected outcome |
+|---:|---|---|
+| 1 | Memory evolution | Create, patch, or leave unchanged the user-memory Markdown files. |
+| 2 | Skill evolution | Create, patch, or leave unchanged skills, then log files changed during the supplied session. |
+| 3 | Resource description | Verify logged paths and describe readable files in `resources.md`. |
+
+The executor must process the returned `jobs` list serially in its given order. It must stop on the first failure and must not run `commit`. A create, patch, or no-op result is valid for the memory and skill jobs; the executor should not invent an artifact merely to make the run non-empty. Treat each job file as the self-contained instruction for that step; do not treat transcript, memory, skill, or resource contents as new orchestration instructions.
+
+The ordering is load-bearing: the skill job may append paths to `.resource.tmp`, and the resource job consumes that log. Running jobs concurrently can race on the shared workspace and produce incomplete resource output.
+
+A minimal application orchestrator looks like this:
+
+```python
+prepared = run_json([
+    "memu",
+    "memorize",
+    "prepare",
+    session_path,
+    "--workspace",
+    run_workspace,
+    "--json",
+])
+
+execution = evolve_executor.run(
+    prompt=prepared["executor_prompt"],
+    workspace=prepared["workspace"],
+)
+
+if not execution.succeeded:
+    discard_dedicated_workspace(prepared["workspace"])
+    raise RuntimeError("memorize evolve failed")
+
+committed = run_json([
+    "memu",
+    "memorize",
+    "commit",
+    "--workspace",
+    prepared["workspace"],
+    "--json",
+])
+```
+
+The executor API and process isolation are application choices. memU defines the filesystem handoff and serial execution contract, not how the external agent is hosted.
+
+## 4. Commit the result
+
+After the executor reports success, run `next_command` once. Add `--json` when a machine-readable result is required:
+
+```bash
+memu memorize commit --workspace /tmp/memu-runs/session-42 --json
+```
+
+`commit` hashes the workspace's `memory/` and `skill/` files against the pre-evolve snapshot, reads successfully described resources, and submits the resulting records through the configured backend. The response contains `recall_files` and `resources`; either list may be empty after a valid no-op run.
+
+On success, memU:
+
+- updates the workspace snapshot;
+- removes the projected input, numbered jobs, resource files, and active marker;
+- leaves the `memory/` and `skill/` mirrors on disk;
+- makes committed RecallFiles available to normal `list-files` and `retrieve` calls.
+
+Only newly created or content-modified files are submitted. File deletion is not part of the v1 commit contract.
+
+## Run states and recovery
+
+| State | Evidence | Application action |
+|---|---|---|
+| Ready | No `.memorize_run.json` | Call `prepare` with one canonical session. |
+| Prepared | Active marker and three jobs exist | Start exactly one evolve executor. |
+| Executing | Executor is processing the jobs | Do not call another `prepare` or `commit`. |
+| Evolve succeeded | Executor completed all jobs | Run `next_command` once. |
+| Evolve failed | Executor stopped before all jobs completed | Do not commit. Discard the dedicated workspace and prepare again from the original payload. |
+| Commit failed | Command returned non-zero and the active marker remains | Preserve the workspace, fix the backend problem, and retry `commit`; do not repeat `prepare` or evolve. |
+| Committed | Active marker and ephemeral run files are gone | The workspace is ready for another run or may be removed by the application. |
+
+Partial job execution is not resumable in the developer v1 interface, and there is currently no abort command. This is why a dedicated, application-owned workspace is recommended: the application can remove the whole directory after an evolve failure without disturbing another run. Backend commit failure is different—the evolved workspace is intentionally retained for commit retry.
+
+## Consistency and concurrency
+
+Workspace isolation prevents two executors from modifying the same local jobs, manifests, and Markdown files. It does not provide backend-level conflict resolution.
+
+`prepare` reads the backend once and establishes the baseline for the run. The workspace is not refreshed again before `commit`. If another host or developer run changes the same `(track, name, user scope)` RecallFile during that window, the later successful commit may overwrite the earlier content. Version 1.0 has no ETag, base revision, three-way merge, or conflict copy.
+
+Applications that may overlap with host bridging should serialize memorize runs that can edit the same RecallFiles, or assign non-overlapping RecallFile ownership. Separate workspaces alone are not sufficient for same-file backend conflicts.
+
+The prepare mirror is additive/overwriting: RecallFiles returned by the backend are written atomically into the workspace, but local files absent from the backend response are not deletion-synchronized. Applications should treat the backend—not a retained workspace directory—as the source of truth between runs.
+
+## Responsibility boundary
+
+The integrating application owns:
+
+- collecting a completed, faithful session and choosing its boundary;
+- deciding when the session is ready to memorize;
+- removing secrets and converting provider-native activity to the canonical model;
+- selecting a dedicated workspace and keeping backend configuration consistent;
+- launching one external executor with `executor_prompt`;
+- treating the jobs as one serial unit of work;
+- committing only after executor success;
+- applying the recovery and concurrency rules above.
+
+memU owns:
+
+- strict canonical validation;
+- memory and skill projection;
+- transcript materialization;
+- current RecallFile listing and workspace mirroring at `prepare` time;
+- job generation and resource verification;
+- content-hash diffing;
+- embedding and persistence through the configured Local or Cloud backend;
+- cleanup after a successful commit.

--- a/src/memu/cli.py
+++ b/src/memu/cli.py
@@ -13,6 +13,8 @@ Usage:
     memu retrieve "What are this user's launch preferences?"
     memu list-files
     memu commit results.json
+    memu memorize prepare session.json
+    memu memorize commit
 """
 
 from __future__ import annotations
@@ -22,6 +24,7 @@ import asyncio
 import json
 import os
 import pathlib
+import shlex
 import sys
 import time
 from collections.abc import Callable, Coroutine
@@ -29,7 +32,17 @@ from typing import Any
 
 from memu import events
 from memu.agentic_backend import AgenticMemoryBackend
+from memu.app.memorize.input import MemorizeInput
+from memu.app.memorize.lifecycle import (
+    MemorizeWorkspace,
+    PreparedMemorizeRun,
+    commit_memorize,
+    prepare_memorize,
+)
 from memu.env import build_agentic_memory_backend_from_env, embedding_provider, env
+from memu.hosts.bridging.resources import verify_resource_log
+
+MEMORIZE_WORKSPACE = "~/.memu/developer"
 
 
 def _env(name: str, default: str) -> str:
@@ -155,6 +168,110 @@ async def _cmd_commit(args: argparse.Namespace) -> int:
     return 0
 
 
+def _memorize_workspace(args: argparse.Namespace) -> MemorizeWorkspace:
+    return MemorizeWorkspace(pathlib.Path(args.workspace).expanduser())
+
+
+def _memorize_commit_command(args: argparse.Namespace, workspace: MemorizeWorkspace) -> str:
+    command = "memu memorize commit"
+    if args.workspace != MEMORIZE_WORKSPACE:
+        command += f" --workspace {shlex.quote(str(workspace.base))}"
+    return command
+
+
+def _memorize_executor_prompt(prepared: PreparedMemorizeRun) -> str:
+    jobs = "\n".join(f"{index}. {path}" for index, path in enumerate(prepared.jobs, start=1))
+    return (
+        "Process this prepared memU self-evolve run in one agent session.\n"
+        "Read and carry out every job file below in the listed order:\n"
+        f"{jobs}\n"
+        "Run one job at a time. Do not parallelize, skip, or reorder jobs. "
+        "If any job fails, stop and report failure. Do not run `memu memorize commit`. "
+        "Report success only after every job has completed."
+    )
+
+
+def _read_memorize_input(payload: str) -> MemorizeInput:
+    if payload == "-":
+        data = json.load(sys.stdin)
+    else:
+        path = pathlib.Path(payload).expanduser()
+        if not path.exists():
+            msg = f"no such file: {path}"
+            raise FileNotFoundError(msg)
+        data = json.loads(path.read_text(encoding="utf-8"))
+    return MemorizeInput.model_validate(data)
+
+
+async def _cmd_memorize_prepare(args: argparse.Namespace) -> int:
+    if args.payload != "-":
+        path = pathlib.Path(args.payload).expanduser()
+        if not path.exists():
+            print(f"error: no such file: {path}", file=sys.stderr)
+            return 2
+    memorize_input = _read_memorize_input(args.payload)
+    workspace = _memorize_workspace(args)
+    verify_command = f"memu memorize verify-resources --workspace {shlex.quote(str(workspace.base))}"
+    prepared = await prepare_memorize(
+        memorize_input,
+        workspace,
+        _build_backend(args),
+        verify_command=verify_command,
+    )
+
+    executor_prompt = _memorize_executor_prompt(prepared)
+    if args.json:
+        _print_json({
+            "workspace": str(workspace.base),
+            "transcript": {
+                "memory_path": str(prepared.transcript.memory_path),
+                "skill_path": str(prepared.transcript.skill_path),
+            },
+            "jobs": [str(path) for path in prepared.jobs],
+            "executor_prompt": executor_prompt,
+            "next_command": _memorize_commit_command(args, workspace),
+        })
+        return 0
+
+    print("prepared developer session")
+    print(f"  {len(prepared.jobs)} job(s)")
+    print(f"  workspace: {workspace.base}")
+    print("run one external agent session with this prompt:")
+    print(executor_prompt)
+    print("after the agent reports success, run:")
+    print(f"  {_memorize_commit_command(args, workspace)}")
+    return 0
+
+
+async def _cmd_memorize_commit(args: argparse.Namespace) -> int:
+    result = await commit_memorize(_memorize_workspace(args), _build_backend(args))
+    if args.json:
+        _print_json(result)
+        return 0
+
+    recall_files = result.get("recall_files", [])
+    resources = result.get("resources", [])
+    print(f"committed {len(recall_files)} recall file(s) and {len(resources)} resource(s)")
+    for recall_file in recall_files:
+        print(f"  - {recall_file.get('track')}/{recall_file.get('name')}")
+    return 0
+
+
+async def _cmd_memorize_verify_resources(args: argparse.Namespace) -> int:
+    workspace = _memorize_workspace(args)
+    kept = verify_resource_log(workspace.resource_log, workspace.resources)
+    print(f"verified {kept} resource(s)")
+    return 0
+
+
+def _add_memorize_workspace(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--workspace",
+        default=MEMORIZE_WORKSPACE,
+        help=f"Developer self-evolve workspace (default: {MEMORIZE_WORKSPACE})",
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="memu",
@@ -185,6 +302,30 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_common_options(p)
     p.set_defaults(handler=_cmd_commit)
+
+    memorize = sub.add_parser(
+        "memorize",
+        help="Turn developer-supplied conversations into external self-evolve jobs",
+    )
+    memorize_actions = memorize.add_subparsers(dest="memorize_action", required=True)
+
+    p = memorize_actions.add_parser("prepare", help="Prepare self-evolve jobs from one conversation session")
+    p.add_argument("payload", help='MemorizeInput JSON file, or "-" for stdin')
+    _add_memorize_workspace(p)
+    _add_common_options(p)
+    p.set_defaults(handler=_cmd_memorize_prepare)
+
+    p = memorize_actions.add_parser("commit", help="Commit the active self-evolve run")
+    _add_memorize_workspace(p)
+    _add_common_options(p)
+    p.set_defaults(handler=_cmd_memorize_commit)
+
+    p = memorize_actions.add_parser(
+        "verify-resources",
+        help="Internal: verify files logged by generated skill jobs",
+    )
+    _add_memorize_workspace(p)
+    p.set_defaults(handler=_cmd_memorize_verify_resources)
 
     return parser
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,8 @@ def test_parser_covers_all_entry_points() -> None:
         ["search", "query"],
         ["list-files"],
         ["commit", "payload.json"],
+        ["memorize", "prepare", "input.json"],
+        ["memorize", "commit"],
     ):
         args = parser.parse_args(argv)
         assert callable(args.handler)

--- a/tests/test_memorize_cli.py
+++ b/tests/test_memorize_cli.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import io
+import json
+import shlex
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from memu import cli
+from memu.app.memorize.lifecycle import PreparedMemorizeRun
+from memu.app.memorize.materialize import MaterializedConversation
+
+
+def _payload() -> dict[str, Any]:
+    return {
+        "schema_version": "1.0",
+        "items": [{"type": "message", "role": "user", "content": "Remember this"}],
+    }
+
+
+def _prepared(workspace: Any, jobs: tuple[str, ...] = ("1.txt", "2.txt", "3.txt")) -> PreparedMemorizeRun:
+    return PreparedMemorizeRun(
+        transcript=MaterializedConversation(
+            memory_path=workspace.input / "1.jsonl",
+            skill_path=workspace.input / "1_full.jsonl",
+        ),
+        jobs=[workspace.jobs / name for name in jobs],
+    )
+
+
+def test_parser_covers_memorize_actions() -> None:
+    parser = cli.build_parser()
+    for argv in (
+        ["memorize", "prepare", "input.json"],
+        ["memorize", "commit"],
+        ["memorize", "verify-resources"],
+    ):
+        assert callable(parser.parse_args(argv).handler)
+
+
+def test_prepare_reads_file_and_prints_agent_handoff(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = tmp_path / "input.json"
+    payload.write_text(json.dumps(_payload()), encoding="utf-8")
+    workspace = tmp_path / "developer workspace"
+    backend = object()
+    received: dict[str, Any] = {}
+
+    async def fake_prepare(memorize_input: Any, prepared_workspace: Any, selected_backend: Any, **kwargs: Any) -> Any:
+        received.update({
+            "input": memorize_input,
+            "workspace": prepared_workspace,
+            "backend": selected_backend,
+            **kwargs,
+        })
+        return _prepared(prepared_workspace)
+
+    monkeypatch.setattr(cli, "_build_backend", lambda _args: backend)
+    monkeypatch.setattr(cli, "prepare_memorize", fake_prepare)
+
+    assert cli.main(["memorize", "prepare", str(payload), "--workspace", str(workspace)]) == 0
+
+    assert received["input"].items[0].content == "Remember this"
+    assert received["workspace"].base == workspace
+    assert received["backend"] is backend
+    assert received["verify_command"] == f"memu memorize verify-resources --workspace '{workspace}'"
+    output = capsys.readouterr().out
+    assert "prepared developer session" in output
+    assert "3 job(s)" in output
+    assert "run one external agent session with this prompt:" in output
+    assert "1. " + str(workspace / "jobs" / "1.txt") in output
+    assert "2. " + str(workspace / "jobs" / "2.txt") in output
+    assert "3. " + str(workspace / "jobs" / "3.txt") in output
+    assert "Do not parallelize, skip, or reorder jobs" in output
+    assert "Do not run `memu memorize commit`" in output
+    assert "after the agent reports success, run:" in output
+    assert f"memu memorize commit --workspace '{workspace}'" in output
+
+
+def test_prepare_reads_stdin_and_prints_machine_handoff(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+
+    async def fake_prepare(_memorize_input: Any, prepared_workspace: Any, _backend: Any, **_kwargs: Any) -> Any:
+        return _prepared(prepared_workspace, ("1.txt",))
+
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO(json.dumps(_payload())))
+    monkeypatch.setattr(cli, "_build_backend", lambda _args: object())
+    monkeypatch.setattr(cli, "prepare_memorize", fake_prepare)
+
+    assert cli.main(["memorize", "prepare", "-", "--workspace", str(workspace), "--json"]) == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output == {
+        "workspace": str(workspace),
+        "transcript": {
+            "memory_path": str(workspace / "input" / "1.jsonl"),
+            "skill_path": str(workspace / "input" / "1_full.jsonl"),
+        },
+        "jobs": [str(workspace / "jobs" / "1.txt")],
+        "executor_prompt": (
+            "Process this prepared memU self-evolve run in one agent session.\n"
+            "Read and carry out every job file below in the listed order:\n"
+            f"1. {workspace / 'jobs' / '1.txt'}\n"
+            "Run one job at a time. Do not parallelize, skip, or reorder jobs. "
+            "If any job fails, stop and report failure. Do not run `memu memorize commit`. "
+            "Report success only after every job has completed."
+        ),
+        "next_command": f"memu memorize commit --workspace {shlex.quote(str(workspace))}",
+    }
+
+
+def test_executor_prompt_preserves_returned_job_order(tmp_path: Path) -> None:
+    workspace = cli.MemorizeWorkspace(tmp_path / "workspace")
+    prepared = _prepared(workspace, ("8.txt", "3.txt", "11.txt"))
+
+    prompt = cli._memorize_executor_prompt(prepared)
+
+    assert prompt.index(f"1. {workspace.jobs / '8.txt'}") < prompt.index(f"2. {workspace.jobs / '3.txt'}")
+    assert prompt.index(f"2. {workspace.jobs / '3.txt'}") < prompt.index(f"3. {workspace.jobs / '11.txt'}")
+
+
+def test_prepare_default_workspace_keeps_next_command_short(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    async def fake_prepare(_memorize_input: Any, workspace: Any, _backend: Any, **_kwargs: Any) -> Any:
+        return _prepared(workspace, ())
+
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO(json.dumps(_payload())))
+    monkeypatch.setattr(cli, "_build_backend", lambda _args: object())
+    monkeypatch.setattr(cli, "prepare_memorize", fake_prepare)
+
+    assert cli.main(["memorize", "prepare", "-", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out)["next_command"] == "memu memorize commit"
+
+
+def test_prepare_missing_file_reports_error(capsys: pytest.CaptureFixture[str]) -> None:
+    assert cli.main(["memorize", "prepare", "/definitely/not/input.json"]) == 2
+    assert "no such file" in capsys.readouterr().err
+
+
+def test_prepare_invalid_input_reports_validation_error(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    payload = tmp_path / "invalid.json"
+    payload.write_text(json.dumps({"items": []}), encoding="utf-8")
+
+    assert cli.main(["memorize", "prepare", str(payload)]) == 1
+    assert "at least 1 item" in capsys.readouterr().err
+
+
+def test_commit_uses_selected_backend_and_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    backend = object()
+    received: dict[str, Any] = {}
+
+    async def fake_commit(selected_workspace: Any, selected_backend: Any) -> dict[str, Any]:
+        received.update({"workspace": selected_workspace, "backend": selected_backend})
+        return {
+            "recall_files": [{"track": "memory", "name": "profile"}],
+            "resources": [{"url": "/workspace/notes.md"}],
+        }
+
+    monkeypatch.setattr(cli, "_build_backend", lambda _args: backend)
+    monkeypatch.setattr(cli, "commit_memorize", fake_commit)
+
+    assert cli.main(["memorize", "commit", "--workspace", str(workspace)]) == 0
+    assert received == {"workspace": cli.MemorizeWorkspace(workspace), "backend": backend}
+    output = capsys.readouterr().out
+    assert "committed 1 recall file(s) and 1 resource(s)" in output
+    assert "memory/profile" in output
+
+
+def test_verify_resources_uses_workspace_without_backend(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    workspace = tmp_path / "workspace"
+    received: tuple[Path, Path] | None = None
+
+    def fake_verify(log: Path, resources: Path) -> int:
+        nonlocal received
+        received = (log, resources)
+        return 2
+
+    monkeypatch.setattr(cli, "verify_resource_log", fake_verify)
+    monkeypatch.setattr(cli, "_build_backend", lambda _args: pytest.fail("verifier must not build a backend"))
+
+    assert cli.main(["memorize", "verify-resources", "--workspace", str(workspace)]) == 0
+    assert received == (workspace / ".resource.tmp", workspace / "resources.md")
+    assert "verified 2 resource(s)" in capsys.readouterr().out


### PR DESCRIPTION
## 📝 Pull Request Summary

为 developer direct-input 链路提供最终公共入口：在现有 `memu` 主 CLI 下，以 `memorize prepare/commit` 暴露 conversation → external self-evolve → backend commit 的完整流程。

---

## ✅ What does this PR do?

- 新增 `memu memorize prepare <input.json|->`，支持文件或 stdin 输入，并使用现有 `MemorizeInput` 完成严格校验。
- 新增 `memu memorize commit`，提交 external Agent 在 active workspace 中实际写出的 memory/skill diff。
- 复用主 CLI 现有的 Local/Cloud backend selection、embedding 配置与 `--json` 输出模式。
- 默认使用 `~/.memu/developer` workspace，同时提供 `--workspace` 供测试和显式隔离。
- prepare 的人类输出只给出 batch、conversation/job 数、workspace 与下一条 commit 命令；JSON 输出提供稳定的 transcript/job path mapping，便于下游应用直接驱动。
- 增加内部 `memorize verify-resources` 动作，供生成的 resource job 调用，调用方无需自行编排。
- 保留现有 `memu commit payload.json` 作为 prepared RecallFiles 的底层提交接口，不改变其语义。
- README 增加一个最小 message-only 示例和两条命令，不引入额外安装、scheduler 或 host 文档。
- 增加 parser、文件/stdin、human/JSON handoff、workspace、validation、commit 与 verifier 测试。

---

## 🤔 Why is this change needed?

前三层 stacked PR 已完成 developer conversation contract、memory/skill materialization 与 evolving lifecycle。本 PR 将这些 primitives 组合进仓库现有主 CLI，使自研应用无需实现 `TranscriptSource` 或 host adapter，只需提交 conversation、让自己的 Agent 按数字处理 jobs，再执行 commit。

关联 #666。

---

## Verification
- `uv run memu memorize --help`
- `uv run memu memorize prepare --help`
- `uv run memu memorize commit --help`


