### PR TITLE
perf(retrieve): scope file roll-up to hit files via id__in

### DIFF
--- a/src/memu/app/agentic.py
+++ b/src/memu/app/agentic.py
@@ -275,8 +275,19 @@ class AgenticMixin:
 
         Every file pointed to by a top segment is returned; a file's score is the
         max score across the segments that point to it.
+
+        Only the files named by ``segment_hits`` are fetched (``id__in``): the
+        pool exists solely so :meth:`_materialize_hits` can expand hit ids, so
+        pulling the whole scoped corpus to look up a handful of ids is wasted
+        work on every retrieve. An empty hit set returns immediately without a
+        listing.
         """
-        file_pool = store.recall_file_repo.list_recall_files(where_filters)
+        hit_file_ids = {
+            seg.recall_file_id for seg_id, _ in segment_hits if (seg := segment_pool.get(seg_id)) is not None
+        }
+        if not hit_file_ids:
+            return [], {}
+        file_pool = store.recall_file_repo.list_recall_files({**where_filters, "id__in": list(hit_file_ids)})
 
         file_scores: dict[str, float] = {}
         for seg_id, score in segment_hits:

--- a/tests/test_agentic.py
+++ b/tests/test_agentic.py
@@ -333,6 +333,55 @@ async def test_progressive_retrieve_rejects_empty_query(service: MemoryService) 
         await service.progressive_retrieve("   ")
 
 
+async def test_retrieve_rollup_fetches_only_hit_files(service: MemoryService) -> None:
+    """Roll-up must not list the whole scoped corpus on every retrieve.
+
+    :meth:`AgenticMixin._collect_files` needs only the :class:`RecallFile` rows
+    that top segments point at, so it should issue an ``id__in`` fetch — a full
+    ``list_recall_files`` read for a handful of ids is wasted work that grows
+    with the store. The response surface stays identical.
+    """
+    await _seed(service)
+    repo = service._get_database().recall_file_repo
+    real_list = repo.list_recall_files
+    seen: list[dict[str, Any]] = []
+
+    def spying_list(where: Any = None) -> Any:
+        seen.append(where or {})
+        return real_list(where)
+
+    repo.list_recall_files = spying_list  # type: ignore[method-assign]
+
+    result = await service.progressive_retrieve("coffee")
+
+    assert len(seen) == 1  # the roll-up fetch; nothing else lists files
+    hit_ids = {seg["recall_file_id"] for seg in result["segments"]}
+    assert set(seen[0].get("id__in", [])) == hit_ids
+
+
+async def test_retrieve_rollup_short_circuits_when_no_segments(service: MemoryService) -> None:
+    """No segment hits means no file fetch at all, not an empty full listing."""
+    await _seed(service)
+    repo = service._get_database().recall_file_repo
+    real_list = repo.list_recall_files
+    calls: list[dict[str, Any]] = []
+
+    def spying_list(where: Any = None) -> Any:
+        calls.append(where or {})
+        return real_list(where)
+
+    repo.list_recall_files = spying_list  # type: ignore[method-assign]
+    segment_repo = service._get_database().recall_file_segment_repo
+
+    def no_hits(query_vec: Any, top_k: int, where: Any = None) -> Any:
+        return []
+
+    segment_repo.vector_search_segments = no_hits  # type: ignore[method-assign]
+
+    await service.progressive_retrieve("nothing matches")
+    assert calls == []
+
+
 async def test_sqlite_resource_commit_sees_writes_from_another_instance(tmp_path: Any) -> None:
     """Two SQLiteStore instances on the same DB file share ground truth, matching
     PostgresResourceRepo's always-fresh reads: an unfiltered ``list_resources`` must


### PR DESCRIPTION
## Summary

`AgenticMixin._collect_files` (in `src/memu/app/agentic.py`) rolled ranked L2 segments up to their L1 `RecallFile`s by calling `list_recall_files(where)` — a **full read of the scoped corpus on every retrieve** — and then looking up only the handful of ids that the top segments point at. The returned pool exists solely so `_materialize_hits` can expand hit ids; nothing downstream needs the files that no segment hit.

## Change

- Collect the `recall_file_id`s from the segment hits and fetch only those files via the existing `id__in` where filter (`column.in_` on sqlite/postgres, `matches_where` on inmemory — all three backends already support it).
- Short-circuit: zero segment hits means no file listing at all, instead of an empty full-corpus read.

The roll-up result is identical (same files, same `max(segment score)` ordering); this removes work that grows linearly with the store on the hot retrieve path.

## Tests

- `test_retrieve_rollup_fetches_only_hit_files`: exactly one listing happens and its `id__in` equals the hit files' ids.
- `test_retrieve_rollup_short_circuits_when_no_segments`: zero hits ⇒ zero listing calls.

Local: `pytest tests/test_agentic.py` 37 passed; `mypy` clean; `ruff` clean.
