### PR TITLE
fix(retrieve): harden cosine_topk and scope file roll-up

### DIFF
--- a/src/memu/app/agentic.py
+++ b/src/memu/app/agentic.py
@@ -275,8 +275,19 @@ class AgenticMixin:
 
         Every file pointed to by a top segment is returned; a file's score is the
         max score across the segments that point to it.
+
+        Only the files named by ``segment_hits`` are fetched (``id__in``): the
+        pool exists solely so :meth:`_materialize_hits` can expand hit ids, so
+        pulling the whole scoped corpus to look up a handful of ids is wasted
+        work on every retrieve. An empty hit set returns immediately without a
+        listing.
         """
-        file_pool = store.recall_file_repo.list_recall_files(where_filters)
+        hit_file_ids = {
+            seg.recall_file_id for seg_id, _ in segment_hits if (seg := segment_pool.get(seg_id)) is not None
+        }
+        if not hit_file_ids:
+            return [], {}
+        file_pool = store.recall_file_repo.list_recall_files({**where_filters, "id__in": list(hit_file_ids)})
 
         file_scores: dict[str, float] = {}
         for seg_id, score in segment_hits:

--- a/src/memu/vector.py
+++ b/src/memu/vector.py
@@ -28,19 +28,31 @@ def cosine_topk(
     if k <= 0:
         return []
 
-    # Filter out None vectors and collect valid entries
+    q = np.asarray(query_vec, dtype=np.float32)
+    if q.ndim != 1 or q.size == 0:
+        return []
+    dim = q.size
+
+    # Filter out None, empty, or wrong-dimension vectors. An empty list is not
+    # a vector, and a dimension mismatch would make np.array() fall back to an
+    # object matrix (then the matrix product below crashes or, worse, silently
+    # mis-scores). Callers already disagree on whether ``[]`` means "unembedded"
+    # (segments skip only ``None``; resources skip only falsy), so treat both
+    # the same way here: unusable rows never enter the ranking.
     ids: list[str] = []
     vecs: list[list[float]] = []
     for _id, vec in corpus:
-        if vec is not None:
-            ids.append(_id)
-            vecs.append(cast(list[float], vec))
+        if vec is None:
+            continue
+        if len(vec) != dim:
+            continue
+        ids.append(_id)
+        vecs.append(cast(list[float], vec))
 
     if not vecs:
         return []
 
     # Vectorized computation: stack all vectors into a matrix
-    q = np.array(query_vec, dtype=np.float32)
     matrix = np.array(vecs, dtype=np.float32)  # shape: (n, dim)
 
     # Compute all cosine similarities at once

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -333,6 +333,55 @@ async def test_progressive_retrieve_rejects_empty_query(service: MemoryService) 
         await service.progressive_retrieve("   ")
 
 
+async def test_retrieve_rollup_fetches_only_hit_files(service: MemoryService) -> None:
+    """Roll-up must not list the whole scoped corpus on every retrieve.
+
+    :meth:`AgenticMixin._collect_files` needs only the :class:`RecallFile` rows
+    that top segments point at, so it should issue an ``id__in`` fetch — a full
+    ``list_recall_files`` read for a handful of ids is wasted work that grows
+    with the store. The response surface stays identical.
+    """
+    await _seed(service)
+    repo = service._get_database().recall_file_repo
+    real_list = repo.list_recall_files
+    seen: list[dict[str, Any]] = []
+
+    def spying_list(where: Any = None) -> Any:
+        seen.append(where or {})
+        return real_list(where)
+
+    repo.list_recall_files = spying_list  # type: ignore[method-assign]
+
+    result = await service.progressive_retrieve("coffee")
+
+    assert len(seen) == 1  # the roll-up fetch; nothing else lists files
+    hit_ids = {seg["recall_file_id"] for seg in result["segments"]}
+    assert set(seen[0].get("id__in", [])) == hit_ids
+
+
+async def test_retrieve_rollup_short_circuits_when_no_segments(service: MemoryService) -> None:
+    """No segment hits means no file fetch at all, not an empty full listing."""
+    await _seed(service)
+    repo = service._get_database().recall_file_repo
+    real_list = repo.list_recall_files
+    calls: list[dict[str, Any]] = []
+
+    def spying_list(where: Any = None) -> Any:
+        calls.append(where or {})
+        return real_list(where)
+
+    repo.list_recall_files = spying_list  # type: ignore[method-assign]
+    segment_repo = service._get_database().recall_file_segment_repo
+
+    def no_hits(query_vec: Any, top_k: int, where: Any = None) -> Any:
+        return []
+
+    segment_repo.vector_search_segments = no_hits  # type: ignore[method-assign]
+
+    await service.progressive_retrieve("nothing matches")
+    assert calls == []
+
+
 async def test_sqlite_resource_commit_sees_writes_from_another_instance(tmp_path: Any) -> None:
     """Two SQLiteStore instances on the same DB file share ground truth, matching
     PostgresResourceRepo's always-fresh reads: an unfiltered ``list_resources`` must

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -17,3 +17,26 @@ def test_cosine_topk_nonpositive_k_returns_empty() -> None:
 def test_cosine_topk_orders_by_similarity() -> None:
     results = cosine_topk([1.0, 0.0], _corpus(), k=2)
     assert [memory_id for memory_id, _ in results] == ["a", "c"]
+
+
+def test_cosine_topk_skips_empty_and_none_vectors() -> None:
+    corpus = [
+        ("ok", [1.0, 0.0]),
+        ("empty", []),
+        ("none", None),
+    ]
+    results = cosine_topk([1.0, 0.0], corpus, k=5)  # type: ignore[list-item]
+    assert [doc_id for doc_id, _ in results] == ["ok"]
+
+
+def test_cosine_topk_skips_wrong_dimension_vectors() -> None:
+    # A dimension mismatch must not collapse np.array() into an object matrix;
+    # the row is skipped so the remaining corpus still ranks.
+    corpus = [("right", [1.0, 0.0]), ("wrong-dim", [0.1, 0.2, 0.3])]
+    results = cosine_topk([1.0, 0.0], corpus, k=5)
+    assert [doc_id for doc_id, _ in results] == ["right"]
+
+
+def test_cosine_topk_empty_or_nonvector_query_returns_empty() -> None:
+    assert cosine_topk([], _corpus(), k=2) == []
+    assert cosine_topk([1.0, 0.0], [], k=2) == []


### PR DESCRIPTION
## Summary

Two bugs found during a source review of the retrieve path:

1. **`cosine_topk` crashes or mis-scores on malformed rows.** It only skips `None` vectors. An empty list (`[]`) is treated as a valid row, and a vector whose dimension differs from the query makes `np.array(vecs)` fall back to an object matrix — the matrix product then either crashes the whole retrieve or silently scores nonsense. Callers already disagree on whether `[]` means "unembedded" (segments skip only `None`, resources skip only falsy), so treat both the same way: unusable rows never enter the ranking.

2. **`_collect_files` lists the whole scoped corpus on every retrieve.** The roll-up only needs the `RecallFile` rows that top segments point at, and the returned pool exists solely so `_materialize_hits` can expand hit ids. A full `list_recall_files(where)` read to look up a handful of ids is wasted work that grows with the store; it now issues an `id__in` fetch and short-circuits when there are no hits.

## Behavior

- Roll-up response is unchanged (same files, same `max(segment score)` ordering).
- Cosine ranking unchanged for well-formed rows; malformed rows are skipped instead of breaking retrieval.

## Tests

- `tests/test_vector.py`: empty/`None`/wrong-dimension vectors skipped; empty or non-vector query returns `[]`.
- `tests/test_agentic.py`: roll-up issues exactly one `id__in` fetch containing the hit files' ids; zero segment hits → zero file listing calls.
- Local: `mypy` clean, `pytest` 645 passed / 8 skipped.
