### PR TITLE
fix(memory): guard and reindex embedding spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,19 @@ npx memu-cli --help          # CLI via npm launcher (engine: PyPI package memu-c
 uvx --from memu-cli memu     # CLI via uv, no install
 ```
 
+If you change the local embedding provider, model, or endpoint, rebuild the
+stored vectors before recording or retrieving memory:
+
+```bash
+memu reindex --db ~/.memu/memu.sqlite3 --provider jina --embed-model jina-embeddings-v3
+```
+
+memU records a non-secret identity for the active embedding space and refuses
+to compare vectors from another or unknown space. `reindex` embeds everything
+before opening one storage transaction, so a provider or database failure
+leaves the previous vectors usable. The command is local-only; memU Cloud owns
+its server-side indexes.
+
 ## Configuration
 
 Values resolve in order: process env → `~/.memu/config.env` → default. memU

--- a/docs/adr/0019-embedding-space-and-atomic-reindex.md
+++ b/docs/adr/0019-embedding-space-and-atomic-reindex.md
@@ -1,0 +1,41 @@
+# ADR 0019: Embedding Spaces Are Store State and Reindex Atomically
+
+- Status: Proposed
+- Date: 2026-09-01
+- Scope: local `MemoryService` storage and the `memu reindex` command
+
+## Context
+
+`commit_results` deliberately reuses a vector when its source text is unchanged.
+The store previously recorded no provider/model identity, so changing embedding
+configuration could silently compare coordinates from two same-dimensional
+models or fail later on a dimension mismatch. CLI config checks cannot enforce
+this for SDK callers, environment overrides, or concurrent processes.
+
+## Decision
+
+Each local store has one active embedding space, identified by a SHA-256 digest
+of the normalized, non-secret provider, model, base URL, and embeddings endpoint.
+API keys, URL credentials, queries, and fragments are excluded.
+
+Every commit and retrieval checks this identity before using vectors. SQL
+repositories repeat the check in the same transaction as each vector write, so
+a process that planned a commit before another process reindexed cannot write
+old-space vectors afterward. A legacy store with vectors but no identity is not
+guessed; it must be reindexed.
+
+`memu reindex` reads all Resource captions, RecallFile names/descriptions, and
+segment texts, deduplicates them in one embedding batch, and only then replaces
+all vectors plus the active identity in one backend transaction. Provider
+failure happens before storage changes; transaction failure rolls everything
+back.
+
+## Consequences
+
+- Changing provider, model, or endpoint is explicit and may incur a full
+  embedding cost.
+- Retrieval never runs an expensive migration implicitly.
+- One database cannot intentionally mix embedding models. Use separate stores
+  when different agents require different spaces.
+- The identity detects configuration changes, not an upstream provider changing
+  a model's semantics without changing its advertised endpoint/model contract.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,3 +18,4 @@
 - [0016: Client Event Reporting — One Envelope, a Spool by Default, Bounded Payloads](0016-client-event-reporting.md)
 - [0017: `config.env` Is Written by a Command — `init` for the Entry, `config` for the Detail](0017-config-env-as-a-command.md)
 - [0018: Mine Claude Cowork Through the Claude Code Bridge](0018-cowork-through-claude-code-bridge.md)
+- [0019: Embedding Spaces Are Store State and Reindex Atomically](0019-embedding-space-and-atomic-reindex.md)

--- a/src/memu/__init__.py
+++ b/src/memu/__init__.py
@@ -1,6 +1,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from memu.app.service import MemoryService
+from memu.database.interfaces import EmbeddingSpaceMismatch
 
 # Public alias used in documentation examples
 MemUService = MemoryService
@@ -12,4 +13,4 @@ except PackageNotFoundError:  # pragma: no cover - a source checkout with no ins
     # field, and a telemetry field must never be able to break `import memu`.
     __version__ = "0+unknown"
 
-__all__ = ["MemUService", "MemoryService", "__version__"]
+__all__ = ["EmbeddingSpaceMismatch", "MemUService", "MemoryService", "__version__"]

--- a/src/memu/agentic_backend.py
+++ b/src/memu/agentic_backend.py
@@ -38,5 +38,4 @@ class AgenticMemoryBackend(Protocol):
         recall_files: list[dict[str, Any]] | None = None,
         resource: list[dict[str, Any]] | None = None,
         user: dict[str, Any] | None = None,
-        reindex: bool = False,
     ) -> dict[str, Any]: ...

--- a/src/memu/agentic_backend.py
+++ b/src/memu/agentic_backend.py
@@ -38,4 +38,5 @@ class AgenticMemoryBackend(Protocol):
         recall_files: list[dict[str, Any]] | None = None,
         resource: list[dict[str, Any]] | None = None,
         user: dict[str, Any] | None = None,
+        reindex: bool = False,
     ) -> dict[str, Any]: ...

--- a/src/memu/app/__init__.py
+++ b/src/memu/app/__init__.py
@@ -22,6 +22,7 @@ from memu.app.settings import (
     ProgressiveRetrieveConfig,
     UserConfig,
 )
+from memu.database.interfaces import EmbeddingSpaceMismatch
 
 __all__ = [
     "ConversationItem",
@@ -29,6 +30,7 @@ __all__ = [
     "DefaultUserModel",
     "EmbeddingConfig",
     "EmbeddingProfilesConfig",
+    "EmbeddingSpaceMismatch",
     "MaterializedConversation",
     "MemorizeInput",
     "MemorizeWorkspace",

--- a/src/memu/app/agentic.py
+++ b/src/memu/app/agentic.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from memu.database.interfaces import Database
     from memu.database.models import RecallFile, Resource
 
+
 # Default recall-file page size for ``list_all_recall_files`` (ADR 0014). Callers
 # follow ``next_cursor`` to reassemble the full set; the page size only bounds the
 # per-call read/serialization/response, not the total returned.
@@ -57,6 +58,7 @@ async def _embed_one(embed_client: Any, text: str) -> list[float]:
 
 _UNRESOLVED_TICKET = "embedding ticket redeemed without a planned vector"
 _VECTOR_COUNT_MISMATCH = "embedding provider returned the wrong number of vectors"
+_REINDEX_PAYLOAD = "reindex cannot be combined with recall_files, resource, or user"
 
 
 class _EmbeddingBatch:
@@ -153,6 +155,7 @@ class AgenticMixin:
         _normalize_where: Callable[[Mapping[str, Any] | None], dict[str, Any]]
         _model_dump_without_embeddings: Callable[[BaseModel], dict[str, Any]]
         _get_embedding_client: Callable[..., Any]
+        _get_embedding_space: Callable[..., str]
         progressive_retrieve_config: ProgressiveRetrieveConfig
         user_model: type[BaseModel]
 
@@ -208,10 +211,13 @@ class AgenticMixin:
         if not query or not query.strip():
             raise ValueError("empty_query")
         store = self._get_database()
+        embedding_space = self._get_embedding_space()
+        store.assert_embedding_space(embedding_space, initialize=False)
         where_filters = self._normalize_where(where)
         config = self.progressive_retrieve_config
         embed_client = self._get_embedding_client("embedding")
         query_vector = await _embed_one(embed_client, query)
+        store.assert_embedding_space(embedding_space)
 
         segment_hits, segment_pool = self._recall_segments(
             store=store, where_filters=where_filters, query_vector=query_vector, enabled=config.file.enabled
@@ -335,6 +341,7 @@ class AgenticMixin:
         recall_files: list[dict[str, Any]] | None = None,
         resource: list[dict[str, Any]] | None = None,
         user: dict[str, Any] | None = None,
+        reindex: bool = False,
     ) -> dict[str, Any]:
         """Persist externally-prepared resources and recall files into the store.
 
@@ -355,6 +362,12 @@ class AgenticMixin:
         carry no such guarantee; only the embedding step is hoisted clear of the writes.
         """
         store = self._get_database()
+        embedding_space = self._get_embedding_space()
+        if reindex:
+            if recall_files or resource or user:
+                raise ValueError(_REINDEX_PAYLOAD)
+            return await self._reindex_embeddings(store=store, embedding_space=embedding_space)
+        store.assert_embedding_space(embedding_space, initialize=False)
         user_scope = self.user_model(**user).model_dump() if user is not None else None
         embed_client = self._get_embedding_client("embedding")
         user_data = dict(user_scope or {})
@@ -371,12 +384,39 @@ class AgenticMixin:
         file_plans = self._plan_recall_files(recall_files or [], store=store, user_data=user_data, batch=batch)
 
         await batch.resolve(embed_client)
+        store.assert_embedding_space(embedding_space)
 
         committed_resources = self._write_resources(resource_plans, store=store, user_data=user_data, batch=batch)
         committed_files = self._write_recall_files(file_plans, store=store, user_data=user_data, batch=batch)
         return {
             "resources": [self._model_dump_without_embeddings(r) for r in committed_resources],
             "recall_files": [self._model_dump_without_embeddings(f) for f in committed_files],
+        }
+
+    async def _reindex_embeddings(self, *, store: Database, embedding_space: str) -> dict[str, int]:
+        """Replace every stored vector in one backend transaction."""
+        batch = _EmbeddingBatch()
+        resource_tickets = {
+            item.id: batch.request(item.caption)
+            for item in store.resource_repo.list_resources().values()
+            if item.caption
+        }
+        file_tickets = {
+            item.id: batch.request(f"{item.name}: {item.description}" if item.description else item.name)
+            for item in store.recall_file_repo.list_recall_files().values()
+        }
+        segment_tickets = {item.id: batch.request(item.text) for item in store.recall_file_segment_repo.list_segments()}
+        await batch.resolve(self._get_embedding_client("embedding"))
+        store.replace_all_embeddings(
+            resources={item_id: batch.vector(ticket) for item_id, ticket in resource_tickets.items()},
+            recall_files={item_id: batch.vector(ticket) for item_id, ticket in file_tickets.items()},
+            segments={item_id: batch.vector(ticket) for item_id, ticket in segment_tickets.items()},
+            embedding_space=embedding_space,
+        )
+        return {
+            "resources": len(resource_tickets),
+            "recall_files": len(file_tickets),
+            "segments": len(segment_tickets),
         }
 
     def _plan_resources(

--- a/src/memu/app/service.py
+++ b/src/memu/app/service.py
@@ -61,6 +61,9 @@ class MemoryService(AgenticMixin):
     def _get_embedding_client(self, profile: str | None = None) -> Any:
         return self._embedding_pool.get(profile)
 
+    def _get_embedding_space(self, profile: str = "embedding") -> str:
+        return self.embedding_profiles.get(profile, self.embedding_profiles["default"]).embedding_space
+
     def _normalize_where(self, where: Mapping[str, Any] | None) -> dict[str, Any]:
         """Validate and clean the `where` scope filters against the configured user model."""
         if not where:

--- a/src/memu/app/settings.py
+++ b/src/memu/app/settings.py
@@ -1,4 +1,7 @@
+import hashlib
+import json
 from typing import Annotated, Any, Literal
+from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import BaseModel, BeforeValidator, Field, RootModel, StringConstraints, model_validator
 
@@ -70,6 +73,27 @@ class EmbeddingConfig(BaseModel):
             if resolved is not None:
                 self.embed_model = resolved
         return self
+
+    @property
+    def embedding_space(self) -> str:
+        """Stable, non-secret identity for vectors produced by this profile."""
+
+        def endpoint(value: str) -> str:
+            parsed = urlsplit(value.strip())
+            host = parsed.hostname or ""
+            if parsed.port:
+                host = f"{host}:{parsed.port}"
+            return urlunsplit((parsed.scheme.lower(), host.lower(), parsed.path.rstrip("/"), "", ""))
+
+        payload = {
+            "version": 1,
+            "provider": self.provider.strip().lower(),
+            "model": self.embed_model.strip(),
+            "base_url": endpoint(self.base_url),
+            "endpoint": endpoint(self.endpoint_overrides.get("embeddings", "")),
+        }
+        digest = hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+        return f"v1:{digest}"
 
 
 class RetrieveResourceConfig(BaseModel):

--- a/src/memu/cli.py
+++ b/src/memu/cli.py
@@ -29,6 +29,7 @@ from typing import Any
 
 from memu import events
 from memu.agentic_backend import AgenticMemoryBackend
+from memu.app import MemoryService
 from memu.env import build_agentic_memory_backend_from_env, embedding_provider, env
 
 
@@ -156,7 +157,11 @@ async def _cmd_commit(args: argparse.Namespace) -> int:
 
 
 async def _cmd_reindex(args: argparse.Namespace) -> int:
-    result = await _build_backend(args).commit_results(reindex=True)
+    backend = _build_backend(args)
+    if not isinstance(backend, MemoryService):
+        print("error: memu reindex is only available in local mode", file=sys.stderr)
+        return 2
+    result = await backend.commit_results(reindex=True)
     if args.json:
         _print_json(result)
         return 0

--- a/src/memu/cli.py
+++ b/src/memu/cli.py
@@ -155,6 +155,18 @@ async def _cmd_commit(args: argparse.Namespace) -> int:
     return 0
 
 
+async def _cmd_reindex(args: argparse.Namespace) -> int:
+    result = await _build_backend(args).commit_results(reindex=True)
+    if args.json:
+        _print_json(result)
+        return 0
+    print(
+        f"reindexed {result['recall_files']} recall file(s), "
+        f"{result['segments']} segment(s), and {result['resources']} resource(s)"
+    )
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="memu",
@@ -185,6 +197,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_common_options(p)
     p.set_defaults(handler=_cmd_commit)
+
+    p = sub.add_parser("reindex", help="Rebuild every local vector after changing the embedding configuration")
+    _add_common_options(p)
+    p.set_defaults(handler=_cmd_reindex)
 
     return parser
 

--- a/src/memu/cloud.py
+++ b/src/memu/cloud.py
@@ -12,6 +12,7 @@ from memu.retry import RETRYABLE_STATUS_CODES, retry_delay
 
 DEFAULT_CLOUD_BASE_URL = "https://api.memu.so/api/v4/memory/"
 DEFAULT_SCOPE = "default"
+_LOCAL_REINDEX_ONLY = "memu reindex is only available in local mode"
 
 _USER_FIELDS = {"user_id", "agent_id", "user_name", "agent_name"}
 _WHERE_FIELDS = {"user_id", "agent_id"}
@@ -142,7 +143,10 @@ class CloudMemoryClient:
         recall_files: list[dict[str, Any]] | None = None,
         resource: list[dict[str, Any]] | None = None,
         user: dict[str, Any] | None = None,
+        reindex: bool = False,
     ) -> dict[str, Any]:
+        if reindex:
+            raise ValueError(_LOCAL_REINDEX_ONLY)
         payload = {
             "user": self._user(user),
             "recall_files": recall_files or [],

--- a/src/memu/cloud.py
+++ b/src/memu/cloud.py
@@ -12,7 +12,6 @@ from memu.retry import RETRYABLE_STATUS_CODES, retry_delay
 
 DEFAULT_CLOUD_BASE_URL = "https://api.memu.so/api/v4/memory/"
 DEFAULT_SCOPE = "default"
-_LOCAL_REINDEX_ONLY = "memu reindex is only available in local mode"
 
 _USER_FIELDS = {"user_id", "agent_id", "user_name", "agent_name"}
 _WHERE_FIELDS = {"user_id", "agent_id"}
@@ -143,10 +142,7 @@ class CloudMemoryClient:
         recall_files: list[dict[str, Any]] | None = None,
         resource: list[dict[str, Any]] | None = None,
         user: dict[str, Any] | None = None,
-        reindex: bool = False,
     ) -> dict[str, Any]:
-        if reindex:
-            raise ValueError(_LOCAL_REINDEX_ONLY)
         payload = {
             "user": self._user(user),
             "recall_files": recall_files or [],

--- a/src/memu/database/inmemory/repo.py
+++ b/src/memu/database/inmemory/repo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from pydantic import BaseModel
@@ -11,13 +12,15 @@ from memu.database.inmemory.repositories import (
     InMemoryResourceRepository,
 )
 from memu.database.inmemory.state import InMemoryState
-from memu.database.interfaces import Database
+from memu.database.interfaces import Database, EmbeddingSpaceMismatch
 from memu.database.models import (
     RecallFile,
     RecallFileSegment,
     Resource,
 )
 from memu.database.repositories import RecallFileRepo, ResourceRepo
+
+_REINDEX_CONFLICT = "record changed during embedding reindex"
 
 
 class InMemoryStore(Database):
@@ -56,3 +59,42 @@ class InMemoryStore(Database):
 
     def close(self) -> None:
         return None
+
+    def assert_embedding_space(self, embedding_space: str, *, initialize: bool = True) -> None:
+        current = self.state.embedding_space
+        if current == embedding_space:
+            self.state.expected_embedding_space = embedding_space
+            return
+        has_vectors = (
+            any(item.embedding for item in self.resources.values())
+            or any(item.embedding for item in self.recall_files.values())
+            or any(item.embedding for item in self.segments)
+        )
+        if has_vectors and current != embedding_space:
+            raise EmbeddingSpaceMismatch
+        self.state.expected_embedding_space = embedding_space
+        if initialize:
+            self.state.embedding_space = embedding_space
+
+    def replace_all_embeddings(
+        self,
+        *,
+        resources: Mapping[str, list[float]],
+        recall_files: Mapping[str, list[float]],
+        segments: Mapping[str, list[float]],
+        embedding_space: str,
+    ) -> None:
+        segment_by_id = {item.id: item for item in self.segments}
+        resource_ids = {item.id for item in self.resources.values() if item.caption}
+        if set(resources) != resource_ids or set(recall_files) != self.recall_files.keys():
+            raise KeyError(_REINDEX_CONFLICT)
+        if set(segments) != segment_by_id.keys():
+            raise KeyError(_REINDEX_CONFLICT)
+        for item_id, vector in resources.items():
+            self.resources[item_id].embedding = vector
+        for item_id, vector in recall_files.items():
+            self.recall_files[item_id].embedding = vector
+        for item_id, vector in segments.items():
+            segment_by_id[item_id].embedding = vector
+        self.state.embedding_space = embedding_space
+        self.state.expected_embedding_space = embedding_space

--- a/src/memu/database/interfaces.py
+++ b/src/memu/database/interfaces.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Protocol, runtime_checkable
 
 from memu.database.models import RecallFile as RecallFileRecord
@@ -10,6 +11,13 @@ from memu.database.repositories import (
     RecallFileSegmentRepo,
     ResourceRepo,
 )
+
+
+class EmbeddingSpaceMismatch(RuntimeError):
+    """The store contains vectors produced by another or unknown model."""
+
+    def __init__(self) -> None:
+        super().__init__("embedding configuration does not match this store; run `memu reindex`")
 
 
 @runtime_checkable
@@ -24,11 +32,23 @@ class Database(Protocol):
     recall_files: dict[str, RecallFileRecord]
     segments: list[RecallFileSegmentRecord]
 
+    def assert_embedding_space(self, embedding_space: str, *, initialize: bool = True) -> None: ...
+
+    def replace_all_embeddings(
+        self,
+        *,
+        resources: Mapping[str, list[float]],
+        recall_files: Mapping[str, list[float]],
+        segments: Mapping[str, list[float]],
+        embedding_space: str,
+    ) -> None: ...
+
     def close(self) -> None: ...
 
 
 __all__ = [
     "Database",
+    "EmbeddingSpaceMismatch",
     "RecallFileRecord",
     "RecallFileSegmentRecord",
     "ResourceRecord",

--- a/src/memu/database/postgres/migrations/versions/20260901_0002_embedding_space.py
+++ b/src/memu/database/postgres/migrations/versions/20260901_0002_embedding_space.py
@@ -1,0 +1,31 @@
+"""track the active embedding space
+
+Revision ID: 20260901_0002
+Revises: 20260703_0001
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260901_0002"
+down_revision: str | Sequence[str] | None = "20260703_0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "memu_embedding_space",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("identity", sa.Text(), nullable=False),
+        sa.CheckConstraint("id = 1", name="ck_memu_embedding_space_singleton"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("memu_embedding_space")

--- a/src/memu/database/postgres/postgres.py
+++ b/src/memu/database/postgres/postgres.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, cast
 
 from pydantic import BaseModel
+from sqlalchemy import select, text, update
 
-from memu.database.interfaces import Database
+from memu.database.interfaces import Database, EmbeddingSpaceMismatch
 from memu.database.models import (
     RecallFile,
     RecallFileSegment,
@@ -25,6 +27,7 @@ from memu.database.repositories import (
 from memu.database.state import DatabaseState
 
 logger = logging.getLogger(__name__)
+_REINDEX_CONFLICT = "record changed during embedding reindex"
 
 
 class PostgresStore(Database):
@@ -103,3 +106,79 @@ class PostgresStore(Database):
         self.resource_repo.load_existing()
         self.recall_file_repo.load_existing()
         self.recall_file_segment_repo.load_existing()
+
+    def assert_embedding_space(self, embedding_space: str, *, initialize: bool = True) -> None:
+        with self._sessions.session() as session:
+            current = session.execute(
+                text("SELECT identity FROM memu_embedding_space WHERE id = 1")
+            ).scalar_one_or_none()
+            if current == embedding_space:
+                self._state.embedding_space = embedding_space
+                self._state.expected_embedding_space = embedding_space
+                return
+            has_vectors = any(
+                session.execute(select(model.id).where(model.embedding.is_not(None)).limit(1)).first()
+                for model in (
+                    self._sqla_models.Resource,
+                    self._sqla_models.RecallFile,
+                    self._sqla_models.RecallFileSegment,
+                )
+            )
+            if has_vectors and current != embedding_space:
+                raise EmbeddingSpaceMismatch
+            if initialize:
+                session.execute(
+                    text(
+                        "INSERT INTO memu_embedding_space (id, identity) VALUES (1, :identity) "
+                        "ON CONFLICT(id) DO UPDATE SET identity = excluded.identity"
+                    ),
+                    {"identity": embedding_space},
+                )
+                session.commit()
+        self._state.expected_embedding_space = embedding_space
+        if initialize:
+            self._state.embedding_space = embedding_space
+
+    def replace_all_embeddings(
+        self,
+        *,
+        resources: Mapping[str, list[float]],
+        recall_files: Mapping[str, list[float]],
+        segments: Mapping[str, list[float]],
+        embedding_space: str,
+    ) -> None:
+        mappings = (
+            (self._sqla_models.Resource, resources, self._sqla_models.Resource.caption.is_not(None)),
+            (self._sqla_models.RecallFile, recall_files, None),
+            (self._sqla_models.RecallFileSegment, segments, None),
+        )
+        with self._sessions.session() as session:
+            session.execute(text("SELECT identity FROM memu_embedding_space WHERE id = 1 FOR UPDATE"))
+            for model, vectors, predicate in mappings:
+                stmt = select(model.id)
+                if predicate is not None:
+                    stmt = stmt.where(predicate)
+                if set(session.execute(stmt).scalars()) != set(vectors):
+                    raise KeyError(_REINDEX_CONFLICT)
+                for item_id, vector in vectors.items():
+                    result = cast(
+                        Any, session.execute(update(model).where(model.id == item_id).values(embedding=list(vector)))
+                    )
+                    if result.rowcount != 1:
+                        raise KeyError(_REINDEX_CONFLICT)
+            session.execute(
+                update(self._sqla_models.Resource)
+                .where(self._sqla_models.Resource.caption.is_(None))
+                .values(embedding=None)
+            )
+            session.execute(
+                text(
+                    "INSERT INTO memu_embedding_space (id, identity) VALUES (1, :identity) "
+                    "ON CONFLICT(id) DO UPDATE SET identity = excluded.identity"
+                ),
+                {"identity": embedding_space},
+            )
+            session.commit()
+        self._state.embedding_space = embedding_space
+        self._state.expected_embedding_space = embedding_space
+        self._load_existing()

--- a/src/memu/database/postgres/repositories/base.py
+++ b/src/memu/database/postgres/repositories/base.py
@@ -5,7 +5,9 @@ from collections.abc import Mapping
 from typing import Any
 
 import pendulum
+from sqlalchemy import text
 
+from memu.database.interfaces import EmbeddingSpaceMismatch
 from memu.database.postgres.session import SessionManager
 from memu.database.state import DatabaseState
 
@@ -60,6 +62,16 @@ class PostgresRepoBase:
         with self._sessions.session() as session:
             session.merge(obj)
             session.commit()
+
+    def _assert_current_embedding_space(self, session: Any) -> None:
+        expected = self._state.expected_embedding_space
+        if expected is None:
+            return
+        current = session.execute(
+            text("SELECT identity FROM memu_embedding_space WHERE id = 1 FOR UPDATE")
+        ).scalar_one_or_none()
+        if current != expected:
+            raise EmbeddingSpaceMismatch
 
     def _now(self) -> pendulum.DateTime:
         return pendulum.now("UTC")

--- a/src/memu/database/postgres/repositories/recall_file_repo.py
+++ b/src/memu/database/postgres/repositories/recall_file_repo.py
@@ -105,6 +105,7 @@ class PostgresRecallFileRepo(PostgresRepoBase, RecallFileRepo):
 
         now = self._now()
         with self._sessions.session() as session:
+            self._assert_current_embedding_space(session)
             filters = [
                 self._sqla_models.RecallFile.name == name,
                 self._sqla_models.RecallFile.track == track,
@@ -161,6 +162,7 @@ class PostgresRecallFileRepo(PostgresRepoBase, RecallFileRepo):
 
         now = self._now()
         with self._sessions.session() as session:
+            self._assert_current_embedding_space(session)
             recall_file = session.scalar(
                 select(self._sqla_models.RecallFile).where(self._sqla_models.RecallFile.id == recall_file_id)
             )

--- a/src/memu/database/postgres/repositories/recall_file_segment_repo.py
+++ b/src/memu/database/postgres/repositories/recall_file_segment_repo.py
@@ -115,6 +115,7 @@ class PostgresRecallFileSegmentRepo(PostgresRepoBase, RecallFileSegmentRepo):
             **user_data,
         )
         with self._sessions.session() as session:
+            self._assert_current_embedding_space(session)
             session.add(row)
             session.commit()
             session.refresh(row)

--- a/src/memu/database/postgres/repositories/resource_repo.py
+++ b/src/memu/database/postgres/repositories/resource_repo.py
@@ -94,6 +94,7 @@ class PostgresResourceRepo(PostgresRepoBase, ResourceRepo):
         )
 
         with self._sessions.session() as session:
+            self._assert_current_embedding_space(session)
             session.add(res)
             session.commit()
             session.refresh(res)
@@ -113,6 +114,7 @@ class PostgresResourceRepo(PostgresRepoBase, ResourceRepo):
         from sqlmodel import select
 
         with self._sessions.session() as session:
+            self._assert_current_embedding_space(session)
             row = session.scalars(
                 select(self._sqla_models.Resource).where(self._sqla_models.Resource.id == resource_id)
             ).first()

--- a/src/memu/database/postgres/schema.py
+++ b/src/memu/database/postgres/schema.py
@@ -12,7 +12,7 @@ except ImportError as exc:
     raise ImportError(msg) from exc
 
 try:
-    from sqlalchemy import MetaData
+    from sqlalchemy import CheckConstraint, Column, Integer, MetaData, Table, Text
 except ImportError as exc:
     msg = "sqlalchemy is required for Postgres storage support"
     raise ImportError(msg) from exc
@@ -65,6 +65,13 @@ def get_sqlalchemy_models(*, scope_model: type[BaseModel] | None = None) -> SQLA
         return cached
 
     metadata_obj = MetaData()
+    Table(
+        "memu_embedding_space",
+        metadata_obj,
+        Column("id", Integer, primary_key=True),
+        Column("identity", Text, nullable=False),
+        CheckConstraint("id = 1", name="ck_memu_embedding_space_singleton"),
+    )
 
     resource_model = build_table_model(
         scope,

--- a/src/memu/database/sqlite/repositories/base.py
+++ b/src/memu/database/sqlite/repositories/base.py
@@ -8,7 +8,9 @@ from collections.abc import Mapping
 from typing import Any
 
 import pendulum
+from sqlalchemy import text
 
+from memu.database.interfaces import EmbeddingSpaceMismatch
 from memu.database.sqlite.session import SQLiteSessionManager
 from memu.database.state import DatabaseState
 
@@ -72,6 +74,17 @@ class SQLiteRepoBase:
         with self._sessions.session() as session:
             session.merge(obj)
             session.commit()
+
+    def _assert_current_embedding_space(self, session: Any) -> None:
+        expected = self._state.expected_embedding_space
+        if expected is None:
+            return
+        # Reindex takes the same SQLite write lock, so neither side can
+        # validate one space and then write into another.
+        session.execute(text("UPDATE memu_embedding_space SET identity = identity WHERE id = 1"))
+        current = session.execute(text("SELECT identity FROM memu_embedding_space WHERE id = 1")).scalar_one_or_none()
+        if current != expected:
+            raise EmbeddingSpaceMismatch
 
     def _now(self) -> pendulum.DateTime:
         """Get current UTC time."""

--- a/src/memu/database/sqlite/repositories/recall_file_repo.py
+++ b/src/memu/database/sqlite/repositories/recall_file_repo.py
@@ -188,6 +188,7 @@ class SQLiteRecallFileRepo(SQLiteRepoBase, RecallFileRepo):
         # Check for existing file with same name, track, and scope
         where: dict[str, Any] = {"name": name, "track": track, **user_data}
         with self._sessions.session() as session:
+            self._assert_current_embedding_space(session)
             stmt = select(self._recall_file_model)
             filters = self._build_filters(self._recall_file_model, where)
             if filters:
@@ -267,6 +268,7 @@ class SQLiteRecallFileRepo(SQLiteRepoBase, RecallFileRepo):
             KeyError: If recall file not found.
         """
         with self._sessions.session() as session:
+            self._assert_current_embedding_space(session)
             stmt = select(self._recall_file_model).where(self._recall_file_model.id == recall_file_id)
             row = session.exec(stmt).first()
 

--- a/src/memu/database/sqlite/repositories/recall_file_segment_repo.py
+++ b/src/memu/database/sqlite/repositories/recall_file_segment_repo.py
@@ -84,6 +84,7 @@ class SQLiteRecallFileSegmentRepo(SQLiteRepoBase, RecallFileSegmentRepo):
     ) -> RecallFileSegment:
         now = self._now()
         with self._sessions.session() as session:
+            self._assert_current_embedding_space(session)
             row = self._recall_file_segment_model(
                 recall_file_id=recall_file_id,
                 track=track,

--- a/src/memu/database/sqlite/repositories/resource_repo.py
+++ b/src/memu/database/sqlite/repositories/resource_repo.py
@@ -173,6 +173,7 @@ class SQLiteResourceRepo(SQLiteRepoBase, ResourceRepo):
             **user_data,
         )
         with self._sessions.session() as session:
+            self._assert_current_embedding_space(session)
             session.add(row)
             session.commit()
             session.refresh(row)
@@ -216,6 +217,7 @@ class SQLiteResourceRepo(SQLiteRepoBase, ResourceRepo):
             KeyError: If no resource has that id.
         """
         with self._sessions.session() as session:
+            self._assert_current_embedding_space(session)
             stmt = select(self._resource_model).where(self._resource_model.id == resource_id)
             row = session.exec(stmt).first()
 

--- a/src/memu/database/sqlite/schema.py
+++ b/src/memu/database/sqlite/schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from pydantic import BaseModel
-from sqlalchemy import MetaData
+from sqlalchemy import CheckConstraint, Column, Integer, MetaData, Table, Text
 from sqlmodel import SQLModel
 
 from memu.database.sqlite.models import (
@@ -46,6 +46,13 @@ def get_sqlite_sqlalchemy_models(*, scope_model: type[BaseModel] | None = None) 
         return cached
 
     metadata_obj = MetaData()
+    Table(
+        "memu_embedding_space",
+        metadata_obj,
+        Column("id", Integer, primary_key=True),
+        Column("identity", Text, nullable=False),
+        CheckConstraint("id = 1", name="ck_memu_embedding_space_singleton"),
+    )
 
     # NOTE: SQLite reserves any table name beginning with "sqlite_", so the tables
     # must use a different prefix.

--- a/src/memu/database/sqlite/sqlite.py
+++ b/src/memu/database/sqlite/sqlite.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, cast
 
 from pydantic import BaseModel
+from sqlalchemy import select, text, update
 from sqlmodel import SQLModel
 
-from memu.database.interfaces import Database
+from memu.database.interfaces import Database, EmbeddingSpaceMismatch
 from memu.database.models import (
     RecallFile,
     RecallFileSegment,
@@ -27,6 +29,7 @@ from memu.database.sqlite.session import SQLiteSessionManager
 from memu.database.state import DatabaseState
 
 logger = logging.getLogger(__name__)
+_REINDEX_CONFLICT = "record changed during embedding reindex"
 
 
 class SQLiteStore(Database):
@@ -128,6 +131,82 @@ class SQLiteStore(Database):
         self.resource_repo.load_existing()
         self.recall_file_repo.load_existing()
         self.recall_file_segment_repo.load_existing()
+
+    def assert_embedding_space(self, embedding_space: str, *, initialize: bool = True) -> None:
+        with self._sessions.session() as session:
+            current = session.execute(
+                text("SELECT identity FROM memu_embedding_space WHERE id = 1")
+            ).scalar_one_or_none()
+            if current == embedding_space:
+                self._state.embedding_space = embedding_space
+                self._state.expected_embedding_space = embedding_space
+                return
+            has_vectors = any(
+                session.execute(select(model.id).where(model.embedding.is_not(None)).limit(1)).first()
+                for model in (
+                    self._sqla_models.Resource,
+                    self._sqla_models.RecallFile,
+                    self._sqla_models.RecallFileSegment,
+                )
+            )
+            if has_vectors and current != embedding_space:
+                raise EmbeddingSpaceMismatch
+            if initialize:
+                session.execute(
+                    text(
+                        "INSERT INTO memu_embedding_space (id, identity) VALUES (1, :identity) "
+                        "ON CONFLICT(id) DO UPDATE SET identity = excluded.identity"
+                    ),
+                    {"identity": embedding_space},
+                )
+                session.commit()
+        self._state.expected_embedding_space = embedding_space
+        if initialize:
+            self._state.embedding_space = embedding_space
+
+    def replace_all_embeddings(
+        self,
+        *,
+        resources: Mapping[str, list[float]],
+        recall_files: Mapping[str, list[float]],
+        segments: Mapping[str, list[float]],
+        embedding_space: str,
+    ) -> None:
+        mappings = (
+            (self._sqla_models.Resource, resources, self._sqla_models.Resource.caption.is_not(None)),
+            (self._sqla_models.RecallFile, recall_files, None),
+            (self._sqla_models.RecallFileSegment, segments, None),
+        )
+        with self._sessions.session() as session:
+            session.execute(text("UPDATE memu_embedding_space SET identity = identity WHERE id = 1"))
+            for model, vectors, predicate in mappings:
+                stmt = select(model.id)
+                if predicate is not None:
+                    stmt = stmt.where(predicate)
+                if set(session.execute(stmt).scalars()) != set(vectors):
+                    raise KeyError(_REINDEX_CONFLICT)
+                for item_id, vector in vectors.items():
+                    result = cast(
+                        Any, session.execute(update(model).where(model.id == item_id).values(embedding=list(vector)))
+                    )
+                    if result.rowcount != 1:
+                        raise KeyError(_REINDEX_CONFLICT)
+            session.execute(
+                update(self._sqla_models.Resource)
+                .where(self._sqla_models.Resource.caption.is_(None))
+                .values(embedding=None)
+            )
+            session.execute(
+                text(
+                    "INSERT INTO memu_embedding_space (id, identity) VALUES (1, :identity) "
+                    "ON CONFLICT(id) DO UPDATE SET identity = excluded.identity"
+                ),
+                {"identity": embedding_space},
+            )
+            session.commit()
+        self._state.embedding_space = embedding_space
+        self._state.expected_embedding_space = embedding_space
+        self.load_existing()
 
 
 __all__ = ["SQLiteStore"]

--- a/src/memu/database/state.py
+++ b/src/memu/database/state.py
@@ -14,6 +14,8 @@ class DatabaseState:
     resources: dict[str, Resource] = field(default_factory=dict)
     recall_files: dict[str, RecallFile] = field(default_factory=dict)
     segments: list[RecallFileSegment] = field(default_factory=list)
+    embedding_space: str | None = None
+    expected_embedding_space: str | None = None
 
 
 __all__ = ["DatabaseState"]

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -12,6 +12,7 @@ from typing import Any
 import pytest
 
 from memu.app import MemoryService
+from memu.database.interfaces import EmbeddingSpaceMismatch
 
 
 class FakeEmbeddingClient:
@@ -208,6 +209,140 @@ class FailingEmbeddingClient(FakeEmbeddingClient):
         if self.calls == self._fail_on_call:
             raise EmbeddingProviderDown
         return await super().embed(inputs)
+
+
+def model_service(dsn: str, model: str, client: Any) -> MemoryService:
+    service = MemoryService(
+        database_config={"metadata_store": {"provider": "sqlite", "dsn": dsn}},
+        embedding_profiles={
+            "default": {
+                "provider": "openai",
+                "embed_model": model,
+                "base_url": "https://api.openai.com/v1",
+            }
+        },
+    )
+    service._embedding_pool._cache["default"] = client
+    service._embedding_pool._cache["embedding"] = client
+    return service
+
+
+async def test_model_change_requires_explicit_atomic_reindex(tmp_path: Any) -> None:
+    dsn = f"sqlite:///{tmp_path}/memu.sqlite3"
+    old = model_service(dsn, "model-a", FakeEmbeddingClient())
+    await _seed(old)
+
+    new_client = CountingEmbeddingClient()
+    new = model_service(dsn, "model-b", new_client)
+    with pytest.raises(EmbeddingSpaceMismatch, match="memu reindex"):
+        await new.progressive_retrieve("coffee")
+    with pytest.raises(EmbeddingSpaceMismatch, match="memu reindex"):
+        await new.commit_results(
+            recall_files=[
+                {"name": "Profile", "track": "memory", "description": "who the user is", "content": "# P\nlikes coffee"}
+            ]
+        )
+    assert new_client.calls == 0
+
+    result = await new.commit_results(reindex=True)
+    assert result == {"resources": 1, "recall_files": 2, "segments": 2}
+    assert new_client.calls == 1
+    assert (await new.progressive_retrieve("coffee"))["files"][0]["name"] == "Profile"
+
+    with pytest.raises(ValueError, match="reindex cannot be combined"):
+        await new.commit_results(reindex=True, resource=[{"path": "/ignored.md"}])
+
+
+async def test_failed_reindex_keeps_the_old_embedding_space_readable(tmp_path: Any) -> None:
+    dsn = f"sqlite:///{tmp_path}/memu.sqlite3"
+    old = model_service(dsn, "model-a", FakeEmbeddingClient())
+    await _seed(old)
+
+    new = model_service(dsn, "model-b", FailingEmbeddingClient())
+    with pytest.raises(EmbeddingProviderDown):
+        await new.commit_results(reindex=True)
+
+    assert (await old.progressive_retrieve("coffee"))["files"][0]["name"] == "Profile"
+    with pytest.raises(EmbeddingSpaceMismatch, match="memu reindex"):
+        await new.progressive_retrieve("coffee")
+
+
+async def test_first_failed_commit_does_not_claim_an_embedding_space() -> None:
+    service = MemoryService(database_config={"metadata_store": {"provider": "inmemory"}})
+    service._embedding_pool._cache["embedding"] = FailingEmbeddingClient()
+
+    with pytest.raises(EmbeddingProviderDown):
+        await service.commit_results(resource=[{"path": "/notes.md", "description": "notes"}])
+
+    assert service._get_database().state.embedding_space is None
+
+
+async def test_legacy_vectors_require_reindex_instead_of_guessing_their_model(tmp_path: Any) -> None:
+    dsn = f"sqlite:///{tmp_path}/memu.sqlite3"
+    legacy = model_service(dsn, "model-a", FakeEmbeddingClient())
+    legacy._get_database().resource_repo.create_resource(
+        url="/legacy.md",
+        local_path="/legacy.md",
+        caption="legacy notes",
+        embedding=[1.0, 0.0, 0.0, 0.0],
+        user_data={},
+        track="workspace",
+    )
+
+    current = model_service(dsn, "model-a", FakeEmbeddingClient())
+    with pytest.raises(EmbeddingSpaceMismatch, match="memu reindex"):
+        await current.progressive_retrieve("notes")
+    assert await current.commit_results(reindex=True) == {"resources": 1, "recall_files": 0, "segments": 0}
+    assert [item["url"] for item in (await current.progressive_retrieve("notes"))["resources"]] == ["/legacy.md"]
+
+
+async def test_sqlite_reindex_rolls_back_every_vector_when_storage_fails(tmp_path: Any) -> None:
+    from sqlalchemy import text
+    from sqlalchemy.exc import DatabaseError
+
+    dsn = f"sqlite:///{tmp_path}/memu.sqlite3"
+    old = model_service(dsn, "model-a", FakeEmbeddingClient())
+    await _seed(old)
+    store = old._get_database()
+    with store._sessions.engine.begin() as connection:
+        connection.execute(
+            text(
+                "CREATE TRIGGER reject_recall_reindex BEFORE UPDATE OF embedding ON memu_recall_files "
+                "BEGIN SELECT RAISE(ABORT, 'reindex failed'); END"
+            )
+        )
+
+    new = model_service(dsn, "model-b", FakeEmbeddingClient())
+    with pytest.raises(DatabaseError, match="reindex failed"):
+        await new.commit_results(reindex=True)
+
+    assert (await old.progressive_retrieve("coffee"))["files"][0]["name"] == "Profile"
+    with pytest.raises(EmbeddingSpaceMismatch, match="memu reindex"):
+        await new.progressive_retrieve("coffee")
+
+
+async def test_sqlite_reindex_rejects_a_row_added_after_its_snapshot(tmp_path: Any) -> None:
+    dsn = f"sqlite:///{tmp_path}/memu.sqlite3"
+    old = model_service(dsn, "model-a", FakeEmbeddingClient())
+    await _seed(old)
+
+    class ConcurrentWriter(FakeEmbeddingClient):
+        async def embed(self, inputs: list[str]) -> tuple[list[list[float]], None]:
+            old._get_database().resource_repo.create_resource(
+                url="/late.md",
+                local_path="/late.md",
+                caption="late notes",
+                embedding=[0.0, 0.0, 1.0, 0.0],
+                user_data={},
+                track="workspace",
+            )
+            return await super().embed(inputs)
+
+    new = model_service(dsn, "model-b", ConcurrentWriter())
+    with pytest.raises(KeyError, match="record changed during embedding reindex"):
+        await new.commit_results(reindex=True)
+
+    assert (await old.progressive_retrieve("coffee"))["files"][0]["name"] == "Profile"
 
 
 async def test_failed_embedding_leaves_the_store_untouched(service: MemoryService) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,7 +120,18 @@ def test_reindex_uses_the_selected_local_backend(
             calls.append(reindex)
             return {"recall_files": 2, "segments": 3, "resources": 1}
 
+    monkeypatch.setattr(cli, "MemoryService", Backend)
     monkeypatch.setattr(cli, "build_agentic_memory_backend_from_env", lambda **kwargs: Backend())
     assert main(["reindex"]) == 0
     assert calls == [True]
     assert "reindexed 2 recall file(s), 3 segment(s), and 1 resource(s)" in capsys.readouterr().out
+
+
+def test_reindex_rejects_cloud_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(cli, "build_agentic_memory_backend_from_env", lambda **kwargs: object())
+
+    assert main(["reindex"]) == 2
+    assert "only available in local mode" in capsys.readouterr().err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,7 @@ def test_parser_covers_all_entry_points() -> None:
         ["search", "query"],
         ["list-files"],
         ["commit", "payload.json"],
+        ["reindex"],
     ):
         args = parser.parse_args(argv)
         assert callable(args.handler)
@@ -106,3 +107,20 @@ def test_retrieve_and_list_files_use_selected_backend(
     assert main(["list-files"]) == 0
     assert calls == [("retrieve", "tea"), ("list", None)]
     assert "0 recall file(s)" in capsys.readouterr().out
+
+
+def test_reindex_uses_the_selected_local_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[bool] = []
+
+    class Backend:
+        async def commit_results(self, *, reindex: bool = False, **kwargs: Any) -> dict[str, int]:
+            calls.append(reindex)
+            return {"recall_files": 2, "segments": 3, "resources": 1}
+
+    monkeypatch.setattr(cli, "build_agentic_memory_backend_from_env", lambda **kwargs: Backend())
+    assert main(["reindex"]) == 0
+    assert calls == [True]
+    assert "reindexed 2 recall file(s), 3 segment(s), and 1 resource(s)" in capsys.readouterr().out

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -301,3 +301,21 @@ def test_embedding_config_provider_defaults():
     assert explicit.base_url == "https://proxy/v1"
     assert explicit.api_key == "real"
     assert explicit.embed_model == "custom"
+
+
+def test_embedding_space_tracks_model_and_endpoint_without_credentials():
+    first = EmbeddingConfig(
+        provider="openai",
+        embed_model="model-a",
+        base_url="https://alice:secret@example.test/v1?token=one",
+    )
+    other_credentials = EmbeddingConfig(
+        provider="openai",
+        embed_model="model-a",
+        base_url="https://bob:different@example.test/v1?token=two",
+    )
+    other_model = first.model_copy(update={"embed_model": "model-b"})
+
+    assert first.embedding_space == other_credentials.embedding_space
+    assert first.embedding_space != other_model.embedding_space
+    assert "secret" not in first.embedding_space

--- a/tests/test_postgres_migration_config.py
+++ b/tests/test_postgres_migration_config.py
@@ -1,6 +1,7 @@
 import importlib.util
 from pathlib import Path
 
+import pytest
 from pydantic import BaseModel
 
 
@@ -29,3 +30,10 @@ def test_make_alembic_config_escapes_percent_encoded_dsn() -> None:
     assert cfg.get_main_option("sqlalchemy.url") == dsn
     assert "%%40%%23%%24%%25%%5E%%26%%2A%%28%%29password" in raw_value
     assert raw_value != dsn
+
+
+def test_embedding_space_table_is_part_of_postgres_schema_validation() -> None:
+    pytest.importorskip("pgvector")
+    from memu.database.postgres.schema import get_metadata
+
+    assert "memu_embedding_space" in get_metadata(_ScopeModel).tables


### PR DESCRIPTION
## Summary

- persist a non-secret store-level embedding-space identity derived from provider, model, and endpoint configuration
- reject normal commit/retrieval when an existing or legacy store belongs to another/unknown space
- add local `memu reindex`, which batches every Resource/RecallFile/Segment embedding before atomically replacing vectors and the active identity
- serialize SQL vector writes against reindex so stale concurrent writers cannot reintroduce old-space vectors
- add SQLite schema bootstrap, a PostgreSQL Alembic migration, ADR 0019, and operator documentation

## Why

`commit_results` correctly reuses vectors for unchanged text, but stored vectors previously carried no model identity. Switching embedding models could therefore silently compare same-dimensional vectors from unrelated coordinate systems, or fail later on a dimension mismatch. CLI config guards do not cover SDK callers, environment overrides, forced config changes, changed defaults, or concurrent processes.

This keeps retrieval cheap: it never starts an implicit full migration. Operators explicitly run `memu reindex` after changing the local embedding configuration. Legacy stores with vectors are treated as unknown instead of being assigned a guessed model.

Related to #480, which improves dimension-mismatch errors but does not detect same-dimensional model changes or rebuild existing vectors.

Fixes #678

## Safety properties

- provider failure occurs before the first reindex write
- Resource, RecallFile, Segment, and active-space updates share one backend transaction
- a storage failure rolls the entire reindex back
- SQL repositories lock/check the active space in the same transaction as each vector write
- reindex revalidates its database snapshot after embedding, so concurrent row changes cause a retryable failure rather than an incomplete successful migration
- credentials, URL userinfo, query strings, and fragments are excluded from the persisted identity

## Verification

- focused embedding-space/CLI/embedding tests: 63 passed
- full suite in the restricted runner: 630 passed, 9 skipped; two localhost-listener tests were blocked by sandbox permissions and passed when rerun outside the sandbox
- one unrelated event-cycle test fails identically on the pre-existing adapter worktree
- `pre-commit run -a`
- Ruff check and format check
- mypy: 127 source files clean
- deptry: no dependency issues
- PostgreSQL migration head resolves to `20260901_0002`; metadata/schema validation includes `memu_embedding_space`

`uv lock --locked` currently reports pre-existing lock drift although this PR changes neither `pyproject.toml` nor `uv.lock`.
