### PR TITLE
feat(retrieve): fuse BM25 with cosine via RRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ By default, uninstalling removes the host integration and tooling while keeping 
 memU runs as a sidecar to a desktop agent, one binary per host. Each binds two seams:
 
 - **record** — a scheduled bridging task slices new session logs into self-contained job files; the agent itself distills them into memory/skill Markdown; `commit` submits whatever the agent left on disk back through `commit_results`.
-- **inject** — a standing instruction in the host's instruction file tells the agent to run `<binary> retrieve` (→ `progressive_retrieve`) before answering.
+- **inject** — a standing instruction in the host's instruction file tells the agent to run `<binary> retrieve` (→ `progressive_retrieve`) before answering. Local retrieve fuses BM25 keyword scores with cosine (RRF); set `MEMU_RETRIEVE_HYBRID=0` for cosine-only.
 
 | Host | Binary | Session log it mines | Instruction file it patches |
 | --- | --- | --- | --- |
@@ -182,6 +182,7 @@ For Local / self-hosted installations, every CLI flag has a matching variable:
 | API key | `MEMU_API_KEY` | the provider's env var, e.g. `OPENAI_API_KEY` |
 | Embedding model | `MEMU_EMBED_MODEL` | the provider's default |
 | Base URL | `MEMU_BASE_URL` | the provider's default |
+| Retrieve hybrid | `MEMU_RETRIEVE_HYBRID` | `1` (set `0` for cosine-only ranking) |
 
 Run `<binary> doctor` to display the resolved mode and verify the same retrieval
 path the host uses.

--- a/docs/adr/0019-hybrid-rrf-retrieve.md
+++ b/docs/adr/0019-hybrid-rrf-retrieve.md
@@ -1,0 +1,58 @@
+# ADR 0019: Hybrid retrieve on the current path — BM25 + cosine via RRF
+
+- Status: Accepted
+- Date: 2026-09-04
+- Builds on: ADR 0007 (hybrid retrieval sketch), ADR 0002 (backend-specific vector search)
+- Scope: local `progressive_retrieve` ranking for L2 segments and workspace
+  resources. Does not change memorize, file roll-up, the wiki-graph kernel, or
+  cloud retrieve.
+
+## Context
+
+ADR 0007 specified a single-pass hybrid: min-max-normalize cosine and BM25,
+fuse, search L2, roll up to L1. The kernel in that ADR is still Proposed.
+Meanwhile `progressive_retrieve` embeds the query once and ranks by cosine
+only — `RecallFileSegment.text` and `Resource.caption` are stored and then
+ignored at search time.
+
+Exact tokens (error codes, hostnames, CJK terms, paths) miss when they are
+not in cosine `top_k`. Inject runs this every turn.
+
+## Decision
+
+Fuse BM25 with cosine on the **current** retrieve path, using Reciprocal Rank
+Fusion rather than ADR 0007’s unspecified min-max linear blend.
+
+- Tokenizer: lowercase latin/digit runs; CJK/kana/hangul unigrams + bigrams.
+- Fusion: `score = Σ 1/(60 + rank_i)` over the cosine ranking and the BM25
+  ranking. No α.
+- sqlite / inmemory / postgres resources: the scoped pool is already scanned
+  in Python; BM25 scores that whole pool (they have no keyword index).
+- postgres segments: pgvector still ranks cosine. Hybrid takes
+  `candidate_k = max(50, 5 * top_k)` cosine hits, BM25 over scoped texts,
+  unions via RRF, then cuts to `top_k`.
+- File layer stays a roll-up (`max` of segment scores).
+- Default on. Cosine-only via `ProgressiveRetrieveConfig.hybrid=False` or
+  `MEMU_RETRIEVE_HYBRID=0`.
+- Ranking stays in the repo. `vector_search_segments` /
+  `vector_search_resources` take optional `query_text`.
+
+When hybrid is on, hit `score` is the RRF value, not cosine similarity.
+
+This **does not accept** ADR 0007’s kernel. The min-max linear sketch there
+remains the formula for that future path if it lands; this ADR is the
+algorithm the current code actually runs.
+
+## Consequences
+
+Positive:
+
+- Exact-term recall without an LLM or a new column.
+- Each backend keeps its vector strategy (Python scan vs pgvector).
+- Kill switch restores the previous ranking.
+
+Negative:
+
+- Default-on changes inject ranking and the numeric `score` field.
+- Postgres hybrid BM25 still reads scoped texts (no `tsvector` yet).
+- CJK n-grams are a coarse substitute for a real word segmenter.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,3 +18,4 @@
 - [0016: Client Event Reporting — One Envelope, a Spool by Default, Bounded Payloads](0016-client-event-reporting.md)
 - [0017: `config.env` Is Written by a Command — `init` for the Entry, `config` for the Detail](0017-config-env-as-a-command.md)
 - [0018: Mine Claude Cowork Through the Claude Code Bridge](0018-cowork-through-claude-code-bridge.md)
+- [0019: Hybrid retrieve on the current path — BM25 + cosine via RRF](0019-hybrid-rrf-retrieve.md)

--- a/src/memu/app/agentic.py
+++ b/src/memu/app/agentic.py
@@ -212,15 +212,24 @@ class AgenticMixin:
         config = self.progressive_retrieve_config
         embed_client = self._get_embedding_client("embedding")
         query_vector = await _embed_one(embed_client, query)
+        query_text = query if config.hybrid else None
 
         segment_hits, segment_pool = self._recall_segments(
-            store=store, where_filters=where_filters, query_vector=query_vector, enabled=config.file.enabled
+            store=store,
+            where_filters=where_filters,
+            query_vector=query_vector,
+            query_text=query_text,
+            enabled=config.file.enabled,
         )
         file_hits, file_pool = self._collect_files(
             store=store, where_filters=where_filters, segment_hits=segment_hits, segment_pool=segment_pool
         )
         resource_hits, resource_pool = self._recall_resources(
-            store=store, where_filters=where_filters, query_vector=query_vector, enabled=config.resource.enabled
+            store=store,
+            where_filters=where_filters,
+            query_vector=query_vector,
+            query_text=query_text,
+            enabled=config.resource.enabled,
         )
 
         return {
@@ -235,9 +244,10 @@ class AgenticMixin:
         store: Database,
         where_filters: dict[str, Any],
         query_vector: list[float],
+        query_text: str | None,
         enabled: bool,
     ) -> tuple[list[tuple[str, float]], dict[str, Any]]:
-        """Rank :class:`RecallFileSegment` slices by embedding similarity.
+        """Rank :class:`RecallFileSegment` slices (cosine, or hybrid when ``query_text``).
 
         The ranking belongs to the repo (:meth:`RecallFileSegmentRepo.vector_search_segments`),
         which is what lets a backend with a native vector index answer from one
@@ -260,6 +270,7 @@ class AgenticMixin:
             query_vector,
             self.progressive_retrieve_config.file.top_k,
             where=segment_where,
+            query_text=query_text,
         )
         return [(seg.id, score) for seg, score in hits], {seg.id: seg for seg, _ in hits}
 
@@ -300,9 +311,10 @@ class AgenticMixin:
         store: Database,
         where_filters: dict[str, Any],
         query_vector: list[float],
+        query_text: str | None,
         enabled: bool,
     ) -> tuple[list[tuple[str, float]], dict[str, Any]]:
-        """Rank workspace-track resources by embedding similarity.
+        """Rank workspace-track resources (cosine, or hybrid when ``query_text``).
 
         Only ``track="workspace"`` resources (the kind :meth:`commit_results`
         writes) are surfaced; other tracks are excluded.
@@ -313,7 +325,10 @@ class AgenticMixin:
         resource_where = {**where_filters, "track": "workspace"}
         resource_pool = store.resource_repo.list_resources(resource_where)
         resource_hits = store.resource_repo.vector_search_resources(
-            query_vector, self.progressive_retrieve_config.resource.top_k, where=resource_where
+            query_vector,
+            self.progressive_retrieve_config.resource.top_k,
+            where=resource_where,
+            query_text=query_text,
         )
         return resource_hits, resource_pool
 

--- a/src/memu/app/settings.py
+++ b/src/memu/app/settings.py
@@ -89,13 +89,17 @@ class RetrieveFileConfig(BaseModel):
 class ProgressiveRetrieveConfig(BaseModel):
     """Configure the single-shot, LLM-free retrieval (``progressive_retrieve``).
 
-    The query is embedded once and the file-segment and resource layers are each
-    ranked by vector similarity. No routing, sufficiency check, or summarization
-    is involved.
+    The query is embedded once. Each layer is ranked by cosine, and — when
+    ``hybrid`` is on — fused with BM25 over the original query text (ADR 0019).
+    No routing, sufficiency check, or summarization is involved.
     """
 
     file: RetrieveFileConfig = Field(default=RetrieveFileConfig())
     resource: RetrieveResourceConfig = Field(default=RetrieveResourceConfig())
+    hybrid: bool = Field(
+        default=True,
+        description="Fuse BM25 with cosine via RRF. False is cosine-only (MEMU_RETRIEVE_HYBRID=0).",
+    )
 
 
 class DefaultUserModel(BaseModel):

--- a/src/memu/database/inmemory/repositories/resource_repo.py
+++ b/src/memu/database/inmemory/repositories/resource_repo.py
@@ -10,7 +10,6 @@ from memu.database.inmemory.repositories.filter import matches_where
 from memu.database.inmemory.state import InMemoryState
 from memu.database.models import Resource
 from memu.database.repositories.resource import ResourceRepo as ResourceRepoProtocol
-from memu.vector import cosine_topk
 
 
 class InMemoryResourceRepository(ResourceRepoProtocol):
@@ -81,16 +80,6 @@ class InMemoryResourceRepository(ResourceRepoProtocol):
         res.track = track
         res.updated_at = pendulum.now("UTC")
         return res
-
-    def vector_search_resources(
-        self,
-        query_vec: list[float],
-        top_k: int,
-        where: Mapping[str, Any] | None = None,
-    ) -> list[tuple[str, float]]:
-        pool = self.list_resources(where)
-        corpus = [(rid, res.embedding) for rid, res in pool.items() if res.embedding]
-        return cosine_topk(query_vec, corpus, k=top_k)
 
     def load_existing(self) -> None:
         return None

--- a/src/memu/database/postgres/repositories/recall_file_segment_repo.py
+++ b/src/memu/database/postgres/repositories/recall_file_segment_repo.py
@@ -65,12 +65,14 @@ class PostgresRecallFileSegmentRepo(PostgresRepoBase, RecallFileSegmentRepo):
         query_vec: list[float],
         top_k: int,
         where: Mapping[str, Any] | None = None,
+        *,
+        query_text: str | None = None,
     ) -> list[tuple[RecallFileSegment, float]]:
         """Rank segments with pgvector, inside the database.
 
-        Postgres does the ordering and the truncation, so only ``top_k`` rows
-        cross the wire instead of every segment in scope — the one thing the
-        inherited Python scan cannot do.
+        Cosine-only: Postgres orders and truncates, so only ``top_k`` rows cross
+        the wire. Hybrid: take ``candidate_k`` cosine hits from the index, BM25
+        over scoped texts, RRF-fuse the two lists, then cut to ``top_k``.
 
         A deployment that asked for a non-pgvector index (``vector_index.provider``)
         gets the inherited scan instead, even though the column type is ``VECTOR``
@@ -79,10 +81,14 @@ class PostgresRecallFileSegmentRepo(PostgresRepoBase, RecallFileSegmentRepo):
         if top_k <= 0:
             return []
         if not self._use_vector:
-            return super().vector_search_segments(query_vec, top_k, where)
+            return super().vector_search_segments(query_vec, top_k, where, query_text=query_text)
 
         from sqlmodel import select
 
+        from memu.hybrid import hybrid_candidate_k, maybe_hybrid_topk
+
+        hybrid = bool(query_text and query_text.strip())
+        cosine_k = hybrid_candidate_k(top_k) if hybrid else top_k
         model = self._sqla_models.RecallFileSegment
         # ``<=>`` yields cosine *distance*; the contract is similarity, hence
         # ``1 - distance`` below. Rows without an embedding are filtered out
@@ -91,9 +97,24 @@ class PostgresRecallFileSegmentRepo(PostgresRepoBase, RecallFileSegmentRepo):
         filters = [*self._build_filters(model, where), model.embedding.is_not(None)]
         with self._sessions.session() as session:
             rows = session.exec(
-                select(model, distance.label("distance")).where(*filters).order_by(distance).limit(top_k)
+                select(model, distance.label("distance")).where(*filters).order_by(distance).limit(cosine_k)
             ).all()
-            return [(self._cache_segment(row), 1.0 - float(dist)) for row, dist in rows]
+            cosine_pairs = [(self._cache_segment(row), 1.0 - float(dist)) for row, dist in rows]
+        if not hybrid:
+            return cosine_pairs
+
+        pool = self.list_segments(where)
+        by_id = {seg.id: seg for seg in pool}
+        for seg, _ in cosine_pairs:
+            by_id.setdefault(seg.id, seg)
+        fused = maybe_hybrid_topk(
+            query_text=query_text,
+            cosine_hits=[(seg.id, score) for seg, score in cosine_pairs],
+            texts={seg.id: seg.text for seg in by_id.values()},
+            top_k=top_k,
+            bm25_limit=cosine_k,
+        )
+        return [(by_id[seg_id], score) for seg_id, score in fused if seg_id in by_id]
 
     def create_segment(
         self,

--- a/src/memu/database/postgres/repositories/resource_repo.py
+++ b/src/memu/database/postgres/repositories/resource_repo.py
@@ -8,7 +8,6 @@ from memu.database.postgres.repositories.base import PostgresRepoBase
 from memu.database.postgres.session import SessionManager
 from memu.database.repositories.resource import ResourceRepo
 from memu.database.state import DatabaseState
-from memu.vector import cosine_topk
 
 
 class PostgresResourceRepo(PostgresRepoBase, ResourceRepo):
@@ -131,21 +130,6 @@ class PostgresResourceRepo(PostgresRepoBase, ResourceRepo):
             session.refresh(row)
             row.embedding = self._normalize_embedding(row.embedding)
             return self._cache_resource(row)
-
-    def vector_search_resources(
-        self,
-        query_vec: list[float],
-        top_k: int,
-        where: Mapping[str, Any] | None = None,
-    ) -> list[tuple[str, float]]:
-        """Rank resources by cosine similarity over stored embeddings.
-
-        Resource captions are not indexed in pgvector, so this scores the loaded
-        resources in Python, matching the previous app-layer behavior.
-        """
-        pool = self.list_resources(where)
-        corpus = [(rid, res.embedding) for rid, res in pool.items() if res.embedding]
-        return cosine_topk(query_vec, corpus, k=top_k)
 
     def load_existing(self) -> None:
         from sqlmodel import select

--- a/src/memu/database/repositories/recall_file_segment.py
+++ b/src/memu/database/repositories/recall_file_segment.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from typing import Any, Protocol, runtime_checkable
 
 from memu.database.models import RecallFileSegment
+from memu.hybrid import maybe_hybrid_topk
 from memu.vector import cosine_topk
 
 
@@ -20,23 +21,32 @@ class RecallFileSegmentRepo(Protocol):
         query_vec: list[float],
         top_k: int,
         where: Mapping[str, Any] | None = None,
+        *,
+        query_text: str | None = None,
     ) -> list[tuple[RecallFileSegment, float]]:
-        """Rank segments by cosine similarity of their stored embeddings.
+        """Rank segments by cosine, optionally fused with BM25 over ``text``.
 
         Returns ``(segment, score)`` pairs ordered by descending score, at most
-        ``top_k`` of them.
+        ``top_k`` of them. ``query_text=None`` is cosine-only (today's contract).
+        With ``query_text``, this default scores the whole scoped pool — sqlite
+        and inmemory already scan it — then RRF-fuses BM25 (ADR 0019).
 
         The segments themselves come back, not their ids.
 
-        This default scans the scoped pool in Python. It is the fallback every
-        backend gets for free; a backend whose store can rank natively should
-        override it, and may call back here via ``super()`` when its index is
-        unavailable.
+        A backend whose store can rank natively should override it, and may
+        call back here via ``super()`` when its index is unavailable.
         """
         pool = self.list_segments(where)
         by_id = {seg.id: seg for seg in pool}
-        ranked = cosine_topk(query_vec, [(seg.id, seg.embedding) for seg in pool], k=top_k)
-        return [(by_id[seg_id], score) for seg_id, score in ranked]
+        cosine_k = len(pool) if query_text and query_text.strip() else top_k
+        ranked = cosine_topk(query_vec, [(seg.id, seg.embedding) for seg in pool], k=cosine_k)
+        fused = maybe_hybrid_topk(
+            query_text=query_text,
+            cosine_hits=ranked,
+            texts={seg.id: seg.text for seg in pool},
+            top_k=top_k,
+        )
+        return [(by_id[seg_id], score) for seg_id, score in fused if seg_id in by_id]
 
     def list_segments_for_file(self, recall_file_id: str) -> list[RecallFileSegment]:
         """Return all segments belonging to a given file."""

--- a/src/memu/database/repositories/resource.py
+++ b/src/memu/database/repositories/resource.py
@@ -4,6 +4,8 @@ from collections.abc import Mapping
 from typing import Any, Protocol, runtime_checkable
 
 from memu.database.models import Resource
+from memu.hybrid import maybe_hybrid_topk
+from memu.vector import cosine_topk
 
 
 @runtime_checkable
@@ -55,12 +57,29 @@ class ResourceRepo(Protocol):
         query_vec: list[float],
         top_k: int,
         where: Mapping[str, Any] | None = None,
+        *,
+        query_text: str | None = None,
     ) -> list[tuple[str, float]]:
-        """Rank resources by cosine similarity of their stored embeddings.
+        """Rank resources by cosine, optionally fused with BM25 over ``caption``.
 
-        Returns a list of ``(resource_id, score)`` tuples ordered by descending
-        similarity. Resources without an embedding are skipped.
+        Returns ``(resource_id, score)`` pairs, best first, at most ``top_k``.
+        ``query_text=None`` is cosine-only. All three backends already scan the
+        scoped pool in Python, so hybrid uses that whole pool (ADR 0019).
+        Resources without an embedding are skipped by cosine; they can still
+        surface through BM25 when ``caption`` matches.
         """
-        ...
+        pool = self.list_resources(where)
+        cosine_k = len(pool) if query_text and query_text.strip() else top_k
+        ranked = cosine_topk(
+            query_vec,
+            [(rid, res.embedding) for rid, res in pool.items() if res.embedding],
+            k=cosine_k,
+        )
+        return maybe_hybrid_topk(
+            query_text=query_text,
+            cosine_hits=ranked,
+            texts={rid: res.caption or "" for rid, res in pool.items()},
+            top_k=top_k,
+        )
 
     def load_existing(self) -> None: ...

--- a/src/memu/database/sqlite/repositories/resource_repo.py
+++ b/src/memu/database/sqlite/repositories/resource_repo.py
@@ -14,7 +14,6 @@ from memu.database.sqlite.repositories.base import SQLiteRepoBase
 from memu.database.sqlite.schema import SQLiteSQLAModels
 from memu.database.sqlite.session import SQLiteSessionManager
 from memu.database.state import DatabaseState
-from memu.vector import cosine_topk
 
 logger = logging.getLogger(__name__)
 
@@ -246,21 +245,6 @@ class SQLiteResourceRepo(SQLiteRepoBase, ResourceRepo):
         )
         self.resources[row.id] = res
         return res
-
-    def vector_search_resources(
-        self,
-        query_vec: list[float],
-        top_k: int,
-        where: Mapping[str, Any] | None = None,
-    ) -> list[tuple[str, float]]:
-        """Rank resources by brute-force cosine similarity.
-
-        SQLite has no native vector support, so this mirrors the item repo and
-        scores stored embeddings in Python.
-        """
-        pool = self.list_resources(where)
-        corpus = [(rid, res.embedding) for rid, res in pool.items() if res.embedding]
-        return cosine_topk(query_vec, corpus, k=top_k)
 
     def load_existing(self) -> None:
         """Load all existing resources from database into cache."""

--- a/src/memu/env.py
+++ b/src/memu/env.py
@@ -122,6 +122,14 @@ def env(name: str, default: str | None = None) -> str | None:
     return os.environ.get(name) or _file_values().get(name) or default
 
 
+def retrieve_hybrid() -> bool:
+    """Local retrieve fuses BM25 with cosine unless ``MEMU_RETRIEVE_HYBRID=0``."""
+    raw = env("MEMU_RETRIEVE_HYBRID")
+    if raw is None:
+        return True
+    return raw.strip().lower() not in {"0", "false", "off", "no"}
+
+
 def env_declared(name: str, default: str = "") -> str:
     """Like :func:`env`, but a *declared* value wins even when it is empty.
 
@@ -243,6 +251,7 @@ def build_agentic_memory_backend_from_env(
     return MemoryService(
         embedding_profiles={"default": resolved_embedding},
         database_config=resolved_database,
+        progressive_retrieve_config={"hybrid": retrieve_hybrid()},
     )
 
 
@@ -259,4 +268,5 @@ def build_service_from_env() -> Any:
     return MemoryService(
         embedding_profiles={"default": embedding_profile()},
         database_config=database_config(require("MEMU_DB")),
+        progressive_retrieve_config={"hybrid": retrieve_hybrid()},
     )

--- a/src/memu/hybrid.py
+++ b/src/memu/hybrid.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import math
 import re
 from collections.abc import Mapping, Sequence
+from itertools import pairwise
 
 RRF_K = 60
 BM25_K1 = 1.5
@@ -39,7 +40,7 @@ def tokenize(text: str) -> list[str]:
             continue
         chars = list(token)
         out.extend(chars)
-        out.extend(a + b for a, b in zip(chars, chars[1:], strict=False))
+        out.extend(a + b for a, b in pairwise(chars))
     return out
 
 

--- a/src/memu/hybrid.py
+++ b/src/memu/hybrid.py
@@ -1,0 +1,140 @@
+"""Storage-neutral hybrid ranking: BM25 + cosine fused with RRF.
+
+Used by every retrieve backend. Cosine itself stays in :mod:`memu.vector`;
+this module only tokenizes, scores BM25, and fuses two ranked id lists.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping, Sequence
+
+RRF_K = 60
+BM25_K1 = 1.5
+BM25_B = 0.75
+
+# Latin/digit runs stay whole tokens. CJK/kana/hangul runs are split into
+# overlapping character n-grams below (unigrams + bigrams).
+_TOKEN_RE = re.compile(
+    r"[a-z0-9]+|[\u3400-\u9fff\uf900-\ufaff\u3040-\u30ff\uac00-\ud7af]+",
+    re.IGNORECASE,
+)
+
+
+def hybrid_candidate_k(top_k: int) -> int:
+    """How many hits each ranker contributes before RRF on an indexed backend."""
+    return max(50, 5 * top_k)
+
+
+def tokenize(text: str) -> list[str]:
+    """Lowercased latin tokens plus CJK unigrams and bigrams."""
+    if not text:
+        return []
+    out: list[str] = []
+    for match in _TOKEN_RE.finditer(text):
+        token = match.group()
+        if token.isascii():
+            out.append(token.lower())
+            continue
+        chars = list(token)
+        out.extend(chars)
+        out.extend(a + b for a, b in zip(chars, chars[1:], strict=False))
+    return out
+
+
+def bm25_rank(
+    query: str,
+    corpus: Sequence[tuple[str, str]],
+    *,
+    k: int | None = None,
+) -> list[tuple[str, float]]:
+    """Return ``(id, bm25)`` pairs, best first, dropping zero-score docs.
+
+    Empty query tokens or an empty tokenized corpus yield ``[]``.
+    """
+    documents = [(doc_id, tokenize(text)) for doc_id, text in corpus]
+    documents = [(doc_id, tokens) for doc_id, tokens in documents if tokens]
+    query_tokens = tokenize(query)
+    if not documents or not query_tokens:
+        return []
+
+    n = len(documents)
+    df: dict[str, int] = {}
+    for _, tokens in documents:
+        for term in set(tokens):
+            df[term] = df.get(term, 0) + 1
+    avgdl = sum(len(tokens) for _, tokens in documents) / n
+
+    scores: dict[str, float] = {}
+    for doc_id, tokens in documents:
+        tf: dict[str, int] = {}
+        for term in tokens:
+            tf[term] = tf.get(term, 0) + 1
+        dl = len(tokens)
+        score = 0.0
+        for term in query_tokens:
+            freq = tf.get(term)
+            if not freq:
+                continue
+            idf = math.log((n - df[term] + 0.5) / (df[term] + 0.5) + 1.0)
+            denom = freq + BM25_K1 * (1.0 - BM25_B + BM25_B * dl / avgdl)
+            score += idf * (freq * (BM25_K1 + 1.0)) / denom
+        if score > 0.0:
+            scores[doc_id] = score
+
+    ordered = sorted(scores.items(), key=lambda item: (-item[1], item[0]))
+    if k is not None:
+        ordered = ordered[:k]
+    return ordered
+
+
+def rrf_topk(*rankings: Sequence[str], top_k: int, rrf_k: int = RRF_K) -> list[tuple[str, float]]:
+    """Fuse best-first id lists with Reciprocal Rank Fusion; cut to ``top_k``."""
+    if top_k <= 0:
+        return []
+    scores: dict[str, float] = {}
+    for ranking in rankings:
+        for rank, doc_id in enumerate(ranking, start=1):
+            scores[doc_id] = scores.get(doc_id, 0.0) + 1.0 / (rrf_k + rank)
+    ordered = sorted(scores.items(), key=lambda item: (-item[1], item[0]))
+    return ordered[:top_k]
+
+
+def maybe_hybrid_topk(
+    *,
+    query_text: str | None,
+    cosine_hits: Sequence[tuple[str, float]],
+    texts: Mapping[str, str],
+    top_k: int,
+    bm25_limit: int | None = None,
+) -> list[tuple[str, float]]:
+    """RRF-fuse cosine and BM25 when the query tokenizes; else keep cosine.
+
+    ``cosine_hits`` is already best-first (full pool or a truncated candidate
+    list). BM25 runs over ``texts``, so a keyword hit missing from the cosine
+    list can still enter the union. Falls back to cosine scores when BM25
+    produces no ranking, so ``query_text=None`` is bit-identical to today's
+    cosine-only retrieve.
+    """
+    if top_k <= 0:
+        return []
+    cosine_ids = [doc_id for doc_id, _ in cosine_hits]
+    if not query_text or not query_text.strip() or not tokenize(query_text):
+        return list(cosine_hits[:top_k])
+
+    corpus = [(doc_id, text) for doc_id, text in texts.items() if text and text.strip()]
+    bm25_hits = bm25_rank(query_text, corpus, k=bm25_limit)
+    if not bm25_hits:
+        return list(cosine_hits[:top_k])
+    return rrf_topk(cosine_ids, [doc_id for doc_id, _ in bm25_hits], top_k=top_k)
+
+
+__all__ = [
+    "RRF_K",
+    "bm25_rank",
+    "hybrid_candidate_k",
+    "maybe_hybrid_topk",
+    "rrf_topk",
+    "tokenize",
+]

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -22,12 +22,12 @@ def test_bm25_ranks_the_document_that_has_the_rare_term() -> None:
             ("keyword", "ECONNREFUSED 127.0.0.1:5432"),
         ],
     )
-    assert [doc_id for doc_id, _ in ranked][0] == "keyword"
+    assert next(doc_id for doc_id, _ in ranked) == "keyword"
 
 
 def test_cjk_query_hits_character_ngrams() -> None:
     ranked = bm25_rank("武汉", [("en", "hello world"), ("zh", "我在武汉大学")])
-    assert [doc_id for doc_id, _ in ranked][0] == "zh"
+    assert next(doc_id for doc_id, _ in ranked) == "zh"
 
 
 def test_rrf_prefers_the_doc_strong_in_both_lists() -> None:

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -1,0 +1,70 @@
+"""BM25 + RRF fusion used by retrieve (ADR 0019)."""
+
+from __future__ import annotations
+
+from memu.hybrid import bm25_rank, hybrid_candidate_k, maybe_hybrid_topk, rrf_topk, tokenize
+
+
+def test_tokenize_latin_and_cjk_ngrams() -> None:
+    assert tokenize("ECONNREFUSED 5432") == ["econnrefused", "5432"]
+    tokens = tokenize("武汉大学")
+    assert "武" in tokens
+    assert "汉" in tokens
+    assert "武汉" in tokens
+    assert "大学" in tokens
+
+
+def test_bm25_ranks_the_document_that_has_the_rare_term() -> None:
+    ranked = bm25_rank(
+        "ECONNREFUSED 5432",
+        [
+            ("semantic", "the database timed out again"),
+            ("keyword", "ECONNREFUSED 127.0.0.1:5432"),
+        ],
+    )
+    assert [doc_id for doc_id, _ in ranked][0] == "keyword"
+
+
+def test_cjk_query_hits_character_ngrams() -> None:
+    ranked = bm25_rank("武汉", [("en", "hello world"), ("zh", "我在武汉大学")])
+    assert [doc_id for doc_id, _ in ranked][0] == "zh"
+
+
+def test_rrf_prefers_the_doc_strong_in_both_lists() -> None:
+    # a is cosine #1 only; b is cosine #2 and BM25 #1.
+    fused = rrf_topk(["a", "b"], ["b"], top_k=2)
+    assert fused[0][0] == "b"
+
+
+def test_hybrid_surfaces_keyword_hit_cosine_ranked_out() -> None:
+    # Query vector is aligned with "close"; the rare token lives on "far".
+    hits = maybe_hybrid_topk(
+        query_text="ECONNREFUSED5432",
+        cosine_hits=[("close", 0.99), ("far", 0.01)],
+        texts={"close": "unrelated prose about weather", "far": "ECONNREFUSED5432 on boot"},
+        top_k=1,
+    )
+    assert hits[0][0] == "far"
+
+
+def test_hybrid_without_query_text_keeps_cosine_order_and_scores() -> None:
+    cosine = [("close", 0.99), ("far", 0.01)]
+    assert maybe_hybrid_topk(query_text=None, cosine_hits=cosine, texts={}, top_k=2) == cosine
+    assert maybe_hybrid_topk(query_text="   ", cosine_hits=cosine, texts={}, top_k=1) == cosine[:1]
+
+
+def test_hybrid_can_introduce_a_bm25_only_id() -> None:
+    hits = maybe_hybrid_topk(
+        query_text="token",
+        cosine_hits=[("close", 0.99)],
+        texts={"close": "unrelated", "only_bm25": "token lives here"},
+        top_k=2,
+        bm25_limit=2,
+    )
+    ids = [doc_id for doc_id, _ in hits]
+    assert "only_bm25" in ids
+
+
+def test_candidate_k_widens_with_top_k() -> None:
+    assert hybrid_candidate_k(5) == 50
+    assert hybrid_candidate_k(20) == 100

--- a/tests/test_segment_vector_search.py
+++ b/tests/test_segment_vector_search.py
@@ -119,7 +119,7 @@ async def test_progressive_retrieve_takes_the_repo_shortcut() -> None:
         scans += 1
         return real_list_segments(where)
 
-    def native_search(query_vec: list[float], top_k: int, where: Any = None) -> Any:
+    def native_search(query_vec: list[float], top_k: int, where: Any = None, *, query_text: str | None = None) -> Any:
         native_calls.append(top_k)
         # A backend-native answer the Python scan would never produce: one hit,
         # the *worse* match, at an impossible score.
@@ -246,6 +246,68 @@ def test_postgres_without_pgvector_falls_back_to_the_python_scan() -> None:
     sql = str(sessions.seen[0])
     assert "<=>" not in sql
     assert "LIMIT" not in sql
+
+
+def test_resource_hybrid_prefers_caption_keyword(db_backend: Database) -> None:
+    repo = db_backend.resource_repo
+    repo.create_resource(
+        url="/a.md",
+        local_path="/a.md",
+        caption="unrelated prose about weather",
+        embedding=[1.0, 0.0],
+        user_data=dict(USER),
+        track="workspace",
+    )
+    repo.create_resource(
+        url="/b.md",
+        local_path="/b.md",
+        caption="ECONNREFUSED 127.0.0.1:5432",
+        embedding=[0.0, 1.0],
+        user_data=dict(USER),
+        track="workspace",
+    )
+
+    cosine = repo.vector_search_resources([1.0, 0.0], 1)
+    cosine_hit = db_backend.resource_repo.resources[cosine[0][0]]
+    assert cosine_hit.caption and cosine_hit.caption.startswith("unrelated")
+
+    hybrid = repo.vector_search_resources([1.0, 0.0], 1, query_text="ECONNREFUSED 5432")
+    hybrid_hit = db_backend.resource_repo.resources[hybrid[0][0]]
+    assert hybrid_hit.caption and "ECONNREFUSED" in hybrid_hit.caption
+
+
+def test_hybrid_query_text_prefers_keyword_over_closer_vector(db_backend: Database) -> None:
+    _seed(
+        db_backend,
+        [
+            ("unrelated prose about weather", [1.0, 0.0], "memory"),
+            ("ECONNREFUSED 127.0.0.1:5432", [0.0, 1.0], "memory"),
+        ],
+    )
+
+    cosine = db_backend.recall_file_segment_repo.vector_search_segments([1.0, 0.0], 1)
+    assert cosine[0][0].text.startswith("unrelated")
+
+    hybrid = db_backend.recall_file_segment_repo.vector_search_segments([1.0, 0.0], 1, query_text="ECONNREFUSED 5432")
+    assert "ECONNREFUSED" in hybrid[0][0].text
+
+
+def test_postgres_hybrid_unions_bm25_outside_the_cosine_window() -> None:
+    pytest.importorskip("pgvector")
+
+    from memu.database.models import RecallFileSegment
+
+    close_row = _row("seg-close", "unrelated prose", [1.0, 0.0])
+    far_row = _row("seg-far", "ECONNREFUSED 5432", [0.0, 1.0])
+    repo, sessions = _postgres_repo([(close_row, 0.0), (far_row, 1.0)], use_vector=True)
+    close = RecallFileSegment(id="seg-close", recall_file_id="file-1", text="unrelated prose", embedding=[1.0, 0.0])
+    far = RecallFileSegment(id="seg-far", recall_file_id="file-1", text="ECONNREFUSED 5432", embedding=[0.0, 1.0])
+    repo.list_segments = lambda where=None: [close, far]  # type: ignore[method-assign]
+
+    hits = repo.vector_search_segments([1.0, 0.0], 5, query_text="ECONNREFUSED 5432")
+
+    assert hits[0][0].id == "seg-far"
+    assert "LIMIT" in str(sessions.seen[0])
 
 
 def test_postgres_native_path_honours_nonpositive_top_k() -> None:


### PR DESCRIPTION
## 📝 Pull Request Summary

Local `progressive_retrieve` now fuses BM25 keyword scores with cosine via Reciprocal Rank Fusion, so exact tokens (error codes, CJK terms, paths) can surface when the embedder ranked them out of `top_k`.

Fixes #689

---

## ✅ What does this PR do?

- After embedding the query, pass the original text into `vector_search_segments` / `vector_search_resources`.
- Rank L2 segments and workspace resources with BM25 + cosine **RRF**. File layer is still `max(segment score)`.
- sqlite / inmemory / postgres resources: BM25 over the scoped pool they already scan.
- postgres segments: pgvector cosine candidates ∪ BM25 over scoped texts, then RRF, then cut to `top_k`.
- CJK unigrams + bigrams from the start (no jieba).
- Default **on**. Kill switch: `MEMU_RETRIEVE_HYBRID=0` or `ProgressiveRetrieveConfig.hybrid=False`.
- ADR 0019 records what the current path actually runs. ADR 0007’s kernel is untouched.

When hybrid is on, hit `score` is the RRF value, not cosine similarity.

---

## 🤔 Why is this change needed?

Inject (`<binary> retrieve`) runs this every turn. The store already has `RecallFileSegment.text` and `Resource.caption`; cosine-only retrieve threw the query string away after embed, so `ECONNREFUSED 5432` could lose to a semantically closer “db timeout” fragment.

CONTRIBUTING lists retrieval performance as High. ADR 0007 already wanted hybrid on L2; this is that slice on the current path.

---

## 🔍 Type of Change

- [x] New feature

---

## Design choices (happy to change — ping me)

1. **Candidate set.** sqlite/inmemory already scan → BM25 the whole pool. Postgres segments keep the index: cosine `candidate_k = max(50, 5 * top_k)` ∪ BM25, then RRF. We did **not** fuse only inside cosine `top_k` (that cannot surface keyword hits the embedder dropped). Postgres resources still brute-force, so they use the full-pool path until they get pgvector.

   *Also considered:* fuse only among cosine hits; Postgres full-table BM25 (breaks “only top_k crosses the wire”).

2. **Fusion = RRF**, not ADR 0007’s min-max linear blend. The ADR never specified α; min-max on `k=5` is jumpy. RRF needs no α.

   *Also considered:* min-max + α=0.7.

3. **On by default.** That’s the product point. Kill switch is there if ranking misbehaves.

   *Also considered:* default off, opt-in.

4. **Segments and resources in v1.** Files benefit via roll-up. Captions (paths, package names) are at least as keyword-heavy as fragments.

5. **CJK n-grams from the start.** Whitespace tokenization is useless for Chinese. No jieba.

   *Also considered:* English/punctuation tokens only.

6. **Repo ranks, not the service.** `query_text` is a kw-only argument on the two search methods so each backend can pick full-pool vs candidate-union. Fusing in `agentic.py` would force Postgres to ship the whole corpus.

If you want any alternative above, say so — I’ll switch.

---

## ✅ PR Quality Checklist

- [x] PR title follows an allowed format (`feat(retrieve): …`)
- [x] Changes are limited in scope and easy to review
- [x] Documentation updated (README env table, ADR 0019)
- [x] Breaking change documented (hybrid-on `score` is RRF, not cosine)
- [x] Related issue linked (#689)

---

## 📌 Optional

- Follow-up: Postgres `tsvector` / pgvector for resources (same hybrid, indexed BM25 / cosine).
- `make check` and `pytest` (656 passed, 3 skipped) locally.
