### PR TITLE
fix(vector): skip empty and wrong-dimension rows in cosine_topk

### DIFF
--- a/src/memu/vector.py
+++ b/src/memu/vector.py
@@ -28,19 +28,31 @@ def cosine_topk(
     if k <= 0:
         return []
 
-    # Filter out None vectors and collect valid entries
+    q = np.asarray(query_vec, dtype=np.float32)
+    if q.ndim != 1 or q.size == 0:
+        return []
+    dim = q.size
+
+    # Filter out None, empty, or wrong-dimension vectors. An empty list is not
+    # a vector, and a dimension mismatch would make np.array() fall back to an
+    # object matrix (then the matrix product below crashes or, worse, silently
+    # mis-scores). Callers already disagree on whether ``[]`` means "unembedded"
+    # (segments skip only ``None``; resources skip only falsy), so treat both
+    # the same way here: unusable rows never enter the ranking.
     ids: list[str] = []
     vecs: list[list[float]] = []
     for _id, vec in corpus:
-        if vec is not None:
-            ids.append(_id)
-            vecs.append(cast(list[float], vec))
+        if vec is None:
+            continue
+        if len(vec) != dim:
+            continue
+        ids.append(_id)
+        vecs.append(cast(list[float], vec))
 
     if not vecs:
         return []
 
     # Vectorized computation: stack all vectors into a matrix
-    q = np.array(query_vec, dtype=np.float32)
     matrix = np.array(vecs, dtype=np.float32)  # shape: (n, dim)
 
     # Compute all cosine similarities at once

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -17,3 +17,26 @@ def test_cosine_topk_nonpositive_k_returns_empty() -> None:
 def test_cosine_topk_orders_by_similarity() -> None:
     results = cosine_topk([1.0, 0.0], _corpus(), k=2)
     assert [memory_id for memory_id, _ in results] == ["a", "c"]
+
+
+def test_cosine_topk_skips_empty_and_none_vectors() -> None:
+    corpus = [
+        ("ok", [1.0, 0.0]),
+        ("empty", []),
+        ("none", None),
+    ]
+    results = cosine_topk([1.0, 0.0], corpus, k=5)  # type: ignore[list-item]
+    assert [doc_id for doc_id, _ in results] == ["ok"]
+
+
+def test_cosine_topk_skips_wrong_dimension_vectors() -> None:
+    # A dimension mismatch must not collapse np.array() into an object matrix;
+    # the row is skipped so the remaining corpus still ranks.
+    corpus = [("right", [1.0, 0.0]), ("wrong-dim", [0.1, 0.2, 0.3])]
+    results = cosine_topk([1.0, 0.0], corpus, k=5)
+    assert [doc_id for doc_id, _ in results] == ["right"]
+
+
+def test_cosine_topk_empty_or_nonvector_query_returns_empty() -> None:
+    assert cosine_topk([], _corpus(), k=2) == []
+    assert cosine_topk([1.0, 0.0], [], k=2) == []


### PR DESCRIPTION
## Summary

`cosine_topk` (in `src/memu/vector.py`) only skipped `None` vectors before ranking. Two malformed-row cases broke retrieval:

1. **Empty list** (`[]`) was treated as a valid vector. Segments skip only `None` ("unembedded" = `None`); resources skip only falsy (so `[]` is also skipped there) — callers disagree on what `[]` means, and the shared ranker accepted it either way.
2. **Dimension mismatch**: a row whose vector length differs from the query's makes `np.array(vecs)` fall back to an **object matrix**; the `matrix @ q` product then crashes the whole retrieve or silently produces nonsense scores (a real risk when the embedding model or its dimensionality changes).

## Change

Rows that are `None`, empty, or of a different dimension than the query are excluded before the vectorized cosine pass. An empty or non-vector query returns `[]` instead of hitting `np.linalg`/matrix code. Well-formed rows rank exactly as before.

## Tests

- empty and `None` vectors are skipped
- wrong-dimension vectors are skipped without collapsing the matrix
- empty query / empty corpus return `[]`

Local: `pytest tests/test_vector.py` 5 passed; `mypy` clean; `ruff` clean.
